### PR TITLE
Reserves the Axon on reregistration

### DIFF
--- a/bittensor/_neuron/text/advanced_server/run.py
+++ b/bittensor/_neuron/text/advanced_server/run.py
@@ -242,7 +242,9 @@ def serve(
             nn = subtensor.neuron_for_pubkey(wallet.hotkey.ss58_address)
             if not wallet.is_registered( subtensor = subtensor ):
                 wallet.register( subtensor = subtensor )
+                axon.serve( subtensor = subtensor ) # Re-serve the erased axon data.
                 nn = subtensor.neuron_for_pubkey(wallet.hotkey.ss58_address)
+                
 
             # --- Run 
             current_block = subtensor.get_current_block()


### PR DESCRIPTION
-- adds the correct axon.serve(subtensor = subtensor) call after the server loses and regains its slot