### PR TITLE
upgrade numpy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,7 +267,7 @@ workflows:
       - build-and-test:
           matrix:
             parameters:
-              python-version: [ "3.9.13", "3.10.6", "3.11.4", "3.12.7"]
+              python-version: [ "3.9.13", "3.10.6", "3.11.4", "3.12.7", "3.13.1" ]
           requires:
             - check-if-pr-is-draft
       - unit-tests-all-python-versions:
@@ -276,7 +276,7 @@ workflows:
       - lint-and-type-check:
           matrix:
             parameters:
-              python-version: [ "3.9.13", "3.10.6", "3.11.4", "3.12.7"]
+              python-version: [ "3.9.13", "3.10.6", "3.11.4", "3.12.7", "3.13.1" ]
           requires:
             - check-if-pr-is-draft
       #- coveralls:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "colorama~=0.4.6",
     "fastapi~=0.110.1",
     "munch~=2.5.0",
-    "numpy~=2.0.1",
+    "numpy>=2.0.1,<3.0.0",
     "msgpack-numpy-opentensor~=0.5.0",
     "nest_asyncio==1.6.0",
     "netaddr==1.3.0",


### PR DESCRIPTION
Loosens numpy requirements, to allow for using newer versions of numpy which come with wheels for Python 3.13