### PR TITLE
Improve `move_stake` extrinsic (add `move_all_stake` parameter)

### DIFF
--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -4657,10 +4657,11 @@ class AsyncSubtensor(SubtensorMixin):
         origin_netuid: int,
         destination_hotkey: str,
         destination_netuid: int,
-        amount: Balance,
+        amount: Optional[Balance] = None,
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
         period: Optional[int] = None,
+        move_all_stake: bool = False,
     ) -> bool:
         """
         Moves stake to a different hotkey and/or subnet.
@@ -4677,6 +4678,7 @@ class AsyncSubtensor(SubtensorMixin):
             period: The number of blocks during which the transaction will remain valid after it's
                 submitted. If the transaction is not included in a block within that number of blocks, it will expire
                 and be rejected. You can think of it as an expiration date for the transaction.
+            move_all_stake: If true, moves all stake from the source hotkey to the destination hotkey.
 
         Returns:
             success: True if the stake movement was successful.
@@ -4693,6 +4695,7 @@ class AsyncSubtensor(SubtensorMixin):
             wait_for_inclusion=wait_for_inclusion,
             wait_for_finalization=wait_for_finalization,
             period=period,
+            move_all_stake=move_all_stake,
         )
 
     async def register(

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -3493,10 +3493,11 @@ class Subtensor(SubtensorMixin):
         origin_netuid: int,
         destination_hotkey: str,
         destination_netuid: int,
-        amount: Balance,
+        amount: Optional[Balance] = None,
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
         period: Optional[int] = None,
+        move_all_stake: bool = False,
     ) -> bool:
         """
         Moves stake to a different hotkey and/or subnet.
@@ -3513,6 +3514,7 @@ class Subtensor(SubtensorMixin):
             period (Optional[int]): The number of blocks during which the transaction will remain valid after it's
                 submitted. If the transaction is not included in a block within that number of blocks, it will expire
                 and be rejected. You can think of it as an expiration date for the transaction.
+            move_all_stake: If true, moves all stake from the source hotkey to the destination hotkey.
 
         Returns:
             success (bool): True if the stake movement was successful.
@@ -3529,6 +3531,7 @@ class Subtensor(SubtensorMixin):
             wait_for_inclusion=wait_for_inclusion,
             wait_for_finalization=wait_for_finalization,
             period=period,
+            move_all_stake=move_all_stake,
         )
 
     def register(

--- a/bittensor/core/subtensor_api/staking.py
+++ b/bittensor/core/subtensor_api/staking.py
@@ -22,6 +22,7 @@ class Staking:
         self.get_stake_operations_fee = subtensor.get_stake_operations_fee
         self.get_stake_weight = subtensor.get_stake_weight
         self.get_unstake_fee = subtensor.get_unstake_fee
+        self.move_stake = subtensor.move_stake
         self.unstake = subtensor.unstake
         self.unstake_all = subtensor.unstake_all
         self.unstake_multiple = subtensor.unstake_multiple

--- a/tests/e2e_tests/test_delegate.py
+++ b/tests/e2e_tests/test_delegate.py
@@ -13,7 +13,7 @@ from tests.e2e_tests.utils.chain_interactions import (
     vote,
 )
 from tests.e2e_tests.utils.e2e_test_utils import wait_to_start_call
-from tests.helpers.helpers import CLOSE_IN_VALUE
+from tests.helpers.helpers import CloseInValue
 
 DEFAULT_DELEGATE_TAKE = 0.179995422293431
 
@@ -449,7 +449,7 @@ def test_get_vote_data(subtensor, alice_wallet):
 
     assert proposal == ProposalVoteData(
         ayes=[],
-        end=CLOSE_IN_VALUE(1_000_000, subtensor.block),
+        end=CloseInValue(1_000_000, subtensor.block),
         index=0,
         nays=[],
         threshold=3,
@@ -475,7 +475,7 @@ def test_get_vote_data(subtensor, alice_wallet):
         ayes=[
             alice_wallet.hotkey.ss58_address,
         ],
-        end=CLOSE_IN_VALUE(1_000_000, subtensor.block),
+        end=CloseInValue(1_000_000, subtensor.block),
         index=0,
         nays=[],
         threshold=3,

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,6 +1,6 @@
 import os
 from .helpers import (  # noqa: F401
-    CLOSE_IN_VALUE,
+    CloseInValue,
     __mock_wallet_factory__,
 )
 from bittensor_wallet.mock.wallet_mock import (  # noqa: F401

--- a/tests/helpers/helpers.py
+++ b/tests/helpers/helpers.py
@@ -34,7 +34,7 @@ def __mock_wallet_factory__(*_, **__) -> _MockWallet:
     return mock_wallet
 
 
-class CLOSE_IN_VALUE:
+class CloseInValue:
     value: Union[float, int, Balance]
     tolerance: Union[float, int, Balance]
 
@@ -53,8 +53,14 @@ class CLOSE_IN_VALUE:
             (self.value - self.tolerance) <= __o <= (self.value + self.tolerance)
         ) or ((__o - self.tolerance) <= self.value <= (__o + self.tolerance))
 
+    def __str__(self) -> str:
+        return f"CloseInValue<value: {self.value}, tolerance: {self.tolerance}>"
 
-class ApproxBalance(CLOSE_IN_VALUE, Balance):
+    def __repr__(self) -> str:
+        return self.__str__()
+
+
+class ApproxBalance(CloseInValue, Balance):
     def __init__(
         self,
         balance: Union[float, int],

--- a/tests/unit_tests/utils/test_balance.py
+++ b/tests/unit_tests/utils/test_balance.py
@@ -7,7 +7,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 
 from bittensor.utils.balance import Balance
-from tests.helpers import CLOSE_IN_VALUE
+from tests.helpers import CloseInValue
 
 
 valid_tao_numbers_strategy = st.one_of(
@@ -36,7 +36,7 @@ def test_balance_init(balance: Union[int, float]):
     if isinstance(balance, int):
         assert balance_.rao == balance
     elif isinstance(balance, float):
-        assert balance_.tao == CLOSE_IN_VALUE(balance, 0.00001)
+        assert balance_.tao == CloseInValue(balance, 0.00001)
 
 
 @given(balance=valid_tao_numbers_strategy, balance2=valid_tao_numbers_strategy)
@@ -59,7 +59,7 @@ def test_balance_add(balance: Union[int, float], balance2: Union[int, float]):
 
     sum_ = balance_ + balance2_
     assert isinstance(sum_, Balance)
-    assert CLOSE_IN_VALUE(sum_.rao, 5) == rao_ + rao2_
+    assert CloseInValue(sum_.rao, 5) == rao_ + rao2_
 
 
 @given(balance=valid_tao_numbers_strategy, balance2=valid_tao_numbers_strategy)
@@ -82,7 +82,7 @@ def test_balance_add_other_not_balance(
 
     sum_ = balance_ + balance2_
     assert isinstance(sum_, Balance)
-    assert CLOSE_IN_VALUE(sum_.rao, 5) == rao_ + rao2_
+    assert CloseInValue(sum_.rao, 5) == rao_ + rao2_
 
 
 @given(balance=valid_tao_numbers_strategy)
@@ -95,7 +95,7 @@ def test_balance_eq_other_not_balance(balance: Union[int, float]):
     # convert balance2 to rao. This assumes balance2 is a rao value
     rao2_ = int(balance_.rao)
 
-    assert CLOSE_IN_VALUE(rao2_, 5) == balance_
+    assert CloseInValue(rao2_, 5) == balance_
 
 
 @given(balance=valid_tao_numbers_strategy, balance2=valid_tao_numbers_strategy)
@@ -118,7 +118,7 @@ def test_balance_radd_other_not_balance(
 
     sum_ = balance2_ + balance_  # This is an radd
     assert isinstance(sum_, Balance)
-    assert CLOSE_IN_VALUE(sum_.rao, 5) == rao2_ + rao_
+    assert CloseInValue(sum_.rao, 5) == rao2_ + rao_
 
 
 @given(balance=valid_tao_numbers_strategy, balance2=valid_tao_numbers_strategy)
@@ -141,7 +141,7 @@ def test_balance_sub(balance: Union[int, float], balance2: Union[int, float]):
 
     diff_ = balance_ - balance2_
     assert isinstance(diff_, Balance)
-    assert CLOSE_IN_VALUE(diff_.rao, 5) == rao_ - rao2_
+    assert CloseInValue(diff_.rao, 5) == rao_ - rao2_
 
 
 @given(balance=valid_tao_numbers_strategy, balance2=valid_tao_numbers_strategy)
@@ -164,7 +164,7 @@ def test_balance_sub_other_not_balance(
 
     diff_ = balance_ - balance2_
     assert isinstance(diff_, Balance)
-    assert CLOSE_IN_VALUE(diff_.rao, 5) == rao_ - rao2_
+    assert CloseInValue(diff_.rao, 5) == rao_ - rao2_
 
 
 @given(balance=valid_tao_numbers_strategy, balance2=valid_tao_numbers_strategy)
@@ -187,7 +187,7 @@ def test_balance_rsub_other_not_balance(
 
     diff_ = balance2_ - balance_  # This is an rsub
     assert isinstance(diff_, Balance)
-    assert CLOSE_IN_VALUE(diff_.rao, 5) == rao2_ - rao_
+    assert CloseInValue(diff_.rao, 5) == rao2_ - rao_
 
 
 @given(balance=valid_tao_numbers_strategy, balance2=valid_tao_numbers_strategy)
@@ -373,7 +373,7 @@ def test_balance_floordiv(balance: Union[int, float], balance2: Union[int, float
 
     quot_ = balance_ // balance2_
     assert isinstance(quot_, Balance)
-    assert CLOSE_IN_VALUE(quot_.rao, 5) == rao_ // rao2_
+    assert CloseInValue(quot_.rao, 5) == rao_ // rao2_
 
 
 @given(


### PR DESCRIPTION
Issue: https://github.com/opentensor/bittensor/issues/2997

Even though the new logic works, I think it's worth implementing a separate function on the subtensor side, because dynamic change (emission) of staking can affect the result. There is a chance that after performing extrinsic, a very small share can remain on the hot key.