### PR TITLE
[v10] Fix `argparser` issue

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,18 +2,12 @@
 
 ## Extrinsics and related
 1. ✅ Standardize parameter order across all extrinsics and related calls. Pass extrinsic-specific arguments first (e.g., wallet, hotkey, netuid, amount), followed by optional general flags (e.g., wait_for_inclusion, wait_for_finalization)
-  
 2. ✅ Set `wait_for_inclusion` and `wait_for_finalization` to `True` by default in extrinsics and their related calls. Then we will guarantee the correct/expected extrinsic call response is consistent with the chain response. If the user changes those values, then it is the user's responsibility.
 3. ✅ Make the internal logic of extrinsics the same. There are extrinsics that are slightly different in implementation.
-
 4. ✅ ~~Since SDK is not a responsible tool, try to remove all calculations inside extrinsics that do not affect the result, but are only used in logging. Actually, this should be applied not to extrinsics only but for all codebase.~~ Just improved regarding usage.
-
 5. ✅ Remove `unstake_all` parameter from `unstake_extrinsic` since we have `unstake_all_extrinsic`which is calles another subtensor function.
-
 6. ✅ `unstake` and `unstake_multiple` extrinsics should have `safe_unstaking` parameters instead of `safe_staking`.
-
 7. ✅ Remove `_do*` extrinsic calls and combine them with extrinsic logic.
-
 8. ✅ ~~`subtensor.get_transfer_fee` calls extrinsic inside the subtensor module. Actually the method could be updated by using `bittensor.core.extrinsics.utils.get_extrinsic_fee`.~~ (`get_transfer_fee` isn't `get_extrinsic_fee`)
 
 ## Subtensor
@@ -35,15 +29,18 @@
 
 ## Balance
 1. ✅ In `bittensor.utils.balance._check_currencies` raise the error instead of `warnings.warn`.
-2. ✅ In `bittensor.utils.balance.check_and_convert_to_balance` raise the error instead of `warnings.warn`. 
-This may seem like a harsh decision at first, but ultimately we will push the community to use Balance and there will be fewer errors in their calculations. Confusion with TAO and Alpha in calculations and display/printing/logging will be eliminated.
+2. ✅ In `bittensor.utils.balance.check_and_convert_to_balance` raise the error instead of `warnings.warn`. This may 
+   seem like a harsh decision at first, but ultimately we will push the community to use Balance and there will be fewer 
+   errors in their calculations. Confusion with TAO and Alpha in calculations and display/printing/logging will be 
+   eliminated.
 
 ## Common things
 1. ✅ Reduce the amount of logging.info or transfer part of logging.info to logging.debug
 
 2. ✅ To be consistent across all SDK regarding local environment variables name:
-remove `BT_CHAIN_ENDPOINT` (settings.py :line 124) and use `BT_SUBTENSOR_CHAIN_ENDPOINT` instead of that.
-rename this variable in documentation.
+   - remove `BT_CHAIN_ENDPOINT` (settings.py :line 124) and use `BT_SUBTENSOR_CHAIN_ENDPOINT` instead of that.
+   rename this variable in documentation.
+   - rename local env variable`BT_NETWORK` to `BT_SUBTENSOR_NETWORK`
 
 3. ✅ ~~Move `bittensor.utils.get_transfer_fn_params` to `bittensor.core.extrinsics.utils`.~~ it's on the right place.
 
@@ -70,7 +67,7 @@ rename this variable in documentation.
 12. ✅ The SDK is dropping support for `Python 3.9` starting with this release.
 13. ✅ Remove `Default is` and `Default to` in docstrings bc parameters enough.
 14. ✅ `camfairchild`: TODO, but we should have a grab_metadata if we don't already. Maybe don't decode, but can have a call that removes the Raw prefix, and another just doing grab_metadata_raw (no decoding). `get_commitment_metadata` added.
-15. Solve the issue when a script using SDK receives the `--config` cli parameter. Disable `argparse` processing by default and enable it only when using SOME? a local environment variable.
+15. ✅ Resolve an issue where a script using the SDK receives the `--config` or any other CLI parameters used in the SDK. Disable configuration processing. Use default values ​​instead.
 16. Find and process all `TODOs` across the entire code base. If in doubt, discuss each one with the team separately. SDK has 29 TODOs.
 
 ## New features
@@ -322,3 +319,7 @@ Currently it contains:
 - [x] `check_and_convert_to_balance` renamed to `check_balance_amount`
 - [x] `check_balance_amount` raised `BalanceTypeError` error instead of deprecated warning message.
 - [x] private function `bittensor.utils.balance._check_currencies` raises `BalanceUnitMismatchError` error instead of deprecated warning message. This function is used inside the Balance class to check if units match during various mathematical and logical operations.
+
+
+### ArgParser issue
+- to turn on args parser across SDK, the local env variable `BT_PARSE_CLI_ARGS` should be set to on of the values: `1`, `true`, `yes`, `on`.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -323,3 +323,4 @@ Currently it contains:
 
 ### ArgParser issue
 - to turn on args parser across SDK, the local env variable `BT_PARSE_CLI_ARGS` should be set to on of the values: `1`, `true`, `yes`, `on`.
+- `bittensor.core.config.DefaultConfig` class has been deleted (unused).

--- a/bittensor/core/config.py
+++ b/bittensor/core/config.py
@@ -53,7 +53,7 @@ class Config(DefaultMunch):
         strict: bool = False,
         default: Any = DEFAULTS,
     ) -> None:
-        parse_cli = os.getenv("BT_PARSE_CLI_ARGS", "").lower() in (
+        no_parse_cli = os.getenv("BT_NO_PARSE_CLI_ARGS", "").lower() in (
             "1",
             "true",
             "yes",
@@ -73,7 +73,7 @@ class Config(DefaultMunch):
         self.__is_set = {}
 
         # If CLI parsing disabled, stop here
-        if not parse_cli or parser is None:
+        if no_parse_cli or parser is None:
             return
 
         self._add_default_arguments(parser)

--- a/bittensor/core/settings.py
+++ b/bittensor/core/settings.py
@@ -122,7 +122,7 @@ DEFAULTS = munchify(
         "subtensor": {
             "chain_endpoint": os.getenv("BT_SUBTENSOR_CHAIN_ENDPOINT")
             or DEFAULT_ENDPOINT,
-            "network": os.getenv("BT_NETWORK") or DEFAULT_NETWORK,
+            "network": os.getenv("BT_SUBTENSOR_NETWORK") or DEFAULT_NETWORK,
             "_mock": False,
         },
         "wallet": {
@@ -130,6 +130,9 @@ DEFAULTS = munchify(
             "hotkey": os.getenv("BT_WALLET_HOTKEY") or "default",
             "path": os.getenv("BT_WALLET_PATH") or str(WALLETS_DIR),
         },
+        "config": False,
+        "strict": False,
+        "no_version_checking": False,
     }
 )
 

--- a/tests/integration_tests/test_config_does_not_process_cli_args.py
+++ b/tests/integration_tests/test_config_does_not_process_cli_args.py
@@ -30,7 +30,6 @@ TEST_ARGS = [
 
 def test_bittensor_cli_parser_enabled(monkeypatch):
     """Tests that the bt cli args are processed."""
-    monkeypatch.setenv("BT_PARSE_CLI_ARGS", "true")
 
     monkeypatch.setattr(sys, "argv", TEST_ARGS)
 
@@ -42,6 +41,7 @@ def test_bittensor_cli_parser_enabled(monkeypatch):
 
 def test_bittensor_cli_parser_disabled(monkeypatch):
     """Tests that the bt cli args are not processed."""
+    monkeypatch.setenv("BT_NO_PARSE_CLI_ARGS", "true")
     monkeypatch.setattr(sys, "argv", TEST_ARGS)
 
     config = _config_call()

--- a/tests/integration_tests/test_config_does_not_process_cli_args.py
+++ b/tests/integration_tests/test_config_does_not_process_cli_args.py
@@ -1,0 +1,51 @@
+import argparse
+import sys
+
+import pytest
+
+import bittensor as bt
+from bittensor.core.config import InvalidConfigFile
+
+
+def _config_call():
+    """Create a config object from the bt cli args."""
+    parser = argparse.ArgumentParser()
+    bt.Axon.add_args(parser)
+    bt.Subtensor.add_args(parser)
+    bt.AsyncSubtensor.add_args(parser)
+    bt.Wallet.add_args(parser)
+    bt.logging.add_args(parser)
+    bt.PriorityThreadPoolExecutor.add_args(parser)
+    config = bt.Config(parser)
+    return config
+
+
+TEST_ARGS = [
+    "bittensor",
+    "--config", "path/to/config.yaml",
+    "--strict",
+    "--no_version_checking"
+]
+
+
+def test_bittensor_cli_parser_enabled(monkeypatch):
+    """Tests that the bt cli args are processed."""
+    monkeypatch.setenv("BT_PARSE_CLI_ARGS", "true")
+
+    monkeypatch.setattr(sys, "argv", TEST_ARGS)
+
+    with pytest.raises(InvalidConfigFile) as error:
+        _config_call()
+
+    assert "No such file or directory" in str(error)
+
+
+def test_bittensor_cli_parser_disabled(monkeypatch):
+    """Tests that the bt cli args are not processed."""
+    monkeypatch.setattr(sys, "argv", TEST_ARGS)
+
+    config = _config_call()
+
+    assert config.config is False
+    assert config.strict is False
+    assert config.no_version_checking is False


### PR DESCRIPTION
This PR refactors the Config class to dynamically respect the `BT_NO_PARSE_CLI_ARGS` environment variable, ensuring CLI argument parsing is enabled by default and can be explicitly disabled when needed.
This change prevents SDK crashes when it is used within external scripts that define their own CLI arguments overlapping with the SDK’s.
- The environment variable is recognized when set to any of the following case-insensitive values: 1, true, yes, or on.
- By default, `BT_NO_PARSE_CLI_ARGS` is not set, and CLI argument parsing remains active.
- The local environment variable `BT_NETWORK` has been renamed to `BT_SUBTENSOR_NETWORK` for consistency with other Subtensor-related settings.

@MichaelTrestman — please note that the documentation needs to be updated to reflect:
- the new environment variable `BT_NO_PARSE_CLI_ARGS`, and
- the renamed variable `BT_SUBTENSOR_NETWORK`.