### PR TITLE
[v10] Remove deprecated `bittensor.version_split`

### DIFF
--- a/bittensor/__init__.py
+++ b/bittensor/__init__.py
@@ -1,15 +1,3 @@
-import warnings
-
-from .core.settings import __version__, version_split, DEFAULTS, DEFAULT_NETWORK
+from .core.settings import __version__, DEFAULTS, DEFAULT_NETWORK
 from .utils.btlogging import logging
 from .utils.easy_imports import *
-
-
-def __getattr__(name):
-    if name == "version_split":
-        warnings.warn(
-            "version_split is deprecated and will be removed in future versions. Use __version__ instead.",
-            DeprecationWarning,
-        )
-        return version_split
-    raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/bittensor/__main__.py
+++ b/bittensor/__main__.py
@@ -1,9 +1,11 @@
+import importlib.metadata
 import os
 import subprocess
 import sys
 
-from bittensor import __version__
 from bittensor.utils.version import check_latest_version_in_pypi
+
+__version__ = importlib.metadata.version("bittensor")
 
 if __name__ == "__main__":
     if len(sys.argv) > 1 and sys.argv[1] == "certifi":

--- a/bittensor/core/settings.py
+++ b/bittensor/core/settings.py
@@ -140,8 +140,8 @@ DEFAULTS = munchify(
 # Parsing version without any literals.
 __version__ = re.match(r"^\d+\.\d+\.\d+", __version__).group(0)
 
-version_split = __version__.split(".")
-_version_info = tuple(int(part) for part in version_split)
+__version_split = __version__.split(".")
+_version_info = tuple(int(part) for part in __version_split)
 _version_int_base = 1000
 assert max(_version_info) < _version_int_base
 

--- a/tests/unit_tests/utils/test_utils.py
+++ b/tests/unit_tests/utils/test_utils.py
@@ -1,17 +1,7 @@
 import pytest
 
-from bittensor import warnings, __getattr__, version_split, logging, trace, debug, utils
+from bittensor import warnings, __getattr__, logging, trace, debug, utils
 from bittensor_wallet.utils import SS58_FORMAT
-
-
-def test_getattr_version_split():
-    """Test that __getattr__ for 'version_split' issues a deprecation warning and returns the correct value."""
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        assert __getattr__("version_split") == version_split
-        assert len(w) == 1
-        assert issubclass(w[-1].category, DeprecationWarning)
-        assert "version_split is deprecated" in str(w[-1].message)
 
 
 @pytest.mark.parametrize("test_input, expected", [(True, "Trace"), (False, "Default")])

--- a/tests/unit_tests/utils/test_utils.py
+++ b/tests/unit_tests/utils/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from bittensor import warnings, __getattr__, logging, trace, debug, utils
+from bittensor import logging, trace, debug, utils
 from bittensor_wallet.utils import SS58_FORMAT
 
 


### PR DESCRIPTION
- removed deprecated `bittensor.version_split`
- removed related warning
- bonus: `python -m bittensor` returns correct version