### PR TITLE
[v10] Release/v10.0.0rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [v10] Remove deprecated `bittensor.version_split` by @basfroman in https://github.com/opentensor/bittensor/pull/3100
 * [v10] Fix `bittensor.core.types.Weights` type annotation by @basfroman in https://github.com/opentensor/bittensor/pull/3103
 * [v10] Integrate Crowdloan by @basfroman in https://github.com/opentensor/bittensor/pull/3098
+* [v10] Rename max_retries to max_attempts to be more obvious by @basfroman in https://github.com/opentensor/bittensor/pull/3108
 
 **Full Changelog**: https://github.com/opentensor/bittensor/compare/release/v10.0.0rc1...release/v10.0.0rc2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 10.0.0rc2 /2025-10-20
+
+* [v10] Remove deprecated `bittensor.version_split` by @basfroman in https://github.com/opentensor/bittensor/pull/3100
+* [v10] Fix `bittensor.core.types.Weights` type annotation by @basfroman in https://github.com/opentensor/bittensor/pull/3103
+* [v10] Integrate Crowdloan by @basfroman in https://github.com/opentensor/bittensor/pull/3098
+
+**Full Changelog**: https://github.com/opentensor/bittensor/compare/release/v10.0.0rc1...v10.0.0rc2
+
 ## 10.0.0rc1 /2025-10-14
 
 ## What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * [v10] Fix `bittensor.core.types.Weights` type annotation by @basfroman in https://github.com/opentensor/bittensor/pull/3103
 * [v10] Integrate Crowdloan by @basfroman in https://github.com/opentensor/bittensor/pull/3098
 
-**Full Changelog**: https://github.com/opentensor/bittensor/compare/release/v10.0.0rc1...v10.0.0rc2
+**Full Changelog**: https://github.com/opentensor/bittensor/compare/release/v10.0.0rc1...release/v10.0.0rc2
 
 ## 10.0.0rc1 /2025-10-14
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bittensor"
-version = "10.0.0rc1"
+version = "10.0.0rc2"
 description = "Bittensor SDK"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## 10.0.0rc2 /2025-10-20

* [v10] Remove deprecated `bittensor.version_split` by @basfroman in https://github.com/opentensor/bittensor/pull/3100
* [v10] Fix `bittensor.core.types.Weights` type annotation by @basfroman in https://github.com/opentensor/bittensor/pull/3103
* [v10] Integrate Crowdloan by @basfroman in https://github.com/opentensor/bittensor/pull/3098
* [v10] Renamed parameters `max_retries` to `max_attempts` to be more obvious by @basfroman in https://github.com/opentensor/bittensor/pull/3108

**Full Changelog**: https://github.com/opentensor/bittensor/compare/release/v10.0.0rc1...release/v10.0.0rc2