### PR TITLE
[v10] Rename `max_retries` to `max_attempts` to be more obvious

### DIFF
--- a/tests/e2e_tests/test_commit_weights.py
+++ b/tests/e2e_tests/test_commit_weights.py
@@ -489,11 +489,11 @@ async def test_commit_weights_uses_next_nonce_async(async_subtensor, alice_walle
             )
             return success_, message_
 
-        max_retries = 3
+        max_attempts = 3
         timeout = 60.0
         sleep = 0.25 if async_subtensor.chain.is_fast_blocks() else 12.0
 
-        for attempt in range(1, max_retries + 1):
+        for attempt in range(1, max_attempts + 1):
             try:
                 start_nonce = await async_subtensor.substrate.get_account_nonce(
                     alice_wallet.hotkey.ss58_address
@@ -518,7 +518,7 @@ async def test_commit_weights_uses_next_nonce_async(async_subtensor, alice_walle
                     time.sleep(sleep)
             except Exception as e:
                 raise e
-        raise Exception(f"Failed to commit weights after {max_retries} attempts.")
+        raise Exception(f"Failed to commit weights after {max_attempts} attempts.")
 
     # Send some number of commit weights
     AMOUNT_OF_COMMIT_WEIGHTS = 3

--- a/tests/e2e_tests/test_set_weights.py
+++ b/tests/e2e_tests/test_set_weights.py
@@ -285,11 +285,11 @@ async def test_set_weights_uses_next_nonce_async(async_subtensor, alice_wallet):
             )
             assert success_ is True, message_
 
-        max_retries = 3
+        max_attempts = 3
         timeout = 60.0
         sleep = 0.25 if async_subtensor.chain.is_fast_blocks() else 12.0
 
-        for attempt in range(1, max_retries + 1):
+        for attempt in range(1, max_attempts + 1):
             try:
                 start_nonce = await async_subtensor.substrate.get_account_nonce(
                     alice_wallet.hotkey.ss58_address
@@ -314,7 +314,7 @@ async def test_set_weights_uses_next_nonce_async(async_subtensor, alice_wallet):
                     time.sleep(sleep)
             except Exception as e:
                 raise e
-        raise Exception(f"Failed to commit weights after {max_retries} attempts.")
+        raise Exception(f"Failed to commit weights after {max_attempts} attempts.")
 
     for mechid in range(TESTED_MECHANISMS):
         # Set weights for each subnet

--- a/tests/e2e_tests/utils/__init__.py
+++ b/tests/e2e_tests/utils/__init__.py
@@ -19,14 +19,14 @@ def get_dynamic_balance(rao: int, netuid: int = 0):
 
 
 def execute_and_wait_for_next_nonce(
-    subtensor: "SubtensorApi", wallet, sleep=0.25, timeout=60.0, max_retries=3
+    subtensor: "SubtensorApi", wallet, sleep=0.25, timeout=60.0, max_attempts=3
 ):
     """Decorator that ensures the nonce has been consumed after a blockchain extrinsic call."""
 
     def decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            for attempt in range(max_retries):
+            for attempt in range(max_attempts):
                 start_nonce = subtensor.substrate.get_account_next_index(
                     wallet.hotkey.ss58_address
                 )
@@ -52,9 +52,11 @@ def execute_and_wait_for_next_nonce(
                     time.sleep(sleep)
 
                 logging.warning(
-                    f"⚠️ Attempt {attempt + 1}/{max_retries}: Nonce did not increment."
+                    f"⚠️ Attempt {attempt + 1}/{max_attempts}: Nonce did not increment."
                 )
-            raise TimeoutError(f"❌ Nonce did not change after {max_retries} attempts.")
+            raise TimeoutError(
+                f"❌ Nonce did not change after {max_attempts} attempts."
+            )
 
         return wrapper
 

--- a/tests/unit_tests/test_async_subtensor.py
+++ b/tests/unit_tests/test_async_subtensor.py
@@ -4610,3 +4610,50 @@ async def test_get_crowdloans(mocker, subtensor):
         block_hash=mocked_determine_block_hash.return_value,
     )
     assert result == [mocked_decode_crowdloan_entry.return_value]
+
+
+@pytest.mark.parametrize(
+    "method, add_salt",
+    [
+        ("commit_weights", True),
+        ("reveal_weights", True),
+        ("set_weights", False),
+    ],
+    ids=["commit_weights", "reveal_weights", "set_weights"],
+)
+@pytest.mark.asyncio
+async def test_commit_weights_with_zero_max_attempts(
+    mocker, subtensor, caplog, method, add_salt
+):
+    """Verify that commit_weights returns response with proper error message."""
+    # Preps
+    wallet = mocker.Mock(spec=Wallet)
+    netuid = mocker.Mock(spec=int)
+    salt = mocker.Mock(spec=list)
+    uids = mocker.Mock(spec=list)
+    weights = mocker.Mock(spec=list)
+    max_attempts = 0
+    expected_message = (
+        f"`max_attempts` parameter must be greater than 0, not {max_attempts}."
+    )
+
+    params = {
+        "wallet": wallet,
+        "netuid": netuid,
+        "uids": uids,
+        "weights": weights,
+        "max_attempts": max_attempts,
+    }
+    if add_salt:
+        params["salt"] = salt
+
+    # Call
+    # with caplog.at_level(logging.WARNING):
+    response = await getattr(subtensor, method)(**params)
+
+    # Asserts
+    assert response.success is False
+    assert response.message == expected_message
+    assert isinstance(response.error, ValueError)
+    assert expected_message in str(response.error)
+    assert expected_message in caplog.text


### PR DESCRIPTION
1. Next async/sync subtensor methods got renames parameter (`max_retries` ->  `max_attempts`):
- `commit_weights`
- `reveal_weights`
- `set_weights`

2. Added validator for `max_attempts=0`. ExtrinsicResponse will contain related message and error.

3. Tests added.

@MichaelTrestman please reflect changes in SDKv10 migration guide too. 