### PR TITLE
Fix for `test_liquidity`

### DIFF
--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -1615,6 +1615,16 @@ class Subtensor(SubtensorMixin):
             logging.debug(f"Subnet {netuid} is not active.")
             return None
 
+        # Fetch positions
+        positions_response = self.query_map(
+            module="Swap",
+            name="Positions",
+            block=block,
+            params=[netuid, wallet.coldkeypub.ss58_address],
+        )
+        if len(positions_response.records) == 0:
+            return []
+
         block_hash = self.determine_block_hash(block)
 
         # Fetch global fees and current price
@@ -1652,13 +1662,6 @@ class Subtensor(SubtensorMixin):
         sqrt_price = fixed_to_float(sqrt_price_query[1])
         current_tick = price_to_tick(sqrt_price**2)
 
-        # Fetch positions
-        positions_response = self.query_map(
-            module="Swap",
-            name="Positions",
-            block=block,
-            params=[netuid, wallet.coldkeypub.ss58_address],
-        )
         positions_values: list[tuple[dict, int, int]] = []
         positions_storage_keys: list[StorageKey] = []
         for _, p in positions_response:

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -1648,7 +1648,7 @@ class Subtensor(SubtensorMixin):
         )
         fee_global_tao_query, fee_global_alpha_query, sqrt_price_query = (
             self.substrate.query_multi(
-                [
+                storage_keys=[
                     fee_global_tao_query_sk,
                     fee_global_alpha_query_sk,
                     sqrt_price_query_sk,

--- a/tests/e2e_tests/test_liquidity.py
+++ b/tests/e2e_tests/test_liquidity.py
@@ -5,8 +5,7 @@ from tests.e2e_tests.utils.e2e_test_utils import wait_to_start_call
 from bittensor.utils.liquidity import LiquidityPosition
 
 
-@pytest.mark.asyncio
-async def test_liquidity(local_chain, subtensor, alice_wallet, bob_wallet):
+def test_liquidity(subtensor, alice_wallet, bob_wallet):
     """
     Tests the liquidity mechanism
 

--- a/tests/unit_tests/test_async_subtensor.py
+++ b/tests/unit_tests/test_async_subtensor.py
@@ -3662,7 +3662,7 @@ async def test_get_liquidity_list_happy_path(subtensor, fake_wallet, mocker):
         ],
     ]
 
-    fake_result = mocker.AsyncMock(autospec=list)
+    fake_result = mocker.AsyncMock(records=fake_positions, autospec=list)
     fake_result.__aiter__.return_value = iter(fake_positions)
 
     mocked_query_map = mocker.AsyncMock(return_value=fake_result)
@@ -3682,8 +3682,10 @@ async def test_get_liquidity_list_happy_path(subtensor, fake_wallet, mocker):
     mocked_query_map.assert_awaited_once_with(
         module="Swap",
         name="Positions",
-        block=None,
         params=[netuid, fake_wallet.coldkeypub.ss58_address],
+        block=None,
+        block_hash=None,
+        reuse_block=False,
     )
     assert len(result) == len(fake_positions)
     assert all([isinstance(p, async_subtensor.LiquidityPosition) for p in result])

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -3868,7 +3868,10 @@ def test_get_liquidity_list_happy_path(subtensor, fake_wallet, mocker):
             ),
         ],
     ]
-    mocked_query_map = mocker.MagicMock(return_value=fake_positions)
+    fake_result = mocker.MagicMock(records=fake_positions, autospec=list)
+    fake_result.__iter__.return_value = iter(fake_positions)
+
+    mocked_query_map = mocker.Mock(return_value=fake_result)
     mocker.patch.object(subtensor, "query_map", new=mocked_query_map)
 
     # Mock storage key creation
@@ -3913,8 +3916,8 @@ def test_get_liquidity_list_happy_path(subtensor, fake_wallet, mocker):
     mocked_query_map.assert_called_once_with(
         module="Swap",
         name="Positions",
-        block=None,
         params=[netuid, fake_wallet.coldkeypub.ss58_address],
+        block=None,
     )
     assert mock_query_multi.call_count == 2  # one for fees, one for ticks
     assert len(result) == len(fake_positions)


### PR DESCRIPTION
The problem is that if there are no positions, AlphaSqrtPrice is 0.

The current logic checks positions before calculating the price. This approach is compatible with Subtensor before and after the Root Claim implementation.

Subtensor PR with failed tests https://github.com/opentensor/subtensor/pull/2053
