### PR TITLE
Allow python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
     {name = "bittensor.com"}
 ]
 license = { file = "LICENSE" }
-requires-python = ">=3.9,<3.14"
+requires-python = ">=3.9,<3.15"
 dependencies = [
     "wheel",
     "setuptools~=70.0.0",


### PR DESCRIPTION
Allows for installing python 3.14 in v9 (for compatibility tests)

SDKv10 version: https://github.com/opentensor/bittensor/pull/3123