### PR TITLE
[V10] python3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
     {name = "bittensor.com"}
 ]
 license = { file = "LICENSE" }
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10,<3.15"
 dependencies = [
     "wheel",
     "setuptools~=70.0.0",


### PR DESCRIPTION
Allows for installing Python 3.14 in SDK v10

Requires drand update still (https://github.com/opentensor/bittensor-drand/pull/52)

v9 version: https://github.com/opentensor/bittensor/pull/3122