### PR TITLE
Release/9.12.2

### DIFF
--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -41,7 +41,8 @@ jobs:
       - name: Install deps for collection
         run: |
          python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          python -m pip install uv
+          uv pip install -e ".[dev]" --system
 
       - name: Find test files
         id: get-tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## 9.12.2 /2025-10-30
+* Use uv pip for e2e dependency installation by @thewhaleking in https://github.com/opentensor/bittensor/pull/3109
+* Fix for `test_liquidity` by @basfroman in https://github.com/opentensor/bittensor/pull/3114
+* Apply default `era.period` to all subtensor extrinsic calls by @basfroman in https://github.com/opentensor/bittensor/pull/3115
+* set root owner for fast runtime time by @basfroman in https://github.com/opentensor/bittensor/pull/3118
+* Allow python 3.14 by @thewhaleking in https://github.com/opentensor/bittensor/pull/3122
+
+**Full Changelog**: https://github.com/opentensor/bittensor/compare/v9.12.1...v9.12.2
 
 ## 9.12.1 /2025-10-20
 

--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -956,7 +956,11 @@ class AsyncSubtensor(SubtensorMixin):
         return b_map
 
     async def commit(
-        self, wallet: "Wallet", netuid: int, data: str, period: Optional[int] = None
+        self,
+        wallet: "Wallet",
+        netuid: int,
+        data: str,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> bool:
         """Commits arbitrary data to the Bittensor network by publishing metadata.
 
@@ -4049,7 +4053,7 @@ class AsyncSubtensor(SubtensorMixin):
         data: str,
         blocks_until_reveal: int = 360,
         block_time: Union[int, float] = 12,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> tuple[bool, int]:
         """
         Commits arbitrary data to the Bittensor network by publishing metadata.
@@ -4443,7 +4447,7 @@ class AsyncSubtensor(SubtensorMixin):
         wait_for_finalization: bool = False,
         sign_with: str = "coldkey",
         use_nonce: bool = False,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
         nonce_key: str = "hotkey",
         raise_error: bool = False,
     ) -> tuple[bool, str]:
@@ -4476,13 +4480,7 @@ class AsyncSubtensor(SubtensorMixin):
                 f"'sign_with' must be either 'coldkey', 'hotkey' or 'coldkeypub', not '{sign_with}'"
             )
         signing_keypair = getattr(wallet, sign_with)
-        extrinsic_data = {
-            "call": call,
-            "keypair": signing_keypair,
-            "era": {
-                "period": period or DEFAULT_PERIOD,
-            },
-        }
+        extrinsic_data = {"call": call, "keypair": signing_keypair}
         if use_nonce:
             if nonce_key not in possible_keys:
                 raise AttributeError(
@@ -4492,6 +4490,9 @@ class AsyncSubtensor(SubtensorMixin):
                 getattr(wallet, nonce_key).ss58_address
             )
             extrinsic_data["nonce"] = next_nonce
+
+        if period is not None:
+            extrinsic_data["era"] = {"period": period}
 
         extrinsic = await self.substrate.create_signed_extrinsic(**extrinsic_data)
         try:
@@ -4533,7 +4534,7 @@ class AsyncSubtensor(SubtensorMixin):
         safe_staking: bool = False,
         allow_partial_stake: bool = False,
         rate_tolerance: float = 0.005,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> bool:
         """
         Adds a stake from the specified wallet to the neuron identified by the SS58 address of its hotkey in specified
@@ -4591,7 +4592,7 @@ class AsyncSubtensor(SubtensorMixin):
         hotkey: Optional[str] = None,
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> tuple[bool, str]:
         """
         Adds liquidity to the specified price range.
@@ -4674,7 +4675,7 @@ class AsyncSubtensor(SubtensorMixin):
         netuid: int,
         wait_for_inclusion: bool = False,
         wait_for_finalization: bool = True,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> bool:
         """
         Registers a neuron on the Bittensor network by recycling TAO. This method of registration involves recycling
@@ -4723,7 +4724,7 @@ class AsyncSubtensor(SubtensorMixin):
         wait_for_inclusion: bool = False,
         wait_for_finalization: bool = False,
         max_retries: int = 5,
-        period: Optional[int] = 16,
+        period: Optional[int] = DEFAULT_PERIOD,
         mechid: int = 0,
     ) -> tuple[bool, str]:
         """
@@ -4798,7 +4799,7 @@ class AsyncSubtensor(SubtensorMixin):
         hotkey: Optional[str] = None,
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> tuple[bool, str]:
         """Modifies liquidity in liquidity position by adding or removing liquidity from it.
 
@@ -4871,7 +4872,7 @@ class AsyncSubtensor(SubtensorMixin):
         amount: Optional[Balance] = None,
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
         move_all_stake: bool = False,
     ) -> bool:
         """
@@ -4923,7 +4924,7 @@ class AsyncSubtensor(SubtensorMixin):
         num_processes: Optional[int] = None,
         update_interval: Optional[int] = None,
         log_verbose: bool = False,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ):
         """
         Registers a neuron on the Bittensor network using the provided wallet.
@@ -4977,7 +4978,7 @@ class AsyncSubtensor(SubtensorMixin):
         wallet: "Wallet",
         wait_for_inclusion: bool = False,
         wait_for_finalization: bool = True,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> bool:
         """
         Registers a new subnetwork on the Bittensor network.
@@ -5011,7 +5012,7 @@ class AsyncSubtensor(SubtensorMixin):
         hotkey: Optional[str] = None,
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> tuple[bool, str]:
         """Remove liquidity and credit balances back to wallet's hotkey stake.
 
@@ -5059,7 +5060,7 @@ class AsyncSubtensor(SubtensorMixin):
         wait_for_inclusion: bool = False,
         wait_for_finalization: bool = False,
         max_retries: int = 5,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
         mechid: int = 0,
     ) -> tuple[bool, str]:
         """
@@ -5124,7 +5125,7 @@ class AsyncSubtensor(SubtensorMixin):
         cooldown: int,
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = True,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> tuple[bool, str]:
         """Sets the pending childkey cooldown.
 
@@ -5160,7 +5161,7 @@ class AsyncSubtensor(SubtensorMixin):
         block_hash: Optional[str] = None,
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = True,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> bool:
         """
         Register neuron by recycling some TAO.
@@ -5195,7 +5196,7 @@ class AsyncSubtensor(SubtensorMixin):
         version_key: int = 0,
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = True,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> bool:
         """
         Set weights for the root network.
@@ -5233,7 +5234,7 @@ class AsyncSubtensor(SubtensorMixin):
         wallet: "Wallet",
         netuid: int,
         hotkey_ss58: str,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
         raise_error: bool = False,
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = True,
@@ -5277,7 +5278,7 @@ class AsyncSubtensor(SubtensorMixin):
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = True,
         raise_error: bool = False,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> tuple[bool, str]:
         """
         Allows a coldkey to set children-keys.
@@ -5331,7 +5332,7 @@ class AsyncSubtensor(SubtensorMixin):
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = True,
         raise_error: bool = False,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> tuple[bool, str]:
         """
         Sets the delegate 'take' percentage for a neuron identified by its hotkey.
@@ -5414,7 +5415,7 @@ class AsyncSubtensor(SubtensorMixin):
         subnet_identity: SubnetIdentity,
         wait_for_inclusion: bool = False,
         wait_for_finalization: bool = True,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> tuple[bool, str]:
         """
         Sets the identity of a subnet for a specific wallet and network.
@@ -5464,7 +5465,7 @@ class AsyncSubtensor(SubtensorMixin):
         wait_for_finalization: bool = False,
         max_retries: int = 5,
         block_time: float = 12.0,
-        period: Optional[int] = 8,
+        period: Optional[int] = DEFAULT_PERIOD,
         mechid: int = 0,
         commit_reveal_version: int = 4,
     ):
@@ -5589,7 +5590,7 @@ class AsyncSubtensor(SubtensorMixin):
         wait_for_inclusion: bool = False,
         wait_for_finalization: bool = True,
         certificate: Optional[Certificate] = None,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> bool:
         """
         Registers an ``Axon`` serving endpoint on the Bittensor network for a specific neuron. This function is used to
@@ -5627,7 +5628,7 @@ class AsyncSubtensor(SubtensorMixin):
         netuid: int,
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> tuple[bool, str]:
         """
         Submits a start_call extrinsic to the blockchain, to trigger the start call process for a subnet (used to start
@@ -5668,7 +5669,7 @@ class AsyncSubtensor(SubtensorMixin):
         safe_staking: bool = False,
         allow_partial_stake: bool = False,
         rate_tolerance: float = 0.005,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> bool:
         """
         Moves stake between subnets while keeping the same coldkey-hotkey pair ownership.
@@ -5727,7 +5728,7 @@ class AsyncSubtensor(SubtensorMixin):
         enable: bool,
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> tuple[bool, str]:
         """Allow to toggle user liquidity for specified subnet.
 
@@ -5767,7 +5768,7 @@ class AsyncSubtensor(SubtensorMixin):
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
         keep_alive: bool = True,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> bool:
         """
         Transfer token of amount to destination.
@@ -5810,7 +5811,7 @@ class AsyncSubtensor(SubtensorMixin):
         amount: Balance,
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> bool:
         """
         Transfers stake from one subnet to another while changing the coldkey owner.
@@ -5856,7 +5857,7 @@ class AsyncSubtensor(SubtensorMixin):
         safe_staking: bool = False,
         allow_partial_stake: bool = False,
         rate_tolerance: float = 0.005,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
         unstake_all: bool = False,
     ) -> bool:
         """
@@ -5913,7 +5914,7 @@ class AsyncSubtensor(SubtensorMixin):
         rate_tolerance: Optional[float] = 0.005,
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> tuple[bool, str]:
         """Unstakes all TAO/Alpha associated with a hotkey from the specified subnets on the Bittensor network.
 
@@ -5997,7 +5998,7 @@ class AsyncSubtensor(SubtensorMixin):
         amounts: Optional[list[Balance]] = None,
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
         unstake_all: bool = False,
     ) -> bool:
         """

--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -93,7 +93,7 @@ from bittensor.core.extrinsics.asyncex.unstaking import (
     unstake_multiple_extrinsic,
 )
 from bittensor.core.metagraph import AsyncMetagraph
-from bittensor.core.settings import version_as_int, TYPE_REGISTRY
+from bittensor.core.settings import version_as_int, TYPE_REGISTRY, DEFAULT_PERIOD
 from bittensor.core.types import (
     ParamWithTypes,
     Salt,
@@ -4476,7 +4476,13 @@ class AsyncSubtensor(SubtensorMixin):
                 f"'sign_with' must be either 'coldkey', 'hotkey' or 'coldkeypub', not '{sign_with}'"
             )
         signing_keypair = getattr(wallet, sign_with)
-        extrinsic_data = {"call": call, "keypair": signing_keypair}
+        extrinsic_data = {
+            "call": call,
+            "keypair": signing_keypair,
+            "era": {
+                "period": period or DEFAULT_PERIOD,
+            },
+        }
         if use_nonce:
             if nonce_key not in possible_keys:
                 raise AttributeError(
@@ -4486,8 +4492,6 @@ class AsyncSubtensor(SubtensorMixin):
                 getattr(wallet, nonce_key).ss58_address
             )
             extrinsic_data["nonce"] = next_nonce
-        if period is not None:
-            extrinsic_data["era"] = {"period": period}
 
         extrinsic = await self.substrate.create_signed_extrinsic(**extrinsic_data)
         try:

--- a/bittensor/core/settings.py
+++ b/bittensor/core/settings.py
@@ -70,6 +70,9 @@ SS58_FORMAT = 42
 # Wallet ss58 address length
 SS58_ADDRESS_LENGTH = 48
 
+# Default period for extrinsic Era
+DEFAULT_PERIOD = 16
+
 # Block Explorers map network to explorer url
 # Must all be polkadotjs explorer urls
 NETWORK_EXPLORER_MAP = {

--- a/bittensor/core/settings.py
+++ b/bittensor/core/settings.py
@@ -71,7 +71,7 @@ SS58_FORMAT = 42
 SS58_ADDRESS_LENGTH = 48
 
 # Default period for extrinsic Era
-DEFAULT_PERIOD = 16
+DEFAULT_PERIOD = 32
 
 # Block Explorers map network to explorer url
 # Must all be polkadotjs explorer urls

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -545,7 +545,11 @@ class Subtensor(SubtensorMixin):
         return b_map
 
     def commit(
-        self, wallet, netuid: int, data: str, period: Optional[int] = None
+        self,
+        wallet: "Wallet",
+        netuid: int,
+        data: str,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> bool:
         """
         Commits arbitrary data to the Bittensor network by publishing metadata.
@@ -2966,7 +2970,7 @@ class Subtensor(SubtensorMixin):
         data: str,
         blocks_until_reveal: int = 360,
         block_time: Union[int, float] = 12,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> tuple[bool, int]:
         """
         Commits arbitrary data to the Bittensor network by publishing metadata.
@@ -3259,7 +3263,7 @@ class Subtensor(SubtensorMixin):
         wait_for_finalization: bool = False,
         sign_with: str = "coldkey",
         use_nonce: bool = False,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
         nonce_key: str = "hotkey",
         raise_error: bool = False,
     ) -> tuple[bool, str]:
@@ -3292,13 +3296,7 @@ class Subtensor(SubtensorMixin):
             )
 
         signing_keypair = getattr(wallet, sign_with)
-        extrinsic_data = {
-            "call": call,
-            "keypair": signing_keypair,
-            "era": {
-                "period": period or DEFAULT_PERIOD,
-            },
-        }
+        extrinsic_data = {"call": call, "keypair": signing_keypair}
         if use_nonce:
             if nonce_key not in possible_keys:
                 raise AttributeError(
@@ -3308,6 +3306,9 @@ class Subtensor(SubtensorMixin):
                 getattr(wallet, nonce_key).ss58_address
             )
             extrinsic_data["nonce"] = next_nonce
+
+        if period is not None:
+            extrinsic_data["era"] = {"period": period}
 
         extrinsic = self.substrate.create_signed_extrinsic(**extrinsic_data)
         try:
@@ -3349,7 +3350,7 @@ class Subtensor(SubtensorMixin):
         safe_staking: bool = False,
         allow_partial_stake: bool = False,
         rate_tolerance: float = 0.005,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> bool:
         """
         Adds a stake from the specified wallet to the neuron identified by the SS58 address of its hotkey in specified
@@ -3408,7 +3409,7 @@ class Subtensor(SubtensorMixin):
         hotkey: Optional[str] = None,
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> tuple[bool, str]:
         """
         Adds liquidity to the specified price range.
@@ -3456,7 +3457,7 @@ class Subtensor(SubtensorMixin):
         amounts: Optional[list[Balance]] = None,
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> bool:
         """
         Adds stakes to multiple neurons identified by their hotkey SS58 addresses.
@@ -3496,7 +3497,7 @@ class Subtensor(SubtensorMixin):
         netuid: int,
         wait_for_inclusion: bool = False,
         wait_for_finalization: bool = True,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> bool:
         """
         Registers a neuron on the Bittensor network by recycling TAO. This method of registration involves recycling
@@ -3546,7 +3547,7 @@ class Subtensor(SubtensorMixin):
         wait_for_inclusion: bool = False,
         wait_for_finalization: bool = False,
         max_retries: int = 5,
-        period: Optional[int] = 16,
+        period: Optional[int] = DEFAULT_PERIOD,
         mechid: int = 0,
     ) -> tuple[bool, str]:
         """
@@ -3617,7 +3618,7 @@ class Subtensor(SubtensorMixin):
         hotkey: Optional[str] = None,
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> tuple[bool, str]:
         """Modifies liquidity in liquidity position by adding or removing liquidity from it.
 
@@ -3690,7 +3691,7 @@ class Subtensor(SubtensorMixin):
         amount: Optional[Balance] = None,
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
         move_all_stake: bool = False,
     ) -> bool:
         """
@@ -3742,7 +3743,7 @@ class Subtensor(SubtensorMixin):
         num_processes: Optional[int] = None,
         update_interval: Optional[int] = None,
         log_verbose: bool = False,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> bool:
         """
         Registers a neuron on the Bittensor network using the provided wallet.
@@ -3797,7 +3798,7 @@ class Subtensor(SubtensorMixin):
         wallet: "Wallet",
         wait_for_inclusion: bool = False,
         wait_for_finalization: bool = True,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> bool:
         """
         Registers a new subnetwork on the Bittensor network.
@@ -3831,7 +3832,7 @@ class Subtensor(SubtensorMixin):
         hotkey: Optional[str] = None,
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> tuple[bool, str]:
         """Remove liquidity and credit balances back to wallet's hotkey stake.
 
@@ -3879,7 +3880,7 @@ class Subtensor(SubtensorMixin):
         wait_for_inclusion: bool = False,
         wait_for_finalization: bool = False,
         max_retries: int = 5,
-        period: Optional[int] = 16,
+        period: Optional[int] = DEFAULT_PERIOD,
         mechid: int = 0,
     ) -> tuple[bool, str]:
         """
@@ -3943,7 +3944,7 @@ class Subtensor(SubtensorMixin):
         wallet: "Wallet",
         wait_for_inclusion: bool = False,
         wait_for_finalization: bool = True,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> bool:
         """
         Register neuron by recycling some TAO.
@@ -3975,7 +3976,7 @@ class Subtensor(SubtensorMixin):
         cooldown: int,
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = True,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> tuple[bool, str]:
         """Sets the pending childkey cooldown.
 
@@ -4012,7 +4013,7 @@ class Subtensor(SubtensorMixin):
         version_key: int = 0,
         wait_for_inclusion: bool = False,
         wait_for_finalization: bool = False,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> bool:
         """
         Set weights for the root network.
@@ -4051,7 +4052,7 @@ class Subtensor(SubtensorMixin):
         wallet: "Wallet",
         netuid: int,
         hotkey_ss58: str,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
         raise_error: bool = False,
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = True,
@@ -4095,7 +4096,7 @@ class Subtensor(SubtensorMixin):
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = True,
         raise_error: bool = False,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> tuple[bool, str]:
         """
         Allows a coldkey to set children-keys.
@@ -4137,7 +4138,7 @@ class Subtensor(SubtensorMixin):
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = True,
         raise_error: bool = False,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> tuple[bool, str]:
         """
         Sets the delegate 'take' percentage for a neuron identified by its hotkey.
@@ -4219,7 +4220,7 @@ class Subtensor(SubtensorMixin):
         subnet_identity: SubnetIdentity,
         wait_for_inclusion: bool = False,
         wait_for_finalization: bool = True,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> tuple[bool, str]:
         """
         Sets the identity of a subnet for a specific wallet and network.
@@ -4269,7 +4270,7 @@ class Subtensor(SubtensorMixin):
         wait_for_finalization: bool = False,
         max_retries: int = 5,
         block_time: float = 12.0,
-        period: Optional[int] = 8,
+        period: Optional[int] = DEFAULT_PERIOD,
         mechid: int = 0,
         commit_reveal_version: int = 4,
     ) -> tuple[bool, str]:
@@ -4380,7 +4381,7 @@ class Subtensor(SubtensorMixin):
         wait_for_inclusion: bool = False,
         wait_for_finalization: bool = True,
         certificate: Optional[Certificate] = None,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> bool:
         """
         Registers an ``Axon`` serving endpoint on the Bittensor network for a specific neuron. This function is used to
@@ -4420,7 +4421,7 @@ class Subtensor(SubtensorMixin):
         netuid: int,
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> tuple[bool, str]:
         """
         Submits a start_call extrinsic to the blockchain, to trigger the start call process for a subnet (used to start
@@ -4463,7 +4464,7 @@ class Subtensor(SubtensorMixin):
         safe_staking: bool = False,
         allow_partial_stake: bool = False,
         rate_tolerance: float = 0.005,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> bool:
         """
         Moves stake between subnets while keeping the same coldkey-hotkey pair ownership.
@@ -4523,7 +4524,7 @@ class Subtensor(SubtensorMixin):
         enable: bool,
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> tuple[bool, str]:
         """Allow to toggle user liquidity for specified subnet.
 
@@ -4563,7 +4564,7 @@ class Subtensor(SubtensorMixin):
         wait_for_finalization: bool = False,
         transfer_all: bool = False,
         keep_alive: bool = True,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> bool:
         """
         Transfer token of amount to destination.
@@ -4608,7 +4609,7 @@ class Subtensor(SubtensorMixin):
         amount: Balance,
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> bool:
         """
         Transfers stake from one subnet to another while changing the coldkey owner.
@@ -4654,7 +4655,7 @@ class Subtensor(SubtensorMixin):
         safe_staking: bool = False,
         allow_partial_stake: bool = False,
         rate_tolerance: float = 0.005,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
         unstake_all: bool = False,
     ) -> bool:
         """
@@ -4711,7 +4712,7 @@ class Subtensor(SubtensorMixin):
         rate_tolerance: Optional[float] = 0.005,
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
     ) -> tuple[bool, str]:
         """Unstakes all TAO/Alpha associated with a hotkey from the specified subnets on the Bittensor network.
 
@@ -4794,7 +4795,7 @@ class Subtensor(SubtensorMixin):
         amounts: Optional[list[Balance]] = None,
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
-        period: Optional[int] = None,
+        period: Optional[int] = DEFAULT_PERIOD,
         unstake_all: bool = False,
     ) -> bool:
         """

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -1615,6 +1615,16 @@ class Subtensor(SubtensorMixin):
             logging.debug(f"Subnet {netuid} is not active.")
             return None
 
+        # Fetch positions
+        positions_response = self.query_map(
+            module="Swap",
+            name="Positions",
+            block=block,
+            params=[netuid, wallet.coldkeypub.ss58_address],
+        )
+        if len(positions_response.records) == 0:
+            return []
+
         block_hash = self.determine_block_hash(block)
 
         # Fetch global fees and current price
@@ -1652,13 +1662,6 @@ class Subtensor(SubtensorMixin):
         sqrt_price = fixed_to_float(sqrt_price_query[1])
         current_tick = price_to_tick(sqrt_price**2)
 
-        # Fetch positions
-        positions_response = self.query_map(
-            module="Swap",
-            name="Positions",
-            block=block,
-            params=[netuid, wallet.coldkeypub.ss58_address],
-        )
         positions_values: list[tuple[dict, int, int]] = []
         positions_storage_keys: list[StorageKey] = []
         for _, p in positions_response:

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -1648,7 +1648,7 @@ class Subtensor(SubtensorMixin):
         )
         fee_global_tao_query, fee_global_alpha_query, sqrt_price_query = (
             self.substrate.query_multi(
-                [
+                storage_keys=[
                     fee_global_tao_query_sk,
                     fee_global_alpha_query_sk,
                     sqrt_price_query_sk,

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -93,6 +93,7 @@ from bittensor.core.extrinsics.unstaking import (
 from bittensor.core.metagraph import Metagraph
 from bittensor.core.settings import (
     version_as_int,
+    DEFAULT_PERIOD,
     SS58_FORMAT,
     TYPE_REGISTRY,
 )
@@ -3291,7 +3292,13 @@ class Subtensor(SubtensorMixin):
             )
 
         signing_keypair = getattr(wallet, sign_with)
-        extrinsic_data = {"call": call, "keypair": signing_keypair}
+        extrinsic_data = {
+            "call": call,
+            "keypair": signing_keypair,
+            "era": {
+                "period": period or DEFAULT_PERIOD,
+            },
+        }
         if use_nonce:
             if nonce_key not in possible_keys:
                 raise AttributeError(
@@ -3301,8 +3308,6 @@ class Subtensor(SubtensorMixin):
                 getattr(wallet, nonce_key).ss58_address
             )
             extrinsic_data["nonce"] = next_nonce
-        if period is not None:
-            extrinsic_data["era"] = {"period": period}
 
         extrinsic = self.substrate.create_signed_extrinsic(**extrinsic_data)
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bittensor"
-version = "9.12.1"
+version = "9.12.2"
 description = "Bittensor"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
     {name = "bittensor.com"}
 ]
 license = { file = "LICENSE" }
-requires-python = ">=3.9,<3.14"
+requires-python = ">=3.9,<3.15"
 dependencies = [
     "wheel",
     "setuptools~=70.0.0",

--- a/tests/e2e_tests/test_liquidity.py
+++ b/tests/e2e_tests/test_liquidity.py
@@ -5,8 +5,7 @@ from tests.e2e_tests.utils.e2e_test_utils import wait_to_start_call
 from bittensor.utils.liquidity import LiquidityPosition
 
 
-@pytest.mark.asyncio
-async def test_liquidity(local_chain, subtensor, alice_wallet, bob_wallet):
+def test_liquidity(subtensor, alice_wallet, bob_wallet):
     """
     Tests the liquidity mechanism
 

--- a/tests/e2e_tests/test_metagraph.py
+++ b/tests/e2e_tests/test_metagraph.py
@@ -304,8 +304,8 @@ def test_metagraph_info(subtensor, alice_wallet, bob_wallet):
             symbol="Τ",
             identity=None,
             network_registered_at=0,
-            owner_hotkey="5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM",
-            owner_coldkey="5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM",
+            owner_hotkey="5Dt9sidKJJxfvznECukm6ptHMWP7AykqkooeZijhDfBQFDqe",  # //Alice_hk
+            owner_coldkey="5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",  # //Alice
             block=1,
             tempo=100,
             last_step=0,

--- a/tests/e2e_tests/test_subtensor_functions.py
+++ b/tests/e2e_tests/test_subtensor_functions.py
@@ -65,25 +65,13 @@ async def test_subtensor_extrinsics(subtensor, templates, alice_wallet, bob_wall
     pre_subnet_creation_cost = subtensor.get_subnet_burn_cost()
 
     # Register subnet
-    assert subtensor.register_subnet(alice_wallet, True, True), (
+    assert subtensor.register_subnet(alice_wallet, True, True, None), (
         "Unable to register the subnet"
     )
-
-    # TODO: in SDKv10 replace this logic with using `ExtrinsicResponse.extrinsic_fee`
-    call = subtensor.substrate.compose_call(
-        call_module="SubtensorModule",
-        call_function="register_network",
-        call_params={
-            "hotkey": alice_wallet.hotkey.ss58_address,
-            "mechid": 1,
-        },
-    )
-    register_fee = get_extrinsic_fee(call, alice_wallet.hotkey, subtensor)
 
     # Subnet burn cost is increased immediately after a subnet is registered
     post_subnet_creation_cost = subtensor.get_subnet_burn_cost()
 
-    # TODO: in SDKv10 replace this logic with using `ExtrinsicResponse.extrinsic_fee`
     call = subtensor.substrate.compose_call(
         call_module="SubtensorModule",
         call_function="register_network",
@@ -158,7 +146,7 @@ async def test_subtensor_extrinsics(subtensor, templates, alice_wallet, bob_wall
     assert wait_to_start_call(subtensor, alice_wallet, netuid)
 
     # Register Bob to the subnet
-    assert subtensor.burned_register(bob_wallet, netuid), (
+    assert subtensor.burned_register(bob_wallet, netuid, period=None), (
         "Unable to register Bob as a neuron"
     )
 

--- a/tests/e2e_tests/test_transfer.py
+++ b/tests/e2e_tests/test_transfer.py
@@ -43,8 +43,9 @@ def test_transfer(subtensor: "SubtensorApi", alice_wallet):
         wallet=alice_wallet,
         dest=dest_coldkey,
         amount=transfer_value,
+        period=None,
         wait_for_finalization=True,
-        wait_for_inclusion=True,
+        wait_for_inclusion=False,
     )
     # Account details after transfer
     balance_after = subtensor.get_balance(alice_wallet.coldkeypub.ss58_address)

--- a/tests/helpers/helpers.py
+++ b/tests/helpers/helpers.py
@@ -14,6 +14,7 @@ from websockets.asyncio.client import ClientConnection, ClientProtocol
 from websockets.uri import parse_uri
 
 from bittensor.core.chain_data import AxonInfo, NeuronInfo, PrometheusInfo
+from bittensor.core.subtensor import DEFAULT_PERIOD
 from bittensor.utils.balance import Balance
 from tests.helpers.integration_websocket_data import WEBSOCKET_RESPONSES
 
@@ -96,6 +97,7 @@ def assert_submit_signed_extrinsic(
     extrinsic = {
         "call": substrate.compose_call.return_value,
         "keypair": keypair,
+        "era": {"period": DEFAULT_PERIOD}
     }
 
     if era:

--- a/tests/unit_tests/extrinsics/asyncex/test_commit_reveal.py
+++ b/tests/unit_tests/extrinsics/asyncex/test_commit_reveal.py
@@ -1,6 +1,7 @@
 from bittensor.core import async_subtensor as subtensor_module
 from bittensor.core.chain_data import SubnetHyperparameters
 from bittensor.core.extrinsics.asyncex import commit_reveal as async_commit_reveal
+from bittensor.core.settings import DEFAULT_PERIOD
 import pytest
 import torch
 import numpy as np
@@ -82,7 +83,7 @@ async def test_do_commit_reveal_v3_success(mocker, subtensor, fake_wallet):
         },
     )
     mocked_create_signed_extrinsic.assert_awaited_once_with(
-        call=mocked_compose_call.return_value, keypair=fake_wallet.hotkey
+        call=mocked_compose_call.return_value, keypair=fake_wallet.hotkey, era={"period": DEFAULT_PERIOD}
     )
     mocked_submit_extrinsic.assert_awaited_once_with(
         mocked_create_signed_extrinsic.return_value,
@@ -142,7 +143,7 @@ async def test_do_commit_reveal_v3_failure_due_to_error(mocker, subtensor, fake_
         },
     )
     mocked_create_signed_extrinsic.assert_awaited_once_with(
-        call=mocked_compose_call.return_value, keypair=fake_wallet.hotkey
+        call=mocked_compose_call.return_value, keypair=fake_wallet.hotkey, era={"period": DEFAULT_PERIOD}
     )
     mocked_submit_extrinsic.assert_awaited_once_with(
         mocked_create_signed_extrinsic.return_value,

--- a/tests/unit_tests/extrinsics/asyncex/test_commit_reveal.py
+++ b/tests/unit_tests/extrinsics/asyncex/test_commit_reveal.py
@@ -83,7 +83,7 @@ async def test_do_commit_reveal_v3_success(mocker, subtensor, fake_wallet):
         },
     )
     mocked_create_signed_extrinsic.assert_awaited_once_with(
-        call=mocked_compose_call.return_value, keypair=fake_wallet.hotkey, era={"period": DEFAULT_PERIOD}
+        call=mocked_compose_call.return_value, keypair=fake_wallet.hotkey
     )
     mocked_submit_extrinsic.assert_awaited_once_with(
         mocked_create_signed_extrinsic.return_value,
@@ -143,7 +143,7 @@ async def test_do_commit_reveal_v3_failure_due_to_error(mocker, subtensor, fake_
         },
     )
     mocked_create_signed_extrinsic.assert_awaited_once_with(
-        call=mocked_compose_call.return_value, keypair=fake_wallet.hotkey, era={"period": DEFAULT_PERIOD}
+        call=mocked_compose_call.return_value, keypair=fake_wallet.hotkey
     )
     mocked_submit_extrinsic.assert_awaited_once_with(
         mocked_create_signed_extrinsic.return_value,

--- a/tests/unit_tests/extrinsics/test_commit_reveal.py
+++ b/tests/unit_tests/extrinsics/test_commit_reveal.py
@@ -5,6 +5,7 @@ import torch
 from bittensor.core import subtensor as subtensor_module
 from bittensor.core.chain_data import SubnetHyperparameters
 from bittensor.core.extrinsics import commit_reveal
+from bittensor.core.settings import DEFAULT_PERIOD
 
 
 @pytest.fixture
@@ -133,7 +134,7 @@ def test_do_commit_reveal_v3_failure_due_to_error(mocker, subtensor, fake_wallet
         },
     )
     mocked_create_signed_extrinsic.assert_called_once_with(
-        call=mocked_compose_call.return_value, keypair=fake_wallet.hotkey
+        call=mocked_compose_call.return_value, keypair=fake_wallet.hotkey, era={"period": DEFAULT_PERIOD}
     )
     mocked_submit_extrinsic.assert_called_once_with(
         mocked_create_signed_extrinsic.return_value,

--- a/tests/unit_tests/extrinsics/test_commit_reveal.py
+++ b/tests/unit_tests/extrinsics/test_commit_reveal.py
@@ -134,7 +134,7 @@ def test_do_commit_reveal_v3_failure_due_to_error(mocker, subtensor, fake_wallet
         },
     )
     mocked_create_signed_extrinsic.assert_called_once_with(
-        call=mocked_compose_call.return_value, keypair=fake_wallet.hotkey, era={"period": DEFAULT_PERIOD}
+        call=mocked_compose_call.return_value, keypair=fake_wallet.hotkey
     )
     mocked_submit_extrinsic.assert_called_once_with(
         mocked_create_signed_extrinsic.return_value,

--- a/tests/unit_tests/test_async_subtensor.py
+++ b/tests/unit_tests/test_async_subtensor.py
@@ -15,6 +15,7 @@ from bittensor.core.chain_data import (
     StakeInfo,
     SelectiveMetagraphIndex,
 )
+from bittensor.core.settings import DEFAULT_PERIOD
 from bittensor.utils import U64_MAX
 from bittensor.utils.balance import Balance
 from tests.helpers.helpers import assert_submit_signed_extrinsic
@@ -1727,7 +1728,7 @@ async def test_sign_and_send_extrinsic_success_finalization(
 
     # Asserts
     mocked_create_signed_extrinsic.assert_called_once_with(
-        call=fake_call, keypair=fake_wallet.coldkey
+        call=fake_call, keypair=fake_wallet.coldkey, era={"period": DEFAULT_PERIOD}
     )
     mocked_submit_extrinsic.assert_called_once_with(
         fake_extrinsic,
@@ -1778,7 +1779,7 @@ async def test_sign_and_send_extrinsic_error_finalization(
 
     # Asserts
     mocked_create_signed_extrinsic.assert_called_once_with(
-        call=fake_call, keypair=fake_wallet.coldkey
+        call=fake_call, keypair=fake_wallet.coldkey, era={"period": DEFAULT_PERIOD}
     )
     mocked_submit_extrinsic.assert_called_once_with(
         fake_extrinsic,
@@ -1814,7 +1815,7 @@ async def test_sign_and_send_extrinsic_success_without_inclusion_finalization(
     # Asserts
     mocked_create_signed_extrinsic.assert_awaited_once()
     mocked_create_signed_extrinsic.assert_called_once_with(
-        call=fake_call, keypair=fake_wallet.coldkey
+        call=fake_call, keypair=fake_wallet.coldkey, era={"period": DEFAULT_PERIOD}
     )
     mocked_submit_extrinsic.assert_awaited_once()
     mocked_submit_extrinsic.assert_called_once_with(

--- a/tests/unit_tests/test_async_subtensor.py
+++ b/tests/unit_tests/test_async_subtensor.py
@@ -3662,7 +3662,7 @@ async def test_get_liquidity_list_happy_path(subtensor, fake_wallet, mocker):
         ],
     ]
 
-    fake_result = mocker.AsyncMock(autospec=list)
+    fake_result = mocker.AsyncMock(records=fake_positions, autospec=list)
     fake_result.__aiter__.return_value = iter(fake_positions)
 
     mocked_query_map = mocker.AsyncMock(return_value=fake_result)
@@ -3682,8 +3682,10 @@ async def test_get_liquidity_list_happy_path(subtensor, fake_wallet, mocker):
     mocked_query_map.assert_awaited_once_with(
         module="Swap",
         name="Positions",
-        block=None,
         params=[netuid, fake_wallet.coldkeypub.ss58_address],
+        block=None,
+        block_hash=None,
+        reuse_block=False,
     )
     assert len(result) == len(fake_positions)
     assert all([isinstance(p, async_subtensor.LiquidityPosition) for p in result])

--- a/tests/unit_tests/test_async_subtensor.py
+++ b/tests/unit_tests/test_async_subtensor.py
@@ -2604,7 +2604,7 @@ async def test_transfer_success(subtensor, fake_wallet, mocker):
         wait_for_inclusion=True,
         wait_for_finalization=False,
         keep_alive=True,
-        period=None,
+        period=DEFAULT_PERIOD,
     )
     assert result == mocked_transfer_extrinsic.return_value
 
@@ -2638,7 +2638,7 @@ async def test_register_success(subtensor, fake_wallet, mocker):
         wait_for_finalization=True,
         wait_for_inclusion=False,
         wallet=fake_wallet,
-        period=None,
+        period=DEFAULT_PERIOD,
     )
     assert result == mocked_register_extrinsic.return_value
 
@@ -2676,7 +2676,7 @@ async def test_set_children(subtensor, fake_wallet, mocker):
         wait_for_finalization=True,
         wait_for_inclusion=True,
         raise_error=False,
-        period=None,
+        period=DEFAULT_PERIOD,
     )
     assert result == mocked_set_children_extrinsic.return_value
 
@@ -2803,7 +2803,7 @@ async def test_set_weights_success(subtensor, fake_wallet, mocker):
         wait_for_finalization=False,
         wait_for_inclusion=False,
         weights=fake_weights,
-        period=8,
+        period=DEFAULT_PERIOD,
         mechid=0,
     )
     mocked_weights_rate_limit.assert_called_once_with(fake_netuid)
@@ -2892,7 +2892,7 @@ async def test_root_set_weights_success(subtensor, fake_wallet, mocker):
         version_key=0,
         wait_for_finalization=True,
         wait_for_inclusion=True,
-        period=None,
+        period=DEFAULT_PERIOD,
     )
     assert result == mocked_set_root_weights_extrinsic.return_value
 
@@ -2934,7 +2934,7 @@ async def test_commit_weights_success(subtensor, fake_wallet, mocker):
         weights=fake_weights,
         wait_for_inclusion=False,
         wait_for_finalization=False,
-        period=16,
+        period=DEFAULT_PERIOD,
         mechid=0,
     )
     assert result is True
@@ -3036,7 +3036,7 @@ async def test_set_subnet_identity(mocker, subtensor, fake_wallet):
         additional=fake_subnet_identity.additional,
         wait_for_finalization=True,
         wait_for_inclusion=False,
-        period=None,
+        period=DEFAULT_PERIOD,
     )
     assert result == mocked_extrinsic.return_value
 
@@ -3142,7 +3142,7 @@ async def test_start_call(subtensor, mocker):
         netuid=netuid,
         wait_for_inclusion=True,
         wait_for_finalization=False,
-        period=None,
+        period=DEFAULT_PERIOD,
     )
     assert result == mocked_extrinsic.return_value
 
@@ -3494,7 +3494,7 @@ async def test_unstake_all(subtensor, fake_wallet, mocker):
         rate_tolerance=0.005,
         wait_for_inclusion=True,
         wait_for_finalization=False,
-        period=None,
+        period=DEFAULT_PERIOD,
     )
     assert result == fake_unstake_all_extrinsic.return_value
 
@@ -3719,7 +3719,7 @@ async def test_add_liquidity(subtensor, fake_wallet, mocker):
         hotkey=None,
         wait_for_inclusion=True,
         wait_for_finalization=False,
-        period=None,
+        period=DEFAULT_PERIOD,
     )
     assert result == mocked_extrinsic.return_value
 
@@ -3752,7 +3752,7 @@ async def test_modify_liquidity(subtensor, fake_wallet, mocker):
         hotkey=None,
         wait_for_inclusion=True,
         wait_for_finalization=False,
-        period=None,
+        period=DEFAULT_PERIOD,
     )
     assert result == mocked_extrinsic.return_value
 
@@ -3783,7 +3783,7 @@ async def test_remove_liquidity(subtensor, fake_wallet, mocker):
         hotkey=None,
         wait_for_inclusion=True,
         wait_for_finalization=False,
-        period=None,
+        period=DEFAULT_PERIOD,
     )
     assert result == mocked_extrinsic.return_value
 
@@ -3813,7 +3813,7 @@ async def test_toggle_user_liquidity(subtensor, fake_wallet, mocker):
         enable=enable,
         wait_for_inclusion=True,
         wait_for_finalization=False,
-        period=None,
+        period=DEFAULT_PERIOD,
     )
     assert result == mocked_extrinsic.return_value
 
@@ -4323,7 +4323,7 @@ async def test_set_auto_stake(subtensor, mocker):
         wallet=wallet,
         netuid=netuid,
         hotkey_ss58=hotkey,
-        period=None,
+        period=DEFAULT_PERIOD,
         raise_error=False,
         wait_for_inclusion=True,
         wait_for_finalization=True,

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -1497,7 +1497,7 @@ def test_do_serve_axon_is_success(
         wait_for_inclusion=fake_wait_for_inclusion,
         wait_for_finalization=fake_wait_for_finalization,
         sign_with="hotkey",
-        period=DEFAULT_PERIOD,
+        period=None,
     )
 
     assert result[0] is True
@@ -1536,7 +1536,7 @@ def test_do_serve_axon_is_not_success(subtensor, fake_wallet, mocker, fake_call_
         wait_for_inclusion=fake_wait_for_inclusion,
         wait_for_finalization=fake_wait_for_finalization,
         sign_with="hotkey",
-        period=DEFAULT_PERIOD,
+        period=None,
     )
 
     assert result == (False, None)
@@ -1575,7 +1575,7 @@ def test_do_serve_axon_no_waits(subtensor, fake_wallet, mocker, fake_call_params
         wait_for_inclusion=fake_wait_for_inclusion,
         wait_for_finalization=fake_wait_for_finalization,
         sign_with="hotkey",
-        period=DEFAULT_PERIOD,
+        period=None,
     )
     assert result == (True, "")
 

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -3868,7 +3868,10 @@ def test_get_liquidity_list_happy_path(subtensor, fake_wallet, mocker):
             ),
         ],
     ]
-    mocked_query_map = mocker.MagicMock(return_value=fake_positions)
+    fake_result = mocker.MagicMock(records=fake_positions, autospec=list)
+    fake_result.__iter__.return_value = iter(fake_positions)
+
+    mocked_query_map = mocker.Mock(return_value=fake_result)
     mocker.patch.object(subtensor, "query_map", new=mocked_query_map)
 
     # Mock storage key creation
@@ -3913,8 +3916,8 @@ def test_get_liquidity_list_happy_path(subtensor, fake_wallet, mocker):
     mocked_query_map.assert_called_once_with(
         module="Swap",
         name="Positions",
-        block=None,
         params=[netuid, fake_wallet.coldkeypub.ss58_address],
+        block=None,
     )
     assert mock_query_multi.call_count == 2  # one for fees, one for ticks
     assert len(result) == len(fake_positions)

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -16,7 +16,7 @@ from bittensor.core.async_subtensor import AsyncSubtensor, logging
 from bittensor.core.axon import Axon
 from bittensor.core.chain_data import SubnetHyperparameters, SelectiveMetagraphIndex
 from bittensor.core.extrinsics.serving import do_serve_axon
-from bittensor.core.settings import version_as_int
+from bittensor.core.settings import version_as_int, DEFAULT_PERIOD
 from bittensor.core.subtensor import Subtensor
 from bittensor.core.types import AxonServeCallParams
 from bittensor.utils import (
@@ -1206,7 +1206,7 @@ def test_set_weights(subtensor, mocker, fake_wallet):
         version_key=settings.version_as_int,
         wait_for_inclusion=fake_wait_for_inclusion,
         wait_for_finalization=fake_wait_for_finalization,
-        period=8,
+        period=DEFAULT_PERIOD,
         mechid=0,
     )
     assert result == expected_result
@@ -1238,7 +1238,7 @@ def test_serve_axon(subtensor, mocker):
         wait_for_inclusion=fake_wait_for_inclusion,
         wait_for_finalization=fake_wait_for_finalization,
         certificate=fake_certificate,
-        period=None,
+        period=DEFAULT_PERIOD,
     )
     assert result == mocked_serve_axon_extrinsic.return_value
 
@@ -1273,7 +1273,7 @@ def test_commit(subtensor, fake_wallet, mocker):
         netuid=fake_netuid,
         data_type=f"Raw{len(fake_data)}",
         data=fake_data.encode(),
-        period=None,
+        period=DEFAULT_PERIOD,
     )
     assert result is mocked_publish_metadata.return_value
 
@@ -1331,7 +1331,7 @@ def test_transfer(subtensor, fake_wallet, mocker):
         wait_for_inclusion=fake_wait_for_inclusion,
         wait_for_finalization=fake_wait_for_finalization,
         keep_alive=True,
-        period=None,
+        period=DEFAULT_PERIOD,
     )
     assert result == mocked_transfer_extrinsic.return_value
 
@@ -1497,7 +1497,7 @@ def test_do_serve_axon_is_success(
         wait_for_inclusion=fake_wait_for_inclusion,
         wait_for_finalization=fake_wait_for_finalization,
         sign_with="hotkey",
-        period=None,
+        period=DEFAULT_PERIOD,
     )
 
     assert result[0] is True
@@ -1536,7 +1536,7 @@ def test_do_serve_axon_is_not_success(subtensor, fake_wallet, mocker, fake_call_
         wait_for_inclusion=fake_wait_for_inclusion,
         wait_for_finalization=fake_wait_for_finalization,
         sign_with="hotkey",
-        period=None,
+        period=DEFAULT_PERIOD,
     )
 
     assert result == (False, None)
@@ -1575,7 +1575,7 @@ def test_do_serve_axon_no_waits(subtensor, fake_wallet, mocker, fake_call_params
         wait_for_inclusion=fake_wait_for_inclusion,
         wait_for_finalization=fake_wait_for_finalization,
         sign_with="hotkey",
-        period=None,
+        period=DEFAULT_PERIOD,
     )
     assert result == (True, "")
 
@@ -1986,7 +1986,7 @@ def test_commit_weights(subtensor, fake_wallet, mocker):
         weights=weights,
         wait_for_inclusion=wait_for_inclusion,
         wait_for_finalization=wait_for_finalization,
-        period=16,
+        period=DEFAULT_PERIOD,
         mechid=0,
     )
     assert result == expected_result
@@ -2029,7 +2029,7 @@ def test_reveal_weights(subtensor, fake_wallet, mocker):
         salt=salt,
         wait_for_inclusion=False,
         wait_for_finalization=False,
-        period=16,
+        period=DEFAULT_PERIOD,
         mechid=0,
     )
 
@@ -2862,7 +2862,7 @@ def test_add_stake_success(mocker, fake_wallet, subtensor):
         safe_staking=False,
         allow_partial_stake=False,
         rate_tolerance=0.005,
-        period=None,
+        period=DEFAULT_PERIOD,
     )
     assert result == mock_add_stake_extrinsic.return_value
 
@@ -2902,7 +2902,7 @@ def test_add_stake_with_safe_staking(mocker, fake_wallet, subtensor):
         safe_staking=True,
         allow_partial_stake=False,
         rate_tolerance=fake_rate_tolerance,
-        period=None,
+        period=DEFAULT_PERIOD,
     )
     assert result == mock_add_stake_extrinsic.return_value
 
@@ -2936,7 +2936,7 @@ def test_add_stake_multiple_success(mocker, fake_wallet, subtensor):
         amounts=fake_amount,
         wait_for_inclusion=True,
         wait_for_finalization=False,
-        period=None,
+        period=DEFAULT_PERIOD,
     )
     assert result == mock_add_stake_multiple_extrinsic.return_value
 
@@ -2973,7 +2973,7 @@ def test_unstake_success(mocker, subtensor, fake_wallet):
         safe_staking=False,
         allow_partial_stake=False,
         rate_tolerance=0.005,
-        period=None,
+        period=DEFAULT_PERIOD,
         unstake_all=False,
     )
     assert result == mock_unstake_extrinsic.return_value
@@ -3011,7 +3011,7 @@ def test_unstake_with_safe_staking(mocker, subtensor, fake_wallet):
         safe_staking=True,
         allow_partial_stake=True,
         rate_tolerance=fake_rate_tolerance,
-        period=None,
+        period=DEFAULT_PERIOD,
         unstake_all=False,
     )
     assert result == mock_unstake_extrinsic.return_value
@@ -3056,7 +3056,7 @@ def test_swap_stake_success(mocker, subtensor, fake_wallet):
         safe_staking=False,
         allow_partial_stake=False,
         rate_tolerance=0.005,
-        period=None,
+        period=DEFAULT_PERIOD,
     )
     assert result == mock_swap_stake_extrinsic.return_value
 
@@ -3101,7 +3101,7 @@ def test_swap_stake_with_safe_staking(mocker, subtensor, fake_wallet):
         safe_staking=True,
         allow_partial_stake=True,
         rate_tolerance=fake_rate_tolerance,
-        period=None,
+        period=DEFAULT_PERIOD,
     )
     assert result == mock_swap_stake_extrinsic.return_value
 
@@ -3135,7 +3135,7 @@ def test_unstake_multiple_success(mocker, subtensor, fake_wallet):
         amounts=fake_amounts,
         wait_for_inclusion=True,
         wait_for_finalization=False,
-        period=None,
+        period=DEFAULT_PERIOD,
         unstake_all=False,
     )
     assert result == mock_unstake_multiple_extrinsic.return_value
@@ -3185,7 +3185,7 @@ def test_set_weights_with_commit_reveal_enabled(subtensor, fake_wallet, mocker):
         wait_for_inclusion=fake_wait_for_inclusion,
         wait_for_finalization=fake_wait_for_finalization,
         block_time=12.0,
-        period=8,
+        period=DEFAULT_PERIOD,
         commit_reveal_version=4,
         mechid=0,
     )
@@ -3246,7 +3246,7 @@ def test_set_subnet_identity(mocker, subtensor, fake_wallet):
         additional=fake_subnet_identity.additional,
         wait_for_finalization=True,
         wait_for_inclusion=False,
-        period=None,
+        period=DEFAULT_PERIOD,
     )
     assert result == mocked_extrinsic.return_value
 
@@ -3346,7 +3346,7 @@ def test_start_call(subtensor, mocker):
         netuid=netuid,
         wait_for_inclusion=True,
         wait_for_finalization=False,
-        period=None,
+        period=DEFAULT_PERIOD,
     )
     assert result == mocked_extrinsic.return_value
 
@@ -3774,7 +3774,7 @@ def test_set_children(subtensor, fake_wallet, mocker):
         wait_for_finalization=True,
         wait_for_inclusion=True,
         raise_error=False,
-        period=None,
+        period=DEFAULT_PERIOD,
     )
     assert result == mocked_set_children_extrinsic.return_value
 
@@ -3801,7 +3801,7 @@ def test_unstake_all(subtensor, fake_wallet, mocker):
         rate_tolerance=0.005,
         wait_for_inclusion=True,
         wait_for_finalization=False,
-        period=None,
+        period=DEFAULT_PERIOD,
     )
     assert result == fake_unstake_all_extrinsic.return_value
 
@@ -3950,7 +3950,7 @@ def test_add_liquidity(subtensor, fake_wallet, mocker):
         hotkey=None,
         wait_for_inclusion=True,
         wait_for_finalization=False,
-        period=None,
+        period=DEFAULT_PERIOD,
     )
     assert result == mocked_extrinsic.return_value
 
@@ -3982,7 +3982,7 @@ def test_modify_liquidity(subtensor, fake_wallet, mocker):
         hotkey=None,
         wait_for_inclusion=True,
         wait_for_finalization=False,
-        period=None,
+        period=DEFAULT_PERIOD,
     )
     assert result == mocked_extrinsic.return_value
 
@@ -4012,7 +4012,7 @@ def test_remove_liquidity(subtensor, fake_wallet, mocker):
         hotkey=None,
         wait_for_inclusion=True,
         wait_for_finalization=False,
-        period=None,
+        period=DEFAULT_PERIOD,
     )
     assert result == mocked_extrinsic.return_value
 
@@ -4041,7 +4041,7 @@ def test_toggle_user_liquidity(subtensor, fake_wallet, mocker):
         enable=enable,
         wait_for_inclusion=True,
         wait_for_finalization=False,
-        period=None,
+        period=DEFAULT_PERIOD,
     )
     assert result == mocked_extrinsic.return_value
 
@@ -4510,7 +4510,7 @@ def test_set_auto_stake(subtensor, mocker):
         wallet=wallet,
         netuid=netuid,
         hotkey_ss58=hotkey,
-        period=None,
+        period=DEFAULT_PERIOD,
         raise_error=False,
         wait_for_inclusion=True,
         wait_for_finalization=True,


### PR DESCRIPTION
## 9.12.2 /2025-10-30
* Use uv pip for e2e dependency installation by @thewhaleking in https://github.com/opentensor/bittensor/pull/3109
* Fix for `test_liquidity` by @basfroman in https://github.com/opentensor/bittensor/pull/3114
* Apply default `era.period` to all subtensor extrinsic calls by @basfroman in https://github.com/opentensor/bittensor/pull/3115
* set root owner for fast runtime time by @basfroman in https://github.com/opentensor/bittensor/pull/3118
* Allow python 3.14 by @thewhaleking in https://github.com/opentensor/bittensor/pull/3122

**Full Changelog**: https://github.com/opentensor/bittensor/compare/v9.12.1...v9.12.2