### PR TITLE
[v10] Release/v10.0.0rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 10.0.0rc3 /2025-11-05
+
+## What's Changed
+* [v10] Apply default era.period to all extrinsics by @basfroman in https://github.com/opentensor/bittensor/pull/3116
+* [V10] python3.14 by @thewhaleking in https://github.com/opentensor/bittensor/pull/3123
+* [v10] Fix py3.14 tests issue by @basfroman in https://github.com/opentensor/bittensor/pull/3124
+* [v10] `Root claim/ Airdrop` mechanism implementation by @basfroman in https://github.com/opentensor/bittensor/pull/3117
+* [v10] RootClaim fix by @basfroman in https://github.com/opentensor/bittensor/pull/3130
+* [v10] EMA InFlow support by @basfroman in https://github.com/opentensor/bittensor/pull/3131
+
+**Full Changelog**: https://github.com/opentensor/bittensor/compare/v10.0.0rc2...v10.0.0rc3
+
 ## 10.0.0rc2 /2025-10-20
 
 * [v10] Remove deprecated `bittensor.version_split` by @basfroman in https://github.com/opentensor/bittensor/pull/3100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bittensor"
-version = "10.0.0rc2"
+version = "10.0.0rc3"
 description = "Bittensor SDK"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
### 05 November, 2025

## Bittensor SDK v10.0.0rc3
`pip install bittensor==10.0.0rc3`

**Features**
- The "period" parameter has been reset to a default value of 128 blocks instead of None. All extrinsics are no longer immortal.
- SDK now supports Python 3.14.
- `Root claim/Airdrop` logic.
- `EMA InFlow` logic.

## Reporting and Feedback

If you encounter bugs or inconsistencies during testing:
- Open an issue in the [Bittensor GitHub repository](https://github.com/opentensor/bittensor/issues)
- Include as much detail as possible (SDK version, network, traceback, code snippet)
- Mark the issue with **`SDKv10`** label for tracking.

We also welcome improvement proposals and feature requests related to SDK usability or developer experience. 
SDKv10 related channel in CoR:  https://discord.com/channels/1120750674595024897/1427734865524297779

Pypi: https://pypi.org/project/bittensor/10.0.0rc3/
Hash: `1933f3eab6a395d4d76449436e02cabcc1289c2a65fddfc3281653586ef212e6`
GH: https://github.com/opentensor/bittensor/releases/tag/v10.0.0rc3