### PR TITLE
[v10] Improve btlogging

### DIFF
--- a/bittensor/core/settings.py
+++ b/bittensor/core/settings.py
@@ -108,11 +108,17 @@ DEFAULTS = munchify(
             "max_workers": int(_BT_AXON_MAX_WORKERS) if _BT_AXON_MAX_WORKERS else 10,
         },
         "logging": {
-            "debug": os.getenv("BT_LOGGING_DEBUG") or False,
-            "trace": os.getenv("BT_LOGGING_TRACE") or False,
-            "info": os.getenv("BT_LOGGING_INFO") or False,
-            "record_log": os.getenv("BT_LOGGING_RECORD_LOG") or False,
-            "logging_dir": os.getenv("BT_LOGGING_LOGGING_DIR") or str(MINERS_DIR),
+            "debug": bool(os.getenv("BT_LOGGING_DEBUG")) or False,
+            "trace": bool(os.getenv("BT_LOGGING_TRACE")) or False,
+            "info": bool(os.getenv("BT_LOGGING_INFO")) or False,
+            "record_log": bool(os.getenv("BT_LOGGING_RECORD_LOG")) or False,
+            "logging_dir": None
+            if READ_ONLY
+            else os.getenv("BT_LOGGING_LOGGING_DIR") or str(MINERS_DIR),
+            "enable_third_party_loggers": os.getenv(
+                "BT_LOGGING_ENABLE_THIRD_PARTY_LOGGERS"
+            )
+            or False,
         },
         "priority": {
             "max_workers": int(_BT_PRIORITY_MAX_WORKERS)

--- a/bittensor/extras/dev_framework/subnet.py
+++ b/bittensor/extras/dev_framework/subnet.py
@@ -311,12 +311,7 @@ class TestSubnet:
             )
         ).value
         # added 10 blocks bc 2.5 seconds is not always enough for the chain to update.
-
-        # === temporary solution while AsyncSubstrateInterface._get_block_handler is broken ===
-        # await self.s.wait_for_block(current_block + activation_block + 10)
-        block_time = 0.25 if self.s.chain.is_fast_blocks() else 12
-        time.sleep(block_time * activation_block)
-        # === temporary solution while AsyncSubstrateInterface._get_block_handler is broken ===
+        await self.s.wait_for_block(current_block + activation_block + 10)
 
         response = await self.s.subnets.start_call(
             wallet=owner_wallet,

--- a/bittensor/extras/dev_framework/subnet.py
+++ b/bittensor/extras/dev_framework/subnet.py
@@ -1,3 +1,4 @@
+import time
 from typing import Optional, Union
 from collections import namedtuple
 from async_substrate_interface.async_substrate import AsyncExtrinsicReceipt
@@ -310,7 +311,13 @@ class TestSubnet:
             )
         ).value
         # added 10 blocks bc 2.5 seconds is not always enough for the chain to update.
-        await self.s.wait_for_block(current_block + activation_block + 10)
+
+        # === temporary solution while AsyncSubstrateInterface._get_block_handler is broken ===
+        # await self.s.wait_for_block(current_block + activation_block + 10)
+        block_time = 0.25 if self.s.chain.is_fast_blocks() else 12
+        time.sleep(block_time * activation_block)
+        # === temporary solution while AsyncSubstrateInterface._get_block_handler is broken ===
+
         response = await self.s.subnets.start_call(
             wallet=owner_wallet,
             netuid=netuid or self._netuid,

--- a/bittensor/extras/dev_framework/subnet.py
+++ b/bittensor/extras/dev_framework/subnet.py
@@ -1,4 +1,3 @@
-import time
 from typing import Optional, Union
 from collections import namedtuple
 from async_substrate_interface.async_substrate import AsyncExtrinsicReceipt

--- a/bittensor/utils/btlogging/console.py
+++ b/bittensor/utils/btlogging/console.py
@@ -16,7 +16,7 @@ Example:
 """
 
 from functools import wraps
-from typing import Callable, TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 from .helpers import all_loggers
 
@@ -45,29 +45,29 @@ class BittensorConsole:
     @_print_wrapper
     def debug(self, message: str):
         """Logs a DEBUG message to the console."""
-        self.logger.debug(message)
+        self.logger.debug(message, stacklevel=3)
 
     @_print_wrapper
     def info(self, message: str):
         """Logs a INFO message to the console."""
-        self.logger.info(message)
+        self.logger.info(message, stacklevel=3)
 
     @_print_wrapper
     def success(self, message: str):
         """Logs a SUCCESS message to the console."""
-        self.logger.success(message)
+        self.logger.success(message, stacklevel=3)
 
     @_print_wrapper
     def warning(self, message: str):
         """Logs a WARNING message to the console."""
-        self.logger.warning(message)
+        self.logger.warning(message, stacklevel=3)
 
     @_print_wrapper
     def error(self, message: str):
         """Logs a ERROR message to the console."""
-        self.logger.error(message)
+        self.logger.error(message, stacklevel=3)
 
     @_print_wrapper
     def critical(self, message: str):
         """Logs a CRITICAL message to the console."""
-        self.logger.critical(message)
+        self.logger.critical(message, stacklevel=3)

--- a/bittensor/utils/btlogging/format.py
+++ b/bittensor/utils/btlogging/format.py
@@ -142,7 +142,7 @@ class BtStreamFormatter(logging.Formatter):
         """
 
         format_orig = self._style._fmt
-        record.levelname = f"{record.levelname:^16}"
+        record.levelname = f"{record.levelname:^8}"
 
         if record.levelno not in LOG_FORMATS:
             self._style._fmt = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "uvicorn",
     "bittensor-drand>=1.0.0,<2.0.0",
     "bittensor-wallet>=4.0.0,<5.0",
-    "async-substrate-interface>=1.5.6"
+    "async-substrate-interface==1.5.9"
 ]
 
 [project.optional-dependencies]

--- a/tests/unit_tests/test_logging.py
+++ b/tests/unit_tests/test_logging.py
@@ -38,7 +38,12 @@ def mock_config(tmp_path):
     log_file_path = log_dir / DEFAULT_LOG_FILE_NAME
 
     mock_config = LoggingConfig(
-        debug=False, trace=False, info=False, record_log=True, logging_dir=str(log_dir)
+        debug=False,
+        trace=False,
+        info=False,
+        record_log=True,
+        logging_dir=str(log_dir),
+        enable_third_party_loggers=False,
     )
 
     yield mock_config, log_file_path
@@ -141,7 +146,12 @@ def test_enable_file_logging_with_new_config(tmp_path):
 
     # check no file handler is created
     config = LoggingConfig(
-        debug=False, trace=False, info=False, record_log=True, logging_dir=None
+        debug=False,
+        trace=False,
+        info=False,
+        record_log=True,
+        logging_dir=None,
+        enable_third_party_loggers=False,
     )
     lm = LoggingMachine(config)
     assert not any(
@@ -150,7 +160,12 @@ def test_enable_file_logging_with_new_config(tmp_path):
 
     # check file handler now exists
     new_config = LoggingConfig(
-        debug=False, trace=False, info=False, record_log=True, logging_dir=str(log_dir)
+        debug=False,
+        trace=False,
+        info=False,
+        record_log=True,
+        logging_dir=str(log_dir),
+        enable_third_party_loggers=False,
     )
     lm.set_config(new_config)
     assert any(isinstance(handler, stdlogging.FileHandler) for handler in lm._handlers)
@@ -263,6 +278,7 @@ def test_runtime_logging_dir_update(tmp_path):
         info=False,
         record_log=True,
         logging_dir=str(initial_log_dir),
+        enable_third_party_loggers=False,
     )
     lm = LoggingMachine(initial_config)
 
@@ -284,6 +300,7 @@ def test_runtime_logging_dir_update(tmp_path):
         info=False,
         record_log=True,
         logging_dir=str(new_log_dir),
+        enable_third_party_loggers=False,
     )
     lm.set_config(new_config)
 
@@ -312,7 +329,12 @@ def test_runtime_disable_file_logging(tmp_path):
 
     # Initialize with file logging enabled
     config = LoggingConfig(
-        debug=False, trace=False, info=False, record_log=True, logging_dir=str(log_dir)
+        debug=False,
+        trace=False,
+        info=False,
+        record_log=True,
+        logging_dir=str(log_dir),
+        enable_third_party_loggers=False,
     )
     lm = LoggingMachine(config)
 
@@ -321,7 +343,12 @@ def test_runtime_disable_file_logging(tmp_path):
 
     # Disable file logging at runtime
     new_config = LoggingConfig(
-        debug=False, trace=False, info=False, record_log=False, logging_dir=str(log_dir)
+        debug=False,
+        trace=False,
+        info=False,
+        record_log=False,
+        logging_dir=str(log_dir),
+        enable_third_party_loggers=False,
     )
     lm.set_config(new_config)
 

--- a/tests/unit_tests/test_logging.py
+++ b/tests/unit_tests/test_logging.py
@@ -234,3 +234,96 @@ def test_logger_level(logging_machine, caplog):
 
     assert "info2" in caplog.text
     assert "warn2" in caplog.text
+
+
+def test_runtime_logging_dir_update(tmp_path):
+    """
+    Test that updating logging_dir at runtime correctly redirects output to the new path.
+    This test addresses issue #3128: runtime updates to logging_dir should redirect output.
+
+    The key test is that the file handler's path is updated when logging_dir changes.
+    """
+    import os
+    from logging.handlers import RotatingFileHandler
+
+    # Create initial logging directory
+    initial_log_dir = tmp_path / "logs1"
+    initial_log_dir.mkdir()
+    initial_log_file = initial_log_dir / DEFAULT_LOG_FILE_NAME
+
+    # Create second logging directory for runtime update
+    new_log_dir = tmp_path / "logs2"
+    new_log_dir.mkdir()
+    new_log_file = new_log_dir / DEFAULT_LOG_FILE_NAME
+
+    # Initialize LoggingMachine with initial directory
+    initial_config = LoggingConfig(
+        debug=False,
+        trace=False,
+        info=False,
+        record_log=True,
+        logging_dir=str(initial_log_dir),
+    )
+    lm = LoggingMachine(initial_config)
+
+    # Verify initial file handler exists and points to initial directory
+    file_handler = None
+    for handler in lm._handlers:
+        if isinstance(handler, RotatingFileHandler):
+            file_handler = handler
+            break
+
+    assert file_handler is not None
+    initial_path = os.path.abspath(file_handler.baseFilename)
+    assert initial_path == os.path.abspath(str(initial_log_file))
+
+    # Update logging_dir at runtime
+    new_config = LoggingConfig(
+        debug=False,
+        trace=False,
+        info=False,
+        record_log=True,
+        logging_dir=str(new_log_dir),
+    )
+    lm.set_config(new_config)
+
+    # Verify file handler now points to new directory (not old one)
+    file_handler = None
+    for handler in lm._handlers:
+        if isinstance(handler, RotatingFileHandler):
+            file_handler = handler
+            break
+
+    assert file_handler is not None
+    new_path = os.path.abspath(file_handler.baseFilename)
+    assert new_path == os.path.abspath(str(new_log_file))
+    # Verify it's NOT pointing to the old path
+    assert new_path != initial_path
+
+
+def test_runtime_disable_file_logging(tmp_path):
+    """
+    Test that disabling file logging at runtime correctly removes the file handler.
+    """
+    from logging.handlers import RotatingFileHandler
+
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+
+    # Initialize with file logging enabled
+    config = LoggingConfig(
+        debug=False, trace=False, info=False, record_log=True, logging_dir=str(log_dir)
+    )
+    lm = LoggingMachine(config)
+
+    # Verify file handler exists
+    assert any(isinstance(handler, RotatingFileHandler) for handler in lm._handlers)
+
+    # Disable file logging at runtime
+    new_config = LoggingConfig(
+        debug=False, trace=False, info=False, record_log=False, logging_dir=str(log_dir)
+    )
+    lm.set_config(new_config)
+
+    # Verify file handler is removed
+    assert not any(isinstance(handler, RotatingFileHandler) for handler in lm._handlers)


### PR DESCRIPTION
- [x] fix for https://github.com/opentensor/bittensor/issues/3128
- [x] Reduce log level column width from 16 to 8
- [x] logging shows the actual calling module
- [x] extending logic regarding https://github.com/opentensor/bittensor/issues/3111 

Added logic for enabling/disabling third-party loggers. This is accomplished using the local environment variable `BT_LOGGING_ENABLE_THIRD_PARTY_LOGGERS`. @MichaelTrestman please add new local env variable to the documentation.
  
**Note:** Regardless of whether third-party loggers are enabled or disabled, the SDK logger is a primary logger and filters logging messages from third-party loggers by the SDK logging level.