### PR TITLE
[v10] Fix async extrinsic receipt coroutine reuse error 

### DIFF
--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -5284,7 +5284,7 @@ class AsyncSubtensor(SubtensorMixin):
                 wait_for_inclusion=wait_for_inclusion,
                 wait_for_finalization=wait_for_finalization,
             )
-            await extrinsic_response.async_apply_extrinsic_receipt(response)
+
             # We only wait here if we expect finalization.
             if not wait_for_finalization and not wait_for_inclusion:
                 extrinsic_response.extrinsic_fee = await self.get_extrinsic_fee(
@@ -5295,6 +5295,8 @@ class AsyncSubtensor(SubtensorMixin):
                 )
                 logging.debug(extrinsic_response.message)
                 return extrinsic_response
+
+            await extrinsic_response.async_apply_extrinsic_receipt(response)
 
             if extrinsic_response.extrinsic_receipt.is_success:
                 extrinsic_response.extrinsic_fee = Balance.from_rao(

--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -5284,7 +5284,7 @@ class AsyncSubtensor(SubtensorMixin):
                 wait_for_inclusion=wait_for_inclusion,
                 wait_for_finalization=wait_for_finalization,
             )
-            extrinsic_response.extrinsic_receipt = response
+            await extrinsic_response.async_apply_extrinsic_receipt(response)
             # We only wait here if we expect finalization.
             if not wait_for_finalization and not wait_for_inclusion:
                 extrinsic_response.extrinsic_fee = await self.get_extrinsic_fee(
@@ -5296,14 +5296,14 @@ class AsyncSubtensor(SubtensorMixin):
                 logging.debug(extrinsic_response.message)
                 return extrinsic_response
 
-            if await response.is_success:
+            if extrinsic_response.extrinsic_receipt.is_success:
                 extrinsic_response.extrinsic_fee = Balance.from_rao(
-                    await response.total_fee_amount
+                    extrinsic_response.extrinsic_receipt.total_fee_amount
                 )
                 extrinsic_response.message = "Success"
                 return extrinsic_response
 
-            response_error_message = await response.error_message
+            response_error_message = extrinsic_response.extrinsic_receipt.error_message
 
             if raise_error:
                 raise ChainError.from_error(response_error_message)

--- a/bittensor/core/extrinsics/asyncex/proxy.py
+++ b/bittensor/core/extrinsics/asyncex/proxy.py
@@ -274,7 +274,7 @@ async def create_pure_proxy_extrinsic(
             logging.debug("[green]Pure proxy created successfully.[/green]")
 
             # Extract pure proxy address from PureCreated triggered event
-            for event in await response.extrinsic_receipt.triggered_events:
+            for event in response.extrinsic_receipt.triggered_events:
                 if event.get("event_id") == "PureCreated":
                     # Event structure: PureProxyCreated { disambiguation_index, proxy_type, pure, who }
                     attributes = event.get("attributes", [])
@@ -284,10 +284,11 @@ async def create_pure_proxy_extrinsic(
                             "spawner": attributes.get("who"),
                             "proxy_type": attributes.get("proxy_type"),
                             "index": attributes.get("disambiguation_index"),
-                            "height": await subtensor.substrate.get_block_number(
+                            "height": response.extrinsic_receipt.block_number
+                            or await response.extrinsic_receipt.substrate.get_block_number(
                                 response.extrinsic_receipt.block_hash
                             ),
-                            "ext_index": await response.extrinsic_receipt.extrinsic_idx,
+                            "ext_index": response.extrinsic_receipt.extrinsic_idx,
                         }
                     break
         else:

--- a/bittensor/core/extrinsics/asyncex/proxy.py
+++ b/bittensor/core/extrinsics/asyncex/proxy.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Optional, Union
 
 from bittensor.core.chain_data.proxy import ProxyType
 from bittensor.core.extrinsics.pallets import Proxy
+from bittensor.core.extrinsics.utils import apply_pure_proxy_data
 from bittensor.core.types import ExtrinsicResponse
 from bittensor.utils.btlogging import logging
 
@@ -274,23 +275,12 @@ async def create_pure_proxy_extrinsic(
             logging.debug("[green]Pure proxy created successfully.[/green]")
 
             # Extract pure proxy address from PureCreated triggered event
-            for event in response.extrinsic_receipt.triggered_events:
-                if event.get("event_id") == "PureCreated":
-                    # Event structure: PureProxyCreated { disambiguation_index, proxy_type, pure, who }
-                    attributes = event.get("attributes", [])
-                    if attributes:
-                        response.data = {
-                            "pure_account": attributes.get("pure"),
-                            "spawner": attributes.get("who"),
-                            "proxy_type": attributes.get("proxy_type"),
-                            "index": attributes.get("disambiguation_index"),
-                            "height": response.extrinsic_receipt.block_number
-                            or await response.extrinsic_receipt.substrate.get_block_number(
-                                response.extrinsic_receipt.block_hash
-                            ),
-                            "ext_index": response.extrinsic_receipt.extrinsic_idx,
-                        }
-                    break
+            block_number = await subtensor.substrate.get_block_number(
+                response.extrinsic_receipt.block_hash
+                if response.extrinsic_receipt
+                else None
+            )
+            response = apply_pure_proxy_data(response, block_number, raise_error)
         else:
             logging.error(f"[red]{response.message}[/red]")
 

--- a/bittensor/core/extrinsics/utils.py
+++ b/bittensor/core/extrinsics/utils.py
@@ -145,3 +145,62 @@ def sudo_call_extrinsic(
 
     except Exception as error:
         return ExtrinsicResponse.from_exception(raise_error=raise_error, error=error)
+
+
+def apply_pure_proxy_data(
+    response: ExtrinsicResponse, block_number: int, raise_error: bool
+) -> ExtrinsicResponse:
+    """Apply pure proxy data to the response object.
+
+    Parameters:
+        response: The response object to update.
+        block_number: The block number of the transaction.
+        raise_error: Whether to raise an error if the data cannot be applied successfully.
+
+    Returns:
+        True if the data was applied successfully, False otherwise.
+    """
+    # Extract pure proxy address from PureCreated triggered event if wait_for_inclusion is True.
+    # Otherwise extrinsic receipt data is not available.
+    if (
+        response.extrinsic_receipt is not None
+        and hasattr(response.extrinsic_receipt, "triggered_events")
+        and response.extrinsic_receipt.triggered_events is not None
+    ):
+        for event in response.extrinsic_receipt.triggered_events:
+            if event.get("event_id") == "PureCreated":
+                # Event structure: PureProxyCreated { disambiguation_index, proxy_type, pure, who }
+                attributes = event.get("attributes", [])
+                if attributes:
+                    response.data = {
+                        "pure_account": attributes.get("pure"),
+                        "spawner": attributes.get("who"),
+                        "proxy_type": attributes.get("proxy_type"),
+                        "index": attributes.get("disambiguation_index"),
+                        "height": block_number,
+                        "ext_index": response.extrinsic_receipt.extrinsic_idx,
+                    }
+                return response
+    message = (
+        f"The ExtrinsicResponse doesn't contain pure_proxy data (`pure_account`, `spawner`, `proxy_type`, etc.) "
+        f"because the extrinsic receipt doesn't have triggered events. This typically happens when "
+        f"`wait_for_inclusion=False` or when `block_hash` is not available. To get this data, either pass "
+        f"`wait_for_inclusion=True` when calling this function, or retrieve the data manually from the blockchain "
+        f"using the extrinsic hash."
+    )
+    if response.extrinsic is not None and hasattr(response.extrinsic, "extrinsic_hash"):
+        extrinsic_hash = response.extrinsic.extrinsic_hash
+        hash_str = (
+            extrinsic_hash.hex()
+            if hasattr(extrinsic_hash, "hex")
+            else str(extrinsic_hash)
+        )
+        message += f" Extrinsic hash: `{hash_str}`"
+
+    response.success = False
+    response.message = message
+
+    if raise_error:
+        raise RuntimeError(message)
+
+    return response.with_log("warning")

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -4029,7 +4029,7 @@ class Subtensor(SubtensorMixin):
                 wait_for_inclusion=wait_for_inclusion,
                 wait_for_finalization=wait_for_finalization,
             )
-            extrinsic_response.extrinsic_receipt = response
+            extrinsic_response.apply_extrinsic_receipt(response)
             # We only wait here if we expect finalization.
             if not wait_for_finalization and not wait_for_inclusion:
                 extrinsic_response.extrinsic_fee = self.get_extrinsic_fee(

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -4029,7 +4029,7 @@ class Subtensor(SubtensorMixin):
                 wait_for_inclusion=wait_for_inclusion,
                 wait_for_finalization=wait_for_finalization,
             )
-            extrinsic_response.apply_extrinsic_receipt(response)
+
             # We only wait here if we expect finalization.
             if not wait_for_finalization and not wait_for_inclusion:
                 extrinsic_response.extrinsic_fee = self.get_extrinsic_fee(
@@ -4040,6 +4040,8 @@ class Subtensor(SubtensorMixin):
                 )
                 logging.debug(extrinsic_response.message)
                 return extrinsic_response
+
+            extrinsic_response.apply_extrinsic_receipt(response)
 
             if response.is_success:
                 extrinsic_response.extrinsic_fee = Balance.from_rao(

--- a/bittensor/core/types.py
+++ b/bittensor/core/types.py
@@ -612,11 +612,7 @@ class ExtrinsicResponse:
             block_number,
             triggered_events,
             is_success,
-        ) = (
-            await asyncio.gather(*gather_tasks)
-            if receipt.block_hash is not None
-            else (None, None, None, None, None, None, None)
-        )
+        ) = await asyncio.gather(*gather_tasks)
 
         self.extrinsic_receipt = SDKExtrinsicReceipt(
             block_hash=receipt.block_hash,

--- a/bittensor/extras/dev_framework/subnet.py
+++ b/bittensor/extras/dev_framework/subnet.py
@@ -248,7 +248,7 @@ class TestSubnet:
         )
         self._check_response(response)
         if netuid := _set_netuid_from_register_response(
-            await response.extrinsic_receipt.triggered_events
+            response.extrinsic_receipt.triggered_events
         ):
             self._netuid = netuid
         else:

--- a/bittensor/extras/dev_framework/subnet.py
+++ b/bittensor/extras/dev_framework/subnet.py
@@ -247,10 +247,11 @@ class TestSubnet:
             wait_for_finalization=wait_for_finalization or self.wait_for_finalization,
         )
         self._check_response(response)
-        if netuid := _set_netuid_from_register_response(
-            response.extrinsic_receipt.triggered_events
-        ):
-            self._netuid = netuid
+
+        if wait_for_inclusion:
+            self._netuid = _set_netuid_from_register_response(
+                response.extrinsic_receipt.triggered_events
+            )
         else:
             self._netuid = self.s.subnets.get_total_subnets() - 1
         if response.success:

--- a/tests/e2e_tests/test_proxy.py
+++ b/tests/e2e_tests/test_proxy.py
@@ -1004,12 +1004,27 @@ def test_create_and_kill_pure_proxy(subtensor, alice_wallet, bob_wallet):
     delay = 0
     index = 0
 
+    # === Tests failed Create pure proxy without wait_for*=True ===
+    response = subtensor.proxies.create_pure_proxy(
+        wallet=spawner_wallet,
+        proxy_type=proxy_type,
+        delay=delay,
+        index=index,
+        wait_for_inclusion=False,
+        wait_for_finalization=False,
+    )
+    assert not response.success
+    assert "The ExtrinsicResponse doesn't contain pure_proxy data" in response.message
+
+    subtensor.wait_for_block()
+
     # === Create pure proxy ===
     response = subtensor.proxies.create_pure_proxy(
         wallet=spawner_wallet,
         proxy_type=proxy_type,
         delay=delay,
         index=index,
+        raise_error=True,
     )
     assert response.success, response.message
 
@@ -1132,6 +1147,20 @@ async def test_create_and_kill_pure_proxy_async(
     proxy_type = ProxyType.Any
     delay = 0
     index = 0
+
+    # === Tests failed Create pure proxy without wait_for*=True ===
+    response = await async_subtensor.proxies.create_pure_proxy(
+        wallet=spawner_wallet,
+        proxy_type=proxy_type,
+        delay=delay,
+        index=index,
+        wait_for_inclusion=False,
+        wait_for_finalization=False,
+    )
+    assert not response.success
+    assert "The ExtrinsicResponse doesn't contain pure_proxy data" in response.message
+
+    await async_subtensor.wait_for_block()
 
     # === Create pure proxy ===
     response = await async_subtensor.proxies.create_pure_proxy(

--- a/tests/unit_tests/extrinsics/asyncex/test_proxy.py
+++ b/tests/unit_tests/extrinsics/asyncex/test_proxy.py
@@ -196,7 +196,7 @@ async def test_create_pure_proxy_extrinsic(subtensor, mocker):
     assert (
         response.data["spawner"] == "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
     )
-    assert response.data["height"] == mock_response.extrinsic_receipt.block_number
+    assert response.data["height"] == subtensor.substrate.get_block_number.return_value
     assert response.data["ext_index"] == 1
 
 

--- a/tests/unit_tests/extrinsics/asyncex/test_proxy.py
+++ b/tests/unit_tests/extrinsics/asyncex/test_proxy.py
@@ -147,7 +147,7 @@ async def test_create_pure_proxy_extrinsic(subtensor, mocker):
     mock_response = mocker.MagicMock(spec=ExtrinsicResponse)
     mock_response.success = True
     mock_response.extrinsic_receipt = mocker.MagicMock()
-    mock_response.extrinsic_receipt.triggered_events = mocker.AsyncMock(
+    mock_response.extrinsic_receipt.triggered_events = mocker.Mock(
         return_value=[
             {
                 "event_id": "PureCreated",
@@ -160,13 +160,9 @@ async def test_create_pure_proxy_extrinsic(subtensor, mocker):
             }
         ]
     )()
-    mock_response.extrinsic_receipt.block_hash = mocker.AsyncMock(spec=str)
-    mock_response.extrinsic_receipt.extrinsic_idx = mocker.AsyncMock(return_value=1)()
+    mock_response.extrinsic_receipt.block_hash = mocker.Mock(spec=str)
+    mock_response.extrinsic_receipt.extrinsic_idx = mocker.Mock(return_value=1)()
     mocked_sign_and_send_extrinsic.return_value = mock_response
-
-    mocked_get_block_number = mocker.patch.object(
-        subtensor.substrate, "get_block_number", new=mocker.AsyncMock()
-    )
 
     # Call
     response = await proxy.create_pure_proxy_extrinsic(
@@ -192,7 +188,6 @@ async def test_create_pure_proxy_extrinsic(subtensor, mocker):
         wait_for_inclusion=True,
         wait_for_finalization=True,
     )
-    mocked_get_block_number.assert_called_once()
     assert response == mock_response
     assert (
         response.data["pure_account"]
@@ -201,7 +196,7 @@ async def test_create_pure_proxy_extrinsic(subtensor, mocker):
     assert (
         response.data["spawner"] == "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
     )
-    assert response.data["height"] == mocked_get_block_number.return_value
+    assert response.data["height"] == mock_response.extrinsic_receipt.block_number
     assert response.data["ext_index"] == 1
 
 


### PR DESCRIPTION
### Problem
Accessing `ExtrinsicResponse.extrinsic_receipt` fields in async code could raise `RuntimeError: cannot reuse already awaited coroutine` if the same coroutines were awaited multiple times. Users experiencing this behavior now.

### Solution:
All async fields from `AsyncExtrinsicReceipt` are awaited once via `asyncio.gather` in `async_apply_extrinsic_receipt` and stored in a synchronous `SDKExtrinsicReceipt`. After that, all fields are accessed synchronously.

### Benefits:
- Users no longer hit RuntimeError when accessing `extrinsic_receipt` fields
- Consistent ExtrinsicResponse interface — extrinsic_receipt is always synchronous, whether using Subtensor or AsyncSubtensor