### PR TITLE
[v10] remove nest asyncio + loosen requirements

### DIFF
--- a/bittensor/core/settings.py
+++ b/bittensor/core/settings.py
@@ -156,19 +156,3 @@ version_as_int: int = sum(
     e * (_version_int_base**i) for i, e in enumerate(reversed(_version_info))
 )
 assert version_as_int < 2**31  # fits in int32
-
-
-def __apply_nest_asyncio():
-    """
-    Apply nest_asyncio if the environment variable NEST_ASYNCIO is set to "1" or not set.
-    If not set, warn the user that the default will change in the future.
-    """
-    nest_asyncio_env = os.getenv("NEST_ASYNCIO")
-    if nest_asyncio_env == "1":
-        # Install and apply nest asyncio to allow the async functions to run in a .ipynb
-        import nest_asyncio
-
-        nest_asyncio.apply()
-
-
-__apply_nest_asyncio()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,15 +14,14 @@ license = { file = "LICENSE" }
 requires-python = ">=3.10,<3.15"
 dependencies = [
     "wheel",
-    "setuptools~=70.0.0",
+    "setuptools~=70",
     "aiohttp~=3.9",
     "asyncstdlib~=3.13.0",
     "colorama~=0.4.6",
-    "fastapi~=0.110.1",
+    "fastapi>=0.110",
     "munch>=4.0.0",
     "numpy>=2.0.1,<3.0.0",
-    "msgpack-numpy-opentensor~=0.5.0",
-    "nest_asyncio==1.6.0",
+    "msgpack-numpy-opentensor~=0.5",
     "netaddr==1.3.0",
     "packaging",
     "python-statemachine~=2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ license = { file = "LICENSE" }
 requires-python = ">=3.10,<3.15"
 dependencies = [
     "wheel",
-    "setuptools~=70",
+    "setuptools~=70.0",
     "aiohttp~=3.9",
     "asyncstdlib~=3.13.0",
     "colorama~=0.4.6",


### PR DESCRIPTION
1. Removes nest-asyncio (deprecated for like 18 months now)
2. Loosens requirements for other requirements