### PR TITLE
Fix: run e2e single

### DIFF
--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -157,3 +157,4 @@ jobs:
       nodeid: ${{ matrix.nodeid }}
       image-name: ${{ needs.pull-docker-image.outputs.image-name }}
     secrets: inherit
+    vars: inherit


### PR DESCRIPTION
Ensures the e2e test runner inherits the vars from GH Actions vars so that the _run-e2e-single.yaml has the needed context

See failures here: https://github.com/opentensor/bittensor/actions/runs/19667665405

for PR #3155