### PR TITLE
feat: add x_handle field to SubnetIdentity

### DIFF
--- a/bittensor/core/chain_data/subnet_identity.py
+++ b/bittensor/core/chain_data/subnet_identity.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass
@@ -13,6 +14,9 @@ class SubnetIdentity:
     discord: str
     description: str
     additional: str
+    x_handle: Optional[str] = (
+        None
+    )
 
     @classmethod
     def _from_dict(cls, decoded: dict) -> "SubnetIdentity":
@@ -26,4 +30,5 @@ class SubnetIdentity:
             discord=decoded["discord"],
             description=decoded["description"],
             additional=decoded["additional"],
+            x_handle=decoded.get("x_handle"),
         )

--- a/tests/unit_tests/test_subnet_identity.py
+++ b/tests/unit_tests/test_subnet_identity.py
@@ -1,0 +1,57 @@
+import pytest
+
+from bittensor.core.chain_data.subnet_identity import SubnetIdentity
+
+
+def test_subnet_identity_x_handle_parsing():
+    # 1. Legacy Data (with NO x_handle)
+    legacy_data = {
+        "subnet_name": "Old",
+        "github_repo": "http://g",
+        "subnet_contact": "c",
+        "subnet_url": "http://u",
+        "logo_url": "http://l",
+        "discord": "http://d",
+        "description": "d",
+        "additional": "a",
+    }
+    identity = SubnetIdentity._from_dict(legacy_data)
+    assert identity.x_handle is None
+
+    # 2. New Data (with x_handle)
+    new_data = legacy_data.copy()
+    new_data["x_handle"] = "@test"
+    identity = SubnetIdentity._from_dict(new_data)
+    assert identity.x_handle == "@test"
+
+    # 3. Explicit None
+    none_data = legacy_data.copy()
+    none_data["x_handle"] = None
+    identity = SubnetIdentity._from_dict(none_data)
+    assert identity.x_handle is None
+
+    # 4. Empty string (with x_handle)
+    new_data = legacy_data.copy()
+    new_data["x_handle"] = ""
+    identity = SubnetIdentity._from_dict(new_data)
+    assert identity.x_handle == ""
+
+    # 5. Extra fields (forward Compatibility)
+    garbage_data = legacy_data.copy()
+    garbage_data["x_handle"] = "@future_proof"
+    garbage_data["y_handle"] = "ignore_me"
+    identity = SubnetIdentity._from_dict(garbage_data)
+    assert identity.x_handle == "@future_proof"
+
+    # 6. Direct Initialization (constructor test to verify x_handle defaults to None)
+    identity_manual = SubnetIdentity(
+        subnet_name="Manual",
+        github_repo=".",
+        subnet_contact=".",
+        subnet_url=".",
+        logo_url=".",
+        discord=".",
+        description=".",
+        additional=".",
+    )
+    assert identity_manual.x_handle is None


### PR DESCRIPTION
# Description
## Summary
Added an optional x_handle field to SubnetIdentity to enable subnet owners to register their X (twitter) handle on-chain.

## Changes
* Modified bittensor/core/chain_data/subnet_identity.py:
  * Added x_handle: Optional[str] = None to the dataclass
  * Updated _from_dict to extract the handle using decoded.get("x_handle").
* Added tests/unit_tests/test_subnet_identity.py:
  * Created a new unit test file to verify parsing logic.
  * Backward Compatibility
  * Used .get("x_handle") instead of direct key access.
This ensures the SDK does not crash when communicating with older nodes or subnets that have not yet set an X handle (legacy data compatibility).
### Tests include:
1. Legacy data (with NO x_handle)
2. New valid data (with x_handle)
3. Explicit None
4. Empty string (with x_handle)
5. Extra fields (forward compatibility)
6. Direct init (constructor test to verify x_handle defaults to None)