### PR TITLE
feat: add comprehensive unit tests for chain_data modules

### DIFF
--- a/tests/unit_tests/chain_data/delegate_info_lite_unit.py
+++ b/tests/unit_tests/chain_data/delegate_info_lite_unit.py
@@ -1,0 +1,255 @@
+"""Unit tests for bittensor.core.chain_data.delegate_info_lite module."""
+import pytest
+from unittest.mock import patch
+from bittensor.core.chain_data.delegate_info_lite import DelegateInfoLite
+from bittensor.utils.balance import Balance
+MOCK_HOTKEY = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+MOCK_OWNER = "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy"
+class TestDelegateInfoLiteCreation:
+    """Tests for DelegateInfoLite dataclass creation."""
+    def test_delegate_info_lite_basic_creation(self):
+        """Test creating a DelegateInfoLite instance with valid data."""
+        delegate = DelegateInfoLite(
+            delegate_ss58=MOCK_HOTKEY,
+            take=0.18,
+            nominators=100,
+            owner_ss58=MOCK_OWNER,
+            registrations=[1, 2, 3],
+            validator_permits=[1, 2],
+            return_per_1000=Balance.from_tao(0.5),
+            total_daily_return=Balance.from_tao(100.0),
+        )
+        assert delegate.delegate_ss58 == MOCK_HOTKEY
+        assert delegate.take == 0.18
+        assert delegate.nominators == 100
+        assert delegate.owner_ss58 == MOCK_OWNER
+        assert delegate.registrations == [1, 2, 3]
+        assert delegate.validator_permits == [1, 2]
+    def test_delegate_info_lite_zero_nominators(self):
+        """Test DelegateInfoLite with zero nominators."""
+        delegate = DelegateInfoLite(
+            delegate_ss58=MOCK_HOTKEY,
+            take=0.0,
+            nominators=0,
+            owner_ss58=MOCK_OWNER,
+            registrations=[],
+            validator_permits=[],
+            return_per_1000=Balance.from_rao(0),
+            total_daily_return=Balance.from_rao(0),
+        )
+        assert delegate.nominators == 0
+        assert delegate.take == 0.0
+    def test_delegate_info_lite_large_nominators(self):
+        """Test DelegateInfoLite with large number of nominators."""
+        delegate = DelegateInfoLite(
+            delegate_ss58=MOCK_HOTKEY,
+            take=0.18,
+            nominators=10000,
+            owner_ss58=MOCK_OWNER,
+            registrations=[1],
+            validator_permits=[1],
+            return_per_1000=Balance.from_tao(1.0),
+            total_daily_return=Balance.from_tao(10000.0),
+        )
+        assert delegate.nominators == 10000
+    def test_delegate_info_lite_max_take(self):
+        """Test DelegateInfoLite with maximum take value."""
+        delegate = DelegateInfoLite(
+            delegate_ss58=MOCK_HOTKEY,
+            take=1.0,
+            nominators=50,
+            owner_ss58=MOCK_OWNER,
+            registrations=[1],
+            validator_permits=[1],
+            return_per_1000=Balance.from_tao(0.1),
+            total_daily_return=Balance.from_tao(50.0),
+        )
+        assert delegate.take == 1.0
+    def test_delegate_info_lite_empty_lists(self):
+        """Test DelegateInfoLite with empty registrations and permits."""
+        delegate = DelegateInfoLite(
+            delegate_ss58=MOCK_HOTKEY,
+            take=0.1,
+            nominators=10,
+            owner_ss58=MOCK_OWNER,
+            registrations=[],
+            validator_permits=[],
+            return_per_1000=Balance.from_rao(100000000),
+            total_daily_return=Balance.from_rao(1000000000),
+        )
+        assert delegate.registrations == []
+        assert delegate.validator_permits == []
+class TestDelegateInfoLiteFromDict:
+    """Tests for DelegateInfoLite._from_dict method."""
+    @patch("bittensor.core.chain_data.delegate_info_lite.decode_account_id")
+    def test_from_dict_basic(self, mock_decode):
+        """Test _from_dict with basic valid data."""
+        mock_decode.side_effect = lambda x: x
+        decoded = {
+            "delegate_ss58": MOCK_HOTKEY,
+            "take": 11796,
+            "nominators": 100,
+            "owner_ss58": MOCK_OWNER,
+            "registrations": [1, 2],
+            "validator_permits": [1],
+            "return_per_1000": 500000000,
+            "total_daily_return": 100000000000,
+        }
+        result = DelegateInfoLite._from_dict(decoded)
+        assert result.delegate_ss58 == MOCK_HOTKEY
+        assert result.nominators == 100
+        assert result.owner_ss58 == MOCK_OWNER
+        assert result.registrations == [1, 2]
+        assert result.validator_permits == [1]
+    @patch("bittensor.core.chain_data.delegate_info_lite.decode_account_id")
+    def test_from_dict_zero_values(self, mock_decode):
+        """Test _from_dict with zero values."""
+        mock_decode.side_effect = lambda x: x
+        decoded = {
+            "delegate_ss58": MOCK_HOTKEY,
+            "take": 0,
+            "nominators": 0,
+            "owner_ss58": MOCK_OWNER,
+            "registrations": [],
+            "validator_permits": [],
+            "return_per_1000": 0,
+            "total_daily_return": 0,
+        }
+        result = DelegateInfoLite._from_dict(decoded)
+        assert result.nominators == 0
+        assert result.take == 0.0
+        assert result.return_per_1000.rao == 0
+        assert result.total_daily_return.rao == 0
+    @patch("bittensor.core.chain_data.delegate_info_lite.decode_account_id")
+    def test_from_dict_large_values(self, mock_decode):
+        """Test _from_dict with large values."""
+        mock_decode.side_effect = lambda x: x
+        decoded = {
+            "delegate_ss58": MOCK_HOTKEY,
+            "take": 65535,
+            "nominators": 1000000,
+            "owner_ss58": MOCK_OWNER,
+            "registrations": list(range(100)),
+            "validator_permits": list(range(50)),
+            "return_per_1000": 10000000000000,
+            "total_daily_return": 100000000000000,
+        }
+        result = DelegateInfoLite._from_dict(decoded)
+        assert result.nominators == 1000000
+        assert len(result.registrations) == 100
+        assert len(result.validator_permits) == 50
+    @patch("bittensor.core.chain_data.delegate_info_lite.decode_account_id")
+    def test_from_dict_take_normalization(self, mock_decode):
+        """Test that take value is properly normalized."""
+        mock_decode.side_effect = lambda x: x
+        decoded = {
+            "delegate_ss58": MOCK_HOTKEY,
+            "take": 32768,
+            "nominators": 10,
+            "owner_ss58": MOCK_OWNER,
+            "registrations": [1],
+            "validator_permits": [1],
+            "return_per_1000": 100000000,
+            "total_daily_return": 1000000000,
+        }
+        result = DelegateInfoLite._from_dict(decoded)
+        assert 0.0 <= result.take <= 1.0
+class TestDelegateInfoLiteBalance:
+    """Tests for balance-related functionality in DelegateInfoLite."""
+    def test_return_per_1000_balance_type(self):
+        """Test that return_per_1000 is a Balance object."""
+        delegate = DelegateInfoLite(
+            delegate_ss58=MOCK_HOTKEY,
+            take=0.18,
+            nominators=100,
+            owner_ss58=MOCK_OWNER,
+            registrations=[1],
+            validator_permits=[1],
+            return_per_1000=Balance.from_tao(0.5),
+            total_daily_return=Balance.from_tao(100.0),
+        )
+        assert isinstance(delegate.return_per_1000, Balance)
+        assert isinstance(delegate.total_daily_return, Balance)
+    def test_balance_from_rao(self):
+        """Test creating DelegateInfoLite with Balance from rao."""
+        delegate = DelegateInfoLite(
+            delegate_ss58=MOCK_HOTKEY,
+            take=0.1,
+            nominators=50,
+            owner_ss58=MOCK_OWNER,
+            registrations=[],
+            validator_permits=[],
+            return_per_1000=Balance.from_rao(1000000000),
+            total_daily_return=Balance.from_rao(10000000000),
+        )
+        assert delegate.return_per_1000.rao == 1000000000
+        assert delegate.total_daily_return.rao == 10000000000
+    def test_balance_tao_conversion(self):
+        """Test tao conversion in balance fields."""
+        delegate = DelegateInfoLite(
+            delegate_ss58=MOCK_HOTKEY,
+            take=0.18,
+            nominators=100,
+            owner_ss58=MOCK_OWNER,
+            registrations=[1],
+            validator_permits=[1],
+            return_per_1000=Balance.from_tao(1.5),
+            total_daily_return=Balance.from_tao(150.0),
+        )
+        assert delegate.return_per_1000.tao == 1.5
+        assert delegate.total_daily_return.tao == 150.0
+class TestDelegateInfoLiteValidation:
+    """Tests for validation scenarios in DelegateInfoLite."""
+    def test_multiple_registrations(self):
+        """Test DelegateInfoLite with multiple subnet registrations."""
+        registrations = [1, 2, 3, 5, 8, 13, 21]
+        delegate = DelegateInfoLite(
+            delegate_ss58=MOCK_HOTKEY,
+            take=0.18,
+            nominators=100,
+            owner_ss58=MOCK_OWNER,
+            registrations=registrations,
+            validator_permits=[1, 2, 3],
+            return_per_1000=Balance.from_tao(0.5),
+            total_daily_return=Balance.from_tao(100.0),
+        )
+        assert delegate.registrations == registrations
+        assert len(delegate.registrations) == 7
+    def test_validator_permits_subset_of_registrations(self):
+        """Test that validator_permits can be a subset of registrations."""
+        delegate = DelegateInfoLite(
+            delegate_ss58=MOCK_HOTKEY,
+            take=0.18,
+            nominators=100,
+            owner_ss58=MOCK_OWNER,
+            registrations=[1, 2, 3, 4, 5],
+            validator_permits=[1, 3],
+            return_per_1000=Balance.from_tao(0.5),
+            total_daily_return=Balance.from_tao(100.0),
+        )
+        assert all(p in delegate.registrations for p in delegate.validator_permits)
+    def test_delegate_info_lite_attributes_access(self):
+        """Test accessing all attributes of DelegateInfoLite."""
+        delegate = DelegateInfoLite(
+            delegate_ss58=MOCK_HOTKEY,
+            take=0.18,
+            nominators=100,
+            owner_ss58=MOCK_OWNER,
+            registrations=[1, 2],
+            validator_permits=[1],
+            return_per_1000=Balance.from_tao(0.5),
+            total_daily_return=Balance.from_tao(100.0),
+        )
+        attrs = [
+            "delegate_ss58",
+            "take",
+            "nominators",
+            "owner_ss58",
+            "registrations",
+            "validator_permits",
+            "return_per_1000",
+            "total_daily_return",
+        ]
+        for attr in attrs:
+            assert hasattr(delegate, attr)
+            assert getattr(delegate, attr) is not None

--- a/tests/unit_tests/chain_data/delegate_info_unit.py
+++ b/tests/unit_tests/chain_data/delegate_info_unit.py
@@ -1,0 +1,278 @@
+"""Unit tests for bittensor.core.chain_data.delegate_info module."""
+import pytest
+from unittest.mock import patch, MagicMock
+from bittensor.core.chain_data.delegate_info import (
+    DelegateInfoBase,
+    DelegateInfo,
+    DelegatedInfo,
+)
+from bittensor.utils.balance import Balance
+MOCK_HOTKEY = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+MOCK_COLDKEY = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+MOCK_OWNER = "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy"
+class TestDelegateInfoBase:
+    """Tests for DelegateInfoBase dataclass."""
+    def test_delegate_info_base_creation(self):
+        """Test creating a DelegateInfoBase instance with valid data."""
+        delegate = DelegateInfoBase(
+            hotkey_ss58=MOCK_HOTKEY,
+            owner_ss58=MOCK_OWNER,
+            take=0.18,
+            validator_permits=[1, 2, 3],
+            registrations=[1, 2],
+            return_per_1000=Balance.from_tao(0.5),
+            total_daily_return=Balance.from_tao(100.0),
+        )
+        assert delegate.hotkey_ss58 == MOCK_HOTKEY
+        assert delegate.owner_ss58 == MOCK_OWNER
+        assert delegate.take == 0.18
+        assert delegate.validator_permits == [1, 2, 3]
+        assert delegate.registrations == [1, 2]
+        assert delegate.return_per_1000.tao == 0.5
+        assert delegate.total_daily_return.tao == 100.0
+    def test_delegate_info_base_empty_permits(self):
+        """Test DelegateInfoBase with empty validator permits."""
+        delegate = DelegateInfoBase(
+            hotkey_ss58=MOCK_HOTKEY,
+            owner_ss58=MOCK_OWNER,
+            take=0.0,
+            validator_permits=[],
+            registrations=[],
+            return_per_1000=Balance.from_rao(0),
+            total_daily_return=Balance.from_rao(0),
+        )
+        assert delegate.validator_permits == []
+        assert delegate.registrations == []
+        assert delegate.take == 0.0
+    def test_delegate_info_base_max_take(self):
+        """Test DelegateInfoBase with maximum take value."""
+        delegate = DelegateInfoBase(
+            hotkey_ss58=MOCK_HOTKEY,
+            owner_ss58=MOCK_OWNER,
+            take=1.0,
+            validator_permits=[1],
+            registrations=[1],
+            return_per_1000=Balance.from_tao(1.0),
+            total_daily_return=Balance.from_tao(1000.0),
+        )
+        assert delegate.take == 1.0
+class TestDelegateInfo:
+    """Tests for DelegateInfo dataclass."""
+    def test_delegate_info_creation(self):
+        """Test creating a DelegateInfo instance with valid data."""
+        total_stake = {1: Balance.from_tao(100.0), 2: Balance.from_tao(200.0)}
+        nominators = {
+            MOCK_COLDKEY: {1: Balance.from_tao(50.0), 2: Balance.from_tao(100.0)},
+        }
+        delegate = DelegateInfo(
+            hotkey_ss58=MOCK_HOTKEY,
+            owner_ss58=MOCK_OWNER,
+            take=0.18,
+            validator_permits=[1, 2],
+            registrations=[1, 2],
+            return_per_1000=Balance.from_tao(0.5),
+            total_daily_return=Balance.from_tao(100.0),
+            total_stake=total_stake,
+            nominators=nominators,
+        )
+        assert delegate.hotkey_ss58 == MOCK_HOTKEY
+        assert delegate.total_stake == total_stake
+        assert delegate.nominators == nominators
+        assert len(delegate.nominators) == 1
+    def test_delegate_info_empty_nominators(self):
+        """Test DelegateInfo with no nominators."""
+        delegate = DelegateInfo(
+            hotkey_ss58=MOCK_HOTKEY,
+            owner_ss58=MOCK_OWNER,
+            take=0.18,
+            validator_permits=[],
+            registrations=[],
+            return_per_1000=Balance.from_rao(0),
+            total_daily_return=Balance.from_rao(0),
+            total_stake={},
+            nominators={},
+        )
+        assert delegate.nominators == {}
+        assert delegate.total_stake == {}
+    def test_delegate_info_multiple_nominators(self):
+        """Test DelegateInfo with multiple nominators."""
+        nominators = {
+            MOCK_COLDKEY: {1: Balance.from_tao(100.0)},
+            MOCK_OWNER: {1: Balance.from_tao(200.0)},
+            MOCK_HOTKEY: {1: Balance.from_tao(50.0)},
+        }
+        delegate = DelegateInfo(
+            hotkey_ss58=MOCK_HOTKEY,
+            owner_ss58=MOCK_OWNER,
+            take=0.1,
+            validator_permits=[1],
+            registrations=[1],
+            return_per_1000=Balance.from_tao(1.0),
+            total_daily_return=Balance.from_tao(500.0),
+            total_stake={1: Balance.from_tao(350.0)},
+            nominators=nominators,
+        )
+        assert len(delegate.nominators) == 3
+    @patch("bittensor.core.chain_data.delegate_info.decode_account_id")
+    def test_delegate_info_from_dict(self, mock_decode):
+        """Test DelegateInfo._from_dict method."""
+        mock_decode.side_effect = lambda x: x if x else ""
+        decoded = {
+            "delegate_ss58": MOCK_HOTKEY,
+            "owner_ss58": MOCK_OWNER,
+            "take": 11796,
+            "validator_permits": [1, 2],
+            "registrations": [1],
+            "return_per_1000": 500000000,
+            "total_daily_return": 100000000000,
+            "nominators": [
+                [MOCK_COLDKEY, [(1, 100000000000), (2, 200000000000)]],
+            ],
+        }
+        result = DelegateInfo._from_dict(decoded)
+        assert result is not None
+        assert result.hotkey_ss58 == MOCK_HOTKEY
+        assert result.owner_ss58 == MOCK_OWNER
+        assert len(result.nominators) == 1
+        assert 1 in result.total_stake
+        assert 2 in result.total_stake
+    @patch("bittensor.core.chain_data.delegate_info.decode_account_id")
+    def test_delegate_info_from_dict_empty_nominators(self, mock_decode):
+        """Test DelegateInfo._from_dict with empty nominators."""
+        mock_decode.side_effect = lambda x: x if x else ""
+        decoded = {
+            "delegate_ss58": MOCK_HOTKEY,
+            "owner_ss58": MOCK_OWNER,
+            "take": 0,
+            "validator_permits": [],
+            "registrations": [],
+            "return_per_1000": 0,
+            "total_daily_return": 0,
+            "nominators": [],
+        }
+        result = DelegateInfo._from_dict(decoded)
+        assert result is not None
+        assert result.nominators == {}
+        assert result.total_stake == {}
+    @patch("bittensor.core.chain_data.delegate_info.decode_account_id")
+    def test_delegate_info_from_dict_missing_optional_fields(self, mock_decode):
+        """Test DelegateInfo._from_dict with missing optional fields."""
+        mock_decode.side_effect = lambda x: x if x else ""
+        decoded = {
+            "delegate_ss58": MOCK_HOTKEY,
+            "owner_ss58": MOCK_OWNER,
+            "take": 5000,
+            "return_per_1000": 0,
+            "total_daily_return": 0,
+        }
+        result = DelegateInfo._from_dict(decoded)
+        assert result is not None
+        assert result.validator_permits == []
+        assert result.registrations == []
+class TestDelegatedInfo:
+    """Tests for DelegatedInfo dataclass."""
+    def test_delegated_info_creation(self):
+        """Test creating a DelegatedInfo instance."""
+        delegated = DelegatedInfo(
+            hotkey_ss58=MOCK_HOTKEY,
+            owner_ss58=MOCK_OWNER,
+            take=0.18,
+            validator_permits=[1, 2],
+            registrations=[1],
+            return_per_1000=Balance.from_tao(0.5),
+            total_daily_return=Balance.from_tao(100.0),
+            netuid=1,
+            stake=Balance.from_tao(500.0),
+        )
+        assert delegated.netuid == 1
+        assert delegated.stake.tao == 500.0
+        assert delegated.hotkey_ss58 == MOCK_HOTKEY
+    def test_delegated_info_zero_stake(self):
+        """Test DelegatedInfo with zero stake."""
+        delegated = DelegatedInfo(
+            hotkey_ss58=MOCK_HOTKEY,
+            owner_ss58=MOCK_OWNER,
+            take=0.0,
+            validator_permits=[],
+            registrations=[],
+            return_per_1000=Balance.from_rao(0),
+            total_daily_return=Balance.from_rao(0),
+            netuid=0,
+            stake=Balance.from_rao(0),
+        )
+        assert delegated.stake.rao == 0
+        assert delegated.netuid == 0
+    @patch("bittensor.core.chain_data.delegate_info.decode_account_id")
+    def test_delegated_info_from_dict(self, mock_decode):
+        """Test DelegatedInfo._from_dict method."""
+        mock_decode.side_effect = lambda x: x if x else ""
+        delegate_info = {
+            "delegate_ss58": MOCK_HOTKEY,
+            "owner_ss58": MOCK_OWNER,
+            "take": 11796,
+            "validator_permits": [1],
+            "registrations": [1],
+            "return_per_1000": 500000000,
+            "total_daily_return": 100000000000,
+        }
+        decoded = (delegate_info, (1, 500000000000))
+        result = DelegatedInfo._from_dict(decoded)
+        assert result is not None
+        assert result.netuid == 1
+        assert result.hotkey_ss58 == MOCK_HOTKEY
+    @patch("bittensor.core.chain_data.delegate_info.decode_account_id")
+    def test_delegated_info_from_dict_different_netuids(self, mock_decode):
+        """Test DelegatedInfo._from_dict with different netuid values."""
+        mock_decode.side_effect = lambda x: x if x else ""
+        for netuid in [0, 1, 10, 100, 255]:
+            delegate_info = {
+                "delegate_ss58": MOCK_HOTKEY,
+                "owner_ss58": MOCK_OWNER,
+                "take": 5000,
+                "validator_permits": [],
+                "registrations": [],
+                "return_per_1000": 0,
+                "total_daily_return": 0,
+            }
+            decoded = (delegate_info, (netuid, 1000000000))
+            result = DelegatedInfo._from_dict(decoded)
+            assert result.netuid == netuid
+class TestDelegateInfoIntegration:
+    """Integration tests for delegate info classes."""
+    def test_delegate_info_inheritance(self):
+        """Test that DelegateInfo inherits from DelegateInfoBase."""
+        assert issubclass(DelegateInfo, DelegateInfoBase)
+    def test_delegated_info_inheritance(self):
+        """Test that DelegatedInfo inherits from DelegateInfoBase."""
+        assert issubclass(DelegatedInfo, DelegateInfoBase)
+    def test_delegate_info_balance_operations(self):
+        """Test balance operations within DelegateInfo."""
+        stake1 = Balance.from_tao(100.0)
+        stake2 = Balance.from_tao(200.0)
+        total_stake = {1: stake1, 2: stake2}
+        delegate = DelegateInfo(
+            hotkey_ss58=MOCK_HOTKEY,
+            owner_ss58=MOCK_OWNER,
+            take=0.18,
+            validator_permits=[1, 2],
+            registrations=[1, 2],
+            return_per_1000=Balance.from_tao(0.5),
+            total_daily_return=Balance.from_tao(100.0),
+            total_stake=total_stake,
+            nominators={},
+        )
+        total = sum(delegate.total_stake.values())
+        assert total.tao == 300.0
+    def test_delegate_info_take_percentage_range(self):
+        """Test take percentage is within valid range."""
+        for take in [0.0, 0.1, 0.18, 0.5, 1.0]:
+            delegate = DelegateInfoBase(
+                hotkey_ss58=MOCK_HOTKEY,
+                owner_ss58=MOCK_OWNER,
+                take=take,
+                validator_permits=[],
+                registrations=[],
+                return_per_1000=Balance.from_rao(0),
+                total_daily_return=Balance.from_rao(0),
+            )
+            assert 0.0 <= delegate.take <= 1.0

--- a/tests/unit_tests/chain_data/neuron_info_lite_unit.py
+++ b/tests/unit_tests/chain_data/neuron_info_lite_unit.py
@@ -1,0 +1,516 @@
+"""Unit tests for bittensor.core.chain_data.neuron_info_lite module."""
+import pytest
+from unittest.mock import patch, MagicMock
+from bittensor.core.chain_data.neuron_info_lite import NeuronInfoLite
+from bittensor.core.chain_data.axon_info import AxonInfo
+from bittensor.core.chain_data.prometheus_info import PrometheusInfo
+from bittensor.utils.balance import Balance
+MOCK_HOTKEY = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+MOCK_COLDKEY = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+NULL_KEY = "000000000000000000000000000000000000000000000000"
+class TestNeuronInfoLiteCreation:
+    """Tests for NeuronInfoLite dataclass creation."""
+    def test_neuron_info_lite_basic_creation(self):
+        """Test creating a NeuronInfoLite instance with valid data."""
+        neuron = NeuronInfoLite(
+            hotkey=MOCK_HOTKEY,
+            coldkey=MOCK_COLDKEY,
+            uid=1,
+            netuid=1,
+            active=1,
+            stake=Balance.from_tao(100.0),
+            stake_dict={MOCK_COLDKEY: Balance.from_tao(100.0)},
+            total_stake=Balance.from_tao(100.0),
+            rank=0.5,
+            emission=0.001,
+            incentive=0.3,
+            consensus=0.8,
+            trust=0.9,
+            validator_trust=0.85,
+            dividends=0.1,
+            last_update=1000,
+            validator_permit=True,
+            prometheus_info=None,
+            axon_info=None,
+            pruning_score=100,
+        )
+        assert neuron.hotkey == MOCK_HOTKEY
+        assert neuron.coldkey == MOCK_COLDKEY
+        assert neuron.uid == 1
+        assert neuron.netuid == 1
+        assert neuron.stake.tao == 100.0
+        assert neuron.validator_permit is True
+        assert neuron.is_null is False
+    def test_neuron_info_lite_with_axon_info(self):
+        """Test NeuronInfoLite with AxonInfo attached."""
+        axon = AxonInfo(
+            version=1,
+            ip="192.168.1.1",
+            port=8080,
+            ip_type=4,
+            hotkey=MOCK_HOTKEY,
+            coldkey=MOCK_COLDKEY,
+        )
+        neuron = NeuronInfoLite(
+            hotkey=MOCK_HOTKEY,
+            coldkey=MOCK_COLDKEY,
+            uid=1,
+            netuid=1,
+            active=1,
+            stake=Balance.from_tao(50.0),
+            stake_dict={},
+            total_stake=Balance.from_tao(50.0),
+            rank=0.3,
+            emission=0.0005,
+            incentive=0.2,
+            consensus=0.7,
+            trust=0.8,
+            validator_trust=0.75,
+            dividends=0.05,
+            last_update=500,
+            validator_permit=False,
+            prometheus_info=None,
+            axon_info=axon,
+            pruning_score=50,
+        )
+        assert neuron.axon_info is not None
+        assert neuron.axon_info.ip == "192.168.1.1"
+    def test_neuron_info_lite_with_prometheus_info(self):
+        """Test NeuronInfoLite with PrometheusInfo attached."""
+        prometheus = PrometheusInfo(
+            block=1000,
+            version=1,
+            ip="10.0.0.1",
+            port=9090,
+            ip_type=4,
+        )
+        neuron = NeuronInfoLite(
+            hotkey=MOCK_HOTKEY,
+            coldkey=MOCK_COLDKEY,
+            uid=2,
+            netuid=1,
+            active=1,
+            stake=Balance.from_tao(200.0),
+            stake_dict={},
+            total_stake=Balance.from_tao(200.0),
+            rank=0.7,
+            emission=0.002,
+            incentive=0.4,
+            consensus=0.85,
+            trust=0.95,
+            validator_trust=0.9,
+            dividends=0.15,
+            last_update=2000,
+            validator_permit=True,
+            prometheus_info=prometheus,
+            axon_info=None,
+            pruning_score=200,
+        )
+        assert neuron.prometheus_info is not None
+        assert neuron.prometheus_info.port == 9090
+    def test_neuron_info_lite_zero_values(self):
+        """Test NeuronInfoLite with zero values."""
+        neuron = NeuronInfoLite(
+            hotkey=MOCK_HOTKEY,
+            coldkey=MOCK_COLDKEY,
+            uid=0,
+            netuid=0,
+            active=0,
+            stake=Balance.from_rao(0),
+            stake_dict={},
+            total_stake=Balance.from_rao(0),
+            rank=0.0,
+            emission=0.0,
+            incentive=0.0,
+            consensus=0.0,
+            trust=0.0,
+            validator_trust=0.0,
+            dividends=0.0,
+            last_update=0,
+            validator_permit=False,
+            prometheus_info=None,
+            axon_info=None,
+            pruning_score=0,
+        )
+        assert neuron.uid == 0
+        assert neuron.rank == 0.0
+        assert neuron.stake.rao == 0
+class TestNeuronInfoLiteNullNeuron:
+    """Tests for NeuronInfoLite.get_null_neuron method."""
+    def test_get_null_neuron(self):
+        """Test get_null_neuron returns a valid null neuron."""
+        null_neuron = NeuronInfoLite.get_null_neuron()
+        assert null_neuron.is_null is True
+        assert null_neuron.uid == 0
+        assert null_neuron.netuid == 0
+        assert null_neuron.hotkey == NULL_KEY
+        assert null_neuron.coldkey == NULL_KEY
+        assert null_neuron.stake.rao == 0
+    def test_null_neuron_all_attributes(self):
+        """Test all attributes of null neuron are properly set."""
+        null_neuron = NeuronInfoLite.get_null_neuron()
+        assert null_neuron.active == 0
+        assert null_neuron.rank == 0
+        assert null_neuron.emission == 0
+        assert null_neuron.incentive == 0
+        assert null_neuron.consensus == 0
+        assert null_neuron.trust == 0
+        assert null_neuron.validator_trust == 0
+        assert null_neuron.dividends == 0
+        assert null_neuron.last_update == 0
+        assert null_neuron.validator_permit is False
+        assert null_neuron.pruning_score == 0
+        assert null_neuron.prometheus_info is None
+        assert null_neuron.axon_info is None
+    def test_null_neuron_consistency(self):
+        """Test that multiple calls return consistent null neurons."""
+        null1 = NeuronInfoLite.get_null_neuron()
+        null2 = NeuronInfoLite.get_null_neuron()
+        assert null1.is_null == null2.is_null
+        assert null1.uid == null2.uid
+        assert null1.hotkey == null2.hotkey
+        assert null1.coldkey == null2.coldkey
+class TestNeuronInfoLiteFromDict:
+    """Tests for NeuronInfoLite._from_dict method."""
+    @patch("bittensor.core.chain_data.neuron_info_lite.decode_account_id")
+    @patch("bittensor.core.chain_data.neuron_info_lite.process_stake_data")
+    @patch("bittensor.core.chain_data.neuron_info_lite.AxonInfo.from_dict")
+    @patch("bittensor.core.chain_data.neuron_info_lite.PrometheusInfo.from_dict")
+    def test_from_dict_basic(
+        self, mock_prometheus, mock_axon, mock_stake, mock_decode
+    ):
+        """Test _from_dict with basic valid data."""
+        mock_decode.side_effect = lambda x: MOCK_HOTKEY if "hotkey" in str(x) else MOCK_COLDKEY
+        mock_stake.return_value = {MOCK_COLDKEY: Balance.from_tao(100.0)}
+        mock_axon.return_value = MagicMock()
+        mock_prometheus.return_value = MagicMock()
+        decoded = {
+            "hotkey": "hotkey_bytes",
+            "coldkey": "coldkey_bytes",
+            "uid": 1,
+            "netuid": 1,
+            "active": 1,
+            "stake": [],
+            "rank": 32768,
+            "emission": 1000000000,
+            "incentive": 16384,
+            "consensus": 49152,
+            "trust": 57344,
+            "validator_trust": 53248,
+            "dividends": 8192,
+            "last_update": 1000,
+            "validator_permit": True,
+            "pruning_score": 100,
+            "axon_info": {},
+            "prometheus_info": {},
+        }
+        result = NeuronInfoLite._from_dict(decoded)
+        assert result is not None
+        assert result.uid == 1
+        assert result.netuid == 1
+        assert result.active == 1
+        assert result.validator_permit is True
+    @patch("bittensor.core.chain_data.neuron_info_lite.decode_account_id")
+    @patch("bittensor.core.chain_data.neuron_info_lite.process_stake_data")
+    @patch("bittensor.core.chain_data.neuron_info_lite.AxonInfo.from_dict")
+    @patch("bittensor.core.chain_data.neuron_info_lite.PrometheusInfo.from_dict")
+    def test_from_dict_zero_stake(
+        self, mock_prometheus, mock_axon, mock_stake, mock_decode
+    ):
+        """Test _from_dict with zero stake."""
+        mock_decode.side_effect = lambda x: MOCK_HOTKEY
+        mock_stake.return_value = {}
+        mock_axon.return_value = None
+        mock_prometheus.return_value = None
+        decoded = {
+            "hotkey": "hotkey_bytes",
+            "coldkey": "coldkey_bytes",
+            "uid": 0,
+            "netuid": 0,
+            "active": 0,
+            "stake": [],
+            "rank": 0,
+            "emission": 0,
+            "incentive": 0,
+            "consensus": 0,
+            "trust": 0,
+            "validator_trust": 0,
+            "dividends": 0,
+            "last_update": 0,
+            "validator_permit": False,
+            "pruning_score": 0,
+            "axon_info": {},
+            "prometheus_info": {},
+        }
+        result = NeuronInfoLite._from_dict(decoded)
+        assert result is not None
+        assert result.stake.rao == 0
+        assert result.stake_dict == {}
+class TestNeuronInfoLiteStake:
+    """Tests for stake-related functionality in NeuronInfoLite."""
+    def test_stake_dict_single_coldkey(self):
+        """Test NeuronInfoLite with single coldkey in stake_dict."""
+        stake_dict = {MOCK_COLDKEY: Balance.from_tao(500.0)}
+        neuron = NeuronInfoLite(
+            hotkey=MOCK_HOTKEY,
+            coldkey=MOCK_COLDKEY,
+            uid=1,
+            netuid=1,
+            active=1,
+            stake=Balance.from_tao(500.0),
+            stake_dict=stake_dict,
+            total_stake=Balance.from_tao(500.0),
+            rank=0.5,
+            emission=0.001,
+            incentive=0.3,
+            consensus=0.8,
+            trust=0.9,
+            validator_trust=0.85,
+            dividends=0.1,
+            last_update=1000,
+            validator_permit=True,
+            prometheus_info=None,
+            axon_info=None,
+            pruning_score=100,
+        )
+        assert len(neuron.stake_dict) == 1
+        assert neuron.stake_dict[MOCK_COLDKEY].tao == 500.0
+    def test_stake_dict_multiple_coldkeys(self):
+        """Test NeuronInfoLite with multiple coldkeys in stake_dict."""
+        other_coldkey = "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy"
+        stake_dict = {
+            MOCK_COLDKEY: Balance.from_tao(300.0),
+            other_coldkey: Balance.from_tao(200.0),
+        }
+        total = Balance.from_tao(500.0)
+        neuron = NeuronInfoLite(
+            hotkey=MOCK_HOTKEY,
+            coldkey=MOCK_COLDKEY,
+            uid=1,
+            netuid=1,
+            active=1,
+            stake=total,
+            stake_dict=stake_dict,
+            total_stake=total,
+            rank=0.5,
+            emission=0.001,
+            incentive=0.3,
+            consensus=0.8,
+            trust=0.9,
+            validator_trust=0.85,
+            dividends=0.1,
+            last_update=1000,
+            validator_permit=True,
+            prometheus_info=None,
+            axon_info=None,
+            pruning_score=100,
+        )
+        assert len(neuron.stake_dict) == 2
+        total_from_dict = sum(neuron.stake_dict.values())
+        assert total_from_dict.tao == 500.0
+    def test_total_stake_equals_stake(self):
+        """Test that total_stake equals stake when properly set."""
+        stake_amount = Balance.from_tao(250.0)
+        neuron = NeuronInfoLite(
+            hotkey=MOCK_HOTKEY,
+            coldkey=MOCK_COLDKEY,
+            uid=1,
+            netuid=1,
+            active=1,
+            stake=stake_amount,
+            stake_dict={MOCK_COLDKEY: stake_amount},
+            total_stake=stake_amount,
+            rank=0.5,
+            emission=0.001,
+            incentive=0.3,
+            consensus=0.8,
+            trust=0.9,
+            validator_trust=0.85,
+            dividends=0.1,
+            last_update=1000,
+            validator_permit=True,
+            prometheus_info=None,
+            axon_info=None,
+            pruning_score=100,
+        )
+        assert neuron.stake == neuron.total_stake
+class TestNeuronInfoLiteMetrics:
+    """Tests for metric values in NeuronInfoLite."""
+    def test_normalized_metrics_range(self):
+        """Test that normalized metrics are within valid range."""
+        neuron = NeuronInfoLite(
+            hotkey=MOCK_HOTKEY,
+            coldkey=MOCK_COLDKEY,
+            uid=1,
+            netuid=1,
+            active=1,
+            stake=Balance.from_tao(100.0),
+            stake_dict={},
+            total_stake=Balance.from_tao(100.0),
+            rank=0.5,
+            emission=0.001,
+            incentive=0.3,
+            consensus=0.8,
+            trust=0.9,
+            validator_trust=0.85,
+            dividends=0.1,
+            last_update=1000,
+            validator_permit=True,
+            prometheus_info=None,
+            axon_info=None,
+            pruning_score=100,
+        )
+        assert 0.0 <= neuron.rank <= 1.0
+        assert 0.0 <= neuron.incentive <= 1.0
+        assert 0.0 <= neuron.consensus <= 1.0
+        assert 0.0 <= neuron.trust <= 1.0
+        assert 0.0 <= neuron.validator_trust <= 1.0
+        assert 0.0 <= neuron.dividends <= 1.0
+    def test_emission_value(self):
+        """Test emission value handling."""
+        neuron = NeuronInfoLite(
+            hotkey=MOCK_HOTKEY,
+            coldkey=MOCK_COLDKEY,
+            uid=1,
+            netuid=1,
+            active=1,
+            stake=Balance.from_tao(100.0),
+            stake_dict={},
+            total_stake=Balance.from_tao(100.0),
+            rank=0.5,
+            emission=0.00123456,
+            incentive=0.3,
+            consensus=0.8,
+            trust=0.9,
+            validator_trust=0.85,
+            dividends=0.1,
+            last_update=1000,
+            validator_permit=True,
+            prometheus_info=None,
+            axon_info=None,
+            pruning_score=100,
+        )
+        assert neuron.emission == 0.00123456
+    def test_last_update_timestamp(self):
+        """Test last_update timestamp handling."""
+        timestamps = [0, 1000, 100000, 1000000000]
+        for ts in timestamps:
+            neuron = NeuronInfoLite(
+                hotkey=MOCK_HOTKEY,
+                coldkey=MOCK_COLDKEY,
+                uid=1,
+                netuid=1,
+                active=1,
+                stake=Balance.from_tao(100.0),
+                stake_dict={},
+                total_stake=Balance.from_tao(100.0),
+                rank=0.5,
+                emission=0.001,
+                incentive=0.3,
+                consensus=0.8,
+                trust=0.9,
+                validator_trust=0.85,
+                dividends=0.1,
+                last_update=ts,
+                validator_permit=True,
+                prometheus_info=None,
+                axon_info=None,
+                pruning_score=100,
+            )
+            assert neuron.last_update == ts
+class TestNeuronInfoLiteComparison:
+    """Tests for comparing NeuronInfoLite instances."""
+    def test_different_uids(self):
+        """Test neurons with different UIDs."""
+        neuron1 = NeuronInfoLite(
+            hotkey=MOCK_HOTKEY,
+            coldkey=MOCK_COLDKEY,
+            uid=1,
+            netuid=1,
+            active=1,
+            stake=Balance.from_tao(100.0),
+            stake_dict={},
+            total_stake=Balance.from_tao(100.0),
+            rank=0.5,
+            emission=0.001,
+            incentive=0.3,
+            consensus=0.8,
+            trust=0.9,
+            validator_trust=0.85,
+            dividends=0.1,
+            last_update=1000,
+            validator_permit=True,
+            prometheus_info=None,
+            axon_info=None,
+            pruning_score=100,
+        )
+        neuron2 = NeuronInfoLite(
+            hotkey=MOCK_HOTKEY,
+            coldkey=MOCK_COLDKEY,
+            uid=2,
+            netuid=1,
+            active=1,
+            stake=Balance.from_tao(100.0),
+            stake_dict={},
+            total_stake=Balance.from_tao(100.0),
+            rank=0.5,
+            emission=0.001,
+            incentive=0.3,
+            consensus=0.8,
+            trust=0.9,
+            validator_trust=0.85,
+            dividends=0.1,
+            last_update=1000,
+            validator_permit=True,
+            prometheus_info=None,
+            axon_info=None,
+            pruning_score=100,
+        )
+        assert neuron1.uid != neuron2.uid
+    def test_different_netuids(self):
+        """Test neurons on different subnets."""
+        neuron1 = NeuronInfoLite(
+            hotkey=MOCK_HOTKEY,
+            coldkey=MOCK_COLDKEY,
+            uid=1,
+            netuid=1,
+            active=1,
+            stake=Balance.from_tao(100.0),
+            stake_dict={},
+            total_stake=Balance.from_tao(100.0),
+            rank=0.5,
+            emission=0.001,
+            incentive=0.3,
+            consensus=0.8,
+            trust=0.9,
+            validator_trust=0.85,
+            dividends=0.1,
+            last_update=1000,
+            validator_permit=True,
+            prometheus_info=None,
+            axon_info=None,
+            pruning_score=100,
+        )
+        neuron2 = NeuronInfoLite(
+            hotkey=MOCK_HOTKEY,
+            coldkey=MOCK_COLDKEY,
+            uid=1,
+            netuid=2,
+            active=1,
+            stake=Balance.from_tao(100.0),
+            stake_dict={},
+            total_stake=Balance.from_tao(100.0),
+            rank=0.5,
+            emission=0.001,
+            incentive=0.3,
+            consensus=0.8,
+            trust=0.9,
+            validator_trust=0.85,
+            dividends=0.1,
+            last_update=1000,
+            validator_permit=True,
+            prometheus_info=None,
+            axon_info=None,
+            pruning_score=100,
+        )
+        assert neuron1.netuid != neuron2.netuid

--- a/tests/unit_tests/chain_data/neuron_info_unit.py
+++ b/tests/unit_tests/chain_data/neuron_info_unit.py
@@ -1,0 +1,436 @@
+"""Unit tests for bittensor.core.chain_data.neuron_info module."""
+import pytest
+from unittest.mock import patch, MagicMock
+from bittensor.core.chain_data.neuron_info import NeuronInfo
+from bittensor.core.chain_data.axon_info import AxonInfo
+from bittensor.core.chain_data.prometheus_info import PrometheusInfo
+from bittensor.utils.balance import Balance
+MOCK_HOTKEY = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+MOCK_COLDKEY = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+NULL_KEY = "000000000000000000000000000000000000000000000000"
+class TestNeuronInfoCreation:
+    """Tests for NeuronInfo dataclass creation."""
+    def test_neuron_info_basic_creation(self):
+        """Test creating a NeuronInfo instance with valid data."""
+        neuron = NeuronInfo(
+            hotkey=MOCK_HOTKEY,
+            coldkey=MOCK_COLDKEY,
+            uid=1,
+            netuid=1,
+            active=1,
+            stake=Balance.from_tao(100.0),
+            stake_dict={MOCK_COLDKEY: Balance.from_tao(100.0)},
+            total_stake=Balance.from_tao(100.0),
+            rank=0.5,
+            emission=0.001,
+            incentive=0.3,
+            consensus=0.8,
+            trust=0.9,
+            validator_trust=0.85,
+            dividends=0.1,
+            last_update=1000,
+            validator_permit=True,
+            weights=[(0, 100), (1, 200)],
+            bonds=[[0, 50], [1, 75]],
+            pruning_score=100,
+        )
+        assert neuron.hotkey == MOCK_HOTKEY
+        assert neuron.coldkey == MOCK_COLDKEY
+        assert neuron.uid == 1
+        assert neuron.netuid == 1
+        assert neuron.active == 1
+        assert neuron.stake.tao == 100.0
+        assert neuron.rank == 0.5
+        assert neuron.validator_permit is True
+    def test_neuron_info_with_axon_info(self):
+        """Test NeuronInfo with AxonInfo attached."""
+        axon = AxonInfo(
+            version=1,
+            ip="192.168.1.1",
+            port=8080,
+            ip_type=4,
+            hotkey=MOCK_HOTKEY,
+            coldkey=MOCK_COLDKEY,
+        )
+        neuron = NeuronInfo(
+            hotkey=MOCK_HOTKEY,
+            coldkey=MOCK_COLDKEY,
+            uid=1,
+            netuid=1,
+            active=1,
+            stake=Balance.from_tao(50.0),
+            stake_dict={},
+            total_stake=Balance.from_tao(50.0),
+            rank=0.3,
+            emission=0.0005,
+            incentive=0.2,
+            consensus=0.7,
+            trust=0.8,
+            validator_trust=0.75,
+            dividends=0.05,
+            last_update=500,
+            validator_permit=False,
+            weights=[],
+            bonds=[],
+            pruning_score=50,
+            axon_info=axon,
+        )
+        assert neuron.axon_info is not None
+        assert neuron.axon_info.ip == "192.168.1.1"
+        assert neuron.axon_info.port == 8080
+    def test_neuron_info_with_prometheus_info(self):
+        """Test NeuronInfo with PrometheusInfo attached."""
+        prometheus = PrometheusInfo(
+            block=1000,
+            version=1,
+            ip="10.0.0.1",
+            port=9090,
+            ip_type=4,
+        )
+        neuron = NeuronInfo(
+            hotkey=MOCK_HOTKEY,
+            coldkey=MOCK_COLDKEY,
+            uid=2,
+            netuid=1,
+            active=1,
+            stake=Balance.from_tao(200.0),
+            stake_dict={},
+            total_stake=Balance.from_tao(200.0),
+            rank=0.7,
+            emission=0.002,
+            incentive=0.4,
+            consensus=0.85,
+            trust=0.95,
+            validator_trust=0.9,
+            dividends=0.15,
+            last_update=2000,
+            validator_permit=True,
+            weights=[(0, 500)],
+            bonds=[[0, 250]],
+            pruning_score=200,
+            prometheus_info=prometheus,
+        )
+        assert neuron.prometheus_info is not None
+        assert neuron.prometheus_info.port == 9090
+    def test_neuron_info_zero_values(self):
+        """Test NeuronInfo with zero values."""
+        neuron = NeuronInfo(
+            hotkey=MOCK_HOTKEY,
+            coldkey=MOCK_COLDKEY,
+            uid=0,
+            netuid=0,
+            active=0,
+            stake=Balance.from_rao(0),
+            stake_dict={},
+            total_stake=Balance.from_rao(0),
+            rank=0.0,
+            emission=0.0,
+            incentive=0.0,
+            consensus=0.0,
+            trust=0.0,
+            validator_trust=0.0,
+            dividends=0.0,
+            last_update=0,
+            validator_permit=False,
+            weights=[],
+            bonds=[],
+            pruning_score=0,
+        )
+        assert neuron.uid == 0
+        assert neuron.rank == 0.0
+        assert neuron.stake.rao == 0
+class TestNeuronInfoNullNeuron:
+    """Tests for NeuronInfo.get_null_neuron method."""
+    def test_get_null_neuron(self):
+        """Test get_null_neuron returns a valid null neuron."""
+        null_neuron = NeuronInfo.get_null_neuron()
+        assert null_neuron.is_null is True
+        assert null_neuron.uid == 0
+        assert null_neuron.netuid == 0
+        assert null_neuron.hotkey == NULL_KEY
+        assert null_neuron.coldkey == NULL_KEY
+        assert null_neuron.stake.rao == 0
+        assert null_neuron.weights == []
+        assert null_neuron.bonds == []
+    def test_null_neuron_attributes(self):
+        """Test all attributes of null neuron are properly set."""
+        null_neuron = NeuronInfo.get_null_neuron()
+        assert null_neuron.active == 0
+        assert null_neuron.rank == 0
+        assert null_neuron.emission == 0
+        assert null_neuron.incentive == 0
+        assert null_neuron.consensus == 0
+        assert null_neuron.trust == 0
+        assert null_neuron.validator_trust == 0
+        assert null_neuron.dividends == 0
+        assert null_neuron.last_update == 0
+        assert null_neuron.validator_permit is False
+        assert null_neuron.pruning_score == 0
+        assert null_neuron.prometheus_info is None
+        assert null_neuron.axon_info is None
+    def test_null_neuron_is_singleton_like(self):
+        """Test that multiple calls return equivalent null neurons."""
+        null1 = NeuronInfo.get_null_neuron()
+        null2 = NeuronInfo.get_null_neuron()
+        assert null1.is_null == null2.is_null
+        assert null1.uid == null2.uid
+        assert null1.hotkey == null2.hotkey
+class TestNeuronInfoFromWeightsBonds:
+    """Tests for NeuronInfo.from_weights_bonds_and_neuron_lite method."""
+    def test_from_weights_bonds_basic(self):
+        """Test creating NeuronInfo from NeuronInfoLite with weights and bonds."""
+        from bittensor.core.chain_data.neuron_info_lite import NeuronInfoLite
+        neuron_lite = NeuronInfoLite(
+            hotkey=MOCK_HOTKEY,
+            coldkey=MOCK_COLDKEY,
+            uid=5,
+            netuid=1,
+            active=1,
+            stake=Balance.from_tao(100.0),
+            stake_dict={MOCK_COLDKEY: Balance.from_tao(100.0)},
+            total_stake=Balance.from_tao(100.0),
+            rank=0.5,
+            emission=0.001,
+            incentive=0.3,
+            consensus=0.8,
+            trust=0.9,
+            validator_trust=0.85,
+            dividends=0.1,
+            last_update=1000,
+            validator_permit=True,
+            prometheus_info=None,
+            axon_info=None,
+            pruning_score=100,
+        )
+        weights_dict = {5: [(0, 100), (1, 200), (2, 150)]}
+        bonds_dict = {5: [(0, 50), (1, 75)]}
+        neuron = NeuronInfo.from_weights_bonds_and_neuron_lite(
+            neuron_lite, weights_dict, bonds_dict
+        )
+        assert neuron.uid == 5
+        assert neuron.weights == [(0, 100), (1, 200), (2, 150)]
+        assert neuron.bonds == [(0, 50), (1, 75)]
+        assert neuron.hotkey == MOCK_HOTKEY
+    def test_from_weights_bonds_empty_dicts(self):
+        """Test with empty weights and bonds dictionaries."""
+        from bittensor.core.chain_data.neuron_info_lite import NeuronInfoLite
+        neuron_lite = NeuronInfoLite(
+            hotkey=MOCK_HOTKEY,
+            coldkey=MOCK_COLDKEY,
+            uid=10,
+            netuid=1,
+            active=1,
+            stake=Balance.from_tao(50.0),
+            stake_dict={},
+            total_stake=Balance.from_tao(50.0),
+            rank=0.3,
+            emission=0.0005,
+            incentive=0.2,
+            consensus=0.7,
+            trust=0.8,
+            validator_trust=0.75,
+            dividends=0.05,
+            last_update=500,
+            validator_permit=False,
+            prometheus_info=None,
+            axon_info=None,
+            pruning_score=50,
+        )
+        neuron = NeuronInfo.from_weights_bonds_and_neuron_lite(
+            neuron_lite, {}, {}
+        )
+        assert neuron.weights == []
+        assert neuron.bonds == []
+    def test_from_weights_bonds_uid_not_in_dict(self):
+        """Test when neuron UID is not in weights/bonds dicts."""
+        from bittensor.core.chain_data.neuron_info_lite import NeuronInfoLite
+        neuron_lite = NeuronInfoLite(
+            hotkey=MOCK_HOTKEY,
+            coldkey=MOCK_COLDKEY,
+            uid=99,
+            netuid=1,
+            active=1,
+            stake=Balance.from_tao(25.0),
+            stake_dict={},
+            total_stake=Balance.from_tao(25.0),
+            rank=0.1,
+            emission=0.0001,
+            incentive=0.1,
+            consensus=0.5,
+            trust=0.6,
+            validator_trust=0.55,
+            dividends=0.02,
+            last_update=100,
+            validator_permit=False,
+            prometheus_info=None,
+            axon_info=None,
+            pruning_score=25,
+        )
+        weights_dict = {1: [(0, 100)], 2: [(0, 200)]}
+        bonds_dict = {1: [(0, 50)]}
+        neuron = NeuronInfo.from_weights_bonds_and_neuron_lite(
+            neuron_lite, weights_dict, bonds_dict
+        )
+        assert neuron.weights == []
+        assert neuron.bonds == []
+class TestNeuronInfoFromDict:
+    """Tests for NeuronInfo._from_dict method."""
+    @patch("bittensor.core.chain_data.neuron_info.decode_account_id")
+    @patch("bittensor.core.chain_data.neuron_info.process_stake_data")
+    @patch("bittensor.core.chain_data.neuron_info.AxonInfo.from_dict")
+    @patch("bittensor.core.chain_data.neuron_info.PrometheusInfo.from_dict")
+    def test_from_dict_basic(
+        self, mock_prometheus, mock_axon, mock_stake, mock_decode
+    ):
+        """Test _from_dict with basic valid data."""
+        mock_decode.side_effect = lambda x: MOCK_HOTKEY if "hotkey" in str(x) else MOCK_COLDKEY
+        mock_stake.return_value = {MOCK_COLDKEY: Balance.from_tao(100.0)}
+        mock_axon.return_value = MagicMock()
+        mock_prometheus.return_value = MagicMock()
+        decoded = {
+            "hotkey": "hotkey_bytes",
+            "coldkey": "coldkey_bytes",
+            "uid": 1,
+            "netuid": 1,
+            "active": 1,
+            "stake": [],
+            "rank": 32768,
+            "emission": 1000000000,
+            "incentive": 16384,
+            "consensus": 49152,
+            "trust": 57344,
+            "validator_trust": 53248,
+            "dividends": 8192,
+            "last_update": 1000,
+            "validator_permit": True,
+            "weights": [(0, 100), (1, 200)],
+            "bonds": [(0, 50), (1, 75)],
+            "pruning_score": 100,
+            "axon_info": {},
+            "prometheus_info": {},
+        }
+        result = NeuronInfo._from_dict(decoded)
+        assert result is not None
+        assert result.uid == 1
+        assert result.netuid == 1
+        assert result.active == 1
+        assert result.validator_permit is True
+class TestNeuronInfoStake:
+    """Tests for stake-related functionality in NeuronInfo."""
+    def test_stake_dict_single_coldkey(self):
+        """Test NeuronInfo with single coldkey in stake_dict."""
+        stake_dict = {MOCK_COLDKEY: Balance.from_tao(500.0)}
+        neuron = NeuronInfo(
+            hotkey=MOCK_HOTKEY,
+            coldkey=MOCK_COLDKEY,
+            uid=1,
+            netuid=1,
+            active=1,
+            stake=Balance.from_tao(500.0),
+            stake_dict=stake_dict,
+            total_stake=Balance.from_tao(500.0),
+            rank=0.5,
+            emission=0.001,
+            incentive=0.3,
+            consensus=0.8,
+            trust=0.9,
+            validator_trust=0.85,
+            dividends=0.1,
+            last_update=1000,
+            validator_permit=True,
+            weights=[],
+            bonds=[],
+            pruning_score=100,
+        )
+        assert len(neuron.stake_dict) == 1
+        assert neuron.stake_dict[MOCK_COLDKEY].tao == 500.0
+    def test_stake_dict_multiple_coldkeys(self):
+        """Test NeuronInfo with multiple coldkeys in stake_dict."""
+        other_coldkey = "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy"
+        stake_dict = {
+            MOCK_COLDKEY: Balance.from_tao(300.0),
+            other_coldkey: Balance.from_tao(200.0),
+        }
+        total = Balance.from_tao(500.0)
+        neuron = NeuronInfo(
+            hotkey=MOCK_HOTKEY,
+            coldkey=MOCK_COLDKEY,
+            uid=1,
+            netuid=1,
+            active=1,
+            stake=total,
+            stake_dict=stake_dict,
+            total_stake=total,
+            rank=0.5,
+            emission=0.001,
+            incentive=0.3,
+            consensus=0.8,
+            trust=0.9,
+            validator_trust=0.85,
+            dividends=0.1,
+            last_update=1000,
+            validator_permit=True,
+            weights=[],
+            bonds=[],
+            pruning_score=100,
+        )
+        assert len(neuron.stake_dict) == 2
+        total_from_dict = sum(neuron.stake_dict.values())
+        assert total_from_dict.tao == 500.0
+class TestNeuronInfoWeightsBonds:
+    """Tests for weights and bonds in NeuronInfo."""
+    def test_weights_format(self):
+        """Test weights are stored as list of tuples."""
+        weights = [(0, 100), (1, 200), (2, 150), (3, 50)]
+        neuron = NeuronInfo(
+            hotkey=MOCK_HOTKEY,
+            coldkey=MOCK_COLDKEY,
+            uid=1,
+            netuid=1,
+            active=1,
+            stake=Balance.from_tao(100.0),
+            stake_dict={},
+            total_stake=Balance.from_tao(100.0),
+            rank=0.5,
+            emission=0.001,
+            incentive=0.3,
+            consensus=0.8,
+            trust=0.9,
+            validator_trust=0.85,
+            dividends=0.1,
+            last_update=1000,
+            validator_permit=True,
+            weights=weights,
+            bonds=[],
+            pruning_score=100,
+        )
+        assert neuron.weights == weights
+        assert len(neuron.weights) == 4
+        assert all(isinstance(w, tuple) and len(w) == 2 for w in neuron.weights)
+    def test_bonds_format(self):
+        """Test bonds are stored as list of lists."""
+        bonds = [[0, 50], [1, 75], [2, 100]]
+        neuron = NeuronInfo(
+            hotkey=MOCK_HOTKEY,
+            coldkey=MOCK_COLDKEY,
+            uid=1,
+            netuid=1,
+            active=1,
+            stake=Balance.from_tao(100.0),
+            stake_dict={},
+            total_stake=Balance.from_tao(100.0),
+            rank=0.5,
+            emission=0.001,
+            incentive=0.3,
+            consensus=0.8,
+            trust=0.9,
+            validator_trust=0.85,
+            dividends=0.1,
+            last_update=1000,
+            validator_permit=True,
+            weights=[],
+            bonds=bonds,
+            pruning_score=100,
+        )
+        assert neuron.bonds == bonds
+        assert len(neuron.bonds) == 3

--- a/tests/unit_tests/chain_data/stake_info_unit.py
+++ b/tests/unit_tests/chain_data/stake_info_unit.py
@@ -1,0 +1,369 @@
+"""Unit tests for bittensor.core.chain_data.stake_info module."""
+import pytest
+from unittest.mock import patch
+from bittensor.core.chain_data.stake_info import StakeInfo
+from bittensor.utils.balance import Balance
+MOCK_HOTKEY = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+MOCK_COLDKEY = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+class TestStakeInfoCreation:
+    """Tests for StakeInfo dataclass creation."""
+    def test_stake_info_basic_creation(self):
+        """Test creating a StakeInfo instance with valid data."""
+        stake_info = StakeInfo(
+            hotkey_ss58=MOCK_HOTKEY,
+            coldkey_ss58=MOCK_COLDKEY,
+            netuid=1,
+            stake=Balance.from_tao(100.0),
+            locked=Balance.from_tao(10.0),
+            emission=Balance.from_tao(0.5),
+            drain=0,
+            is_registered=True,
+        )
+        assert stake_info.hotkey_ss58 == MOCK_HOTKEY
+        assert stake_info.coldkey_ss58 == MOCK_COLDKEY
+        assert stake_info.netuid == 1
+        assert stake_info.stake.tao == 100.0
+        assert stake_info.locked.tao == 10.0
+        assert stake_info.emission.tao == 0.5
+        assert stake_info.drain == 0
+        assert stake_info.is_registered is True
+    def test_stake_info_zero_stake(self):
+        """Test StakeInfo with zero stake."""
+        stake_info = StakeInfo(
+            hotkey_ss58=MOCK_HOTKEY,
+            coldkey_ss58=MOCK_COLDKEY,
+            netuid=1,
+            stake=Balance.from_rao(0),
+            locked=Balance.from_rao(0),
+            emission=Balance.from_rao(0),
+            drain=0,
+            is_registered=False,
+        )
+        assert stake_info.stake.rao == 0
+        assert stake_info.locked.rao == 0
+        assert stake_info.emission.rao == 0
+        assert stake_info.is_registered is False
+    def test_stake_info_large_stake(self):
+        """Test StakeInfo with large stake values."""
+        stake_info = StakeInfo(
+            hotkey_ss58=MOCK_HOTKEY,
+            coldkey_ss58=MOCK_COLDKEY,
+            netuid=1,
+            stake=Balance.from_tao(1000000.0),
+            locked=Balance.from_tao(100000.0),
+            emission=Balance.from_tao(1000.0),
+            drain=100,
+            is_registered=True,
+        )
+        assert stake_info.stake.tao == 1000000.0
+        assert stake_info.locked.tao == 100000.0
+        assert stake_info.emission.tao == 1000.0
+    def test_stake_info_different_netuids(self):
+        """Test StakeInfo with different netuid values."""
+        for netuid in [0, 1, 10, 100, 255]:
+            stake_info = StakeInfo(
+                hotkey_ss58=MOCK_HOTKEY,
+                coldkey_ss58=MOCK_COLDKEY,
+                netuid=netuid,
+                stake=Balance.from_tao(50.0),
+                locked=Balance.from_tao(5.0),
+                emission=Balance.from_tao(0.1),
+                drain=0,
+                is_registered=True,
+            )
+            assert stake_info.netuid == netuid
+    def test_stake_info_drain_values(self):
+        """Test StakeInfo with various drain values."""
+        for drain in [0, 1, 100, 1000, 10000]:
+            stake_info = StakeInfo(
+                hotkey_ss58=MOCK_HOTKEY,
+                coldkey_ss58=MOCK_COLDKEY,
+                netuid=1,
+                stake=Balance.from_tao(100.0),
+                locked=Balance.from_tao(10.0),
+                emission=Balance.from_tao(0.5),
+                drain=drain,
+                is_registered=True,
+            )
+            assert stake_info.drain == drain
+class TestStakeInfoFromDict:
+    """Tests for StakeInfo.from_dict method."""
+    @patch("bittensor.core.chain_data.stake_info.decode_account_id")
+    def test_from_dict_basic(self, mock_decode):
+        """Test from_dict with basic valid data."""
+        mock_decode.side_effect = lambda x: x
+        decoded = {
+            "hotkey": MOCK_HOTKEY,
+            "coldkey": MOCK_COLDKEY,
+            "netuid": 1,
+            "stake": 100000000000,
+            "locked": 10000000000,
+            "emission": 500000000,
+            "drain": 0,
+            "is_registered": True,
+        }
+        result = StakeInfo.from_dict(decoded)
+        assert result.hotkey_ss58 == MOCK_HOTKEY
+        assert result.coldkey_ss58 == MOCK_COLDKEY
+        assert result.netuid == 1
+        assert result.is_registered is True
+    @patch("bittensor.core.chain_data.stake_info.decode_account_id")
+    def test_from_dict_zero_values(self, mock_decode):
+        """Test from_dict with zero values."""
+        mock_decode.side_effect = lambda x: x
+        decoded = {
+            "hotkey": MOCK_HOTKEY,
+            "coldkey": MOCK_COLDKEY,
+            "netuid": 0,
+            "stake": 0,
+            "locked": 0,
+            "emission": 0,
+            "drain": 0,
+            "is_registered": False,
+        }
+        result = StakeInfo.from_dict(decoded)
+        assert result.stake.rao == 0
+        assert result.locked.rao == 0
+        assert result.emission.rao == 0
+        assert result.is_registered is False
+    @patch("bittensor.core.chain_data.stake_info.decode_account_id")
+    def test_from_dict_large_values(self, mock_decode):
+        """Test from_dict with large values."""
+        mock_decode.side_effect = lambda x: x
+        decoded = {
+            "hotkey": MOCK_HOTKEY,
+            "coldkey": MOCK_COLDKEY,
+            "netuid": 255,
+            "stake": 10000000000000000,
+            "locked": 1000000000000000,
+            "emission": 100000000000000,
+            "drain": 999999,
+            "is_registered": True,
+        }
+        result = StakeInfo.from_dict(decoded)
+        assert result.netuid == 255
+        assert result.drain == 999999
+    @patch("bittensor.core.chain_data.stake_info.decode_account_id")
+    def test_from_dict_netuid_unit_setting(self, mock_decode):
+        """Test that from_dict sets the correct unit based on netuid."""
+        mock_decode.side_effect = lambda x: x
+        for netuid in [0, 1, 5, 10]:
+            decoded = {
+                "hotkey": MOCK_HOTKEY,
+                "coldkey": MOCK_COLDKEY,
+                "netuid": netuid,
+                "stake": 1000000000,
+                "locked": 100000000,
+                "emission": 10000000,
+                "drain": 0,
+                "is_registered": True,
+            }
+            result = StakeInfo.from_dict(decoded)
+            assert result.netuid == netuid
+class TestStakeInfoBalance:
+    """Tests for balance-related functionality in StakeInfo."""
+    def test_stake_balance_type(self):
+        """Test that stake is a Balance object."""
+        stake_info = StakeInfo(
+            hotkey_ss58=MOCK_HOTKEY,
+            coldkey_ss58=MOCK_COLDKEY,
+            netuid=1,
+            stake=Balance.from_tao(100.0),
+            locked=Balance.from_tao(10.0),
+            emission=Balance.from_tao(0.5),
+            drain=0,
+            is_registered=True,
+        )
+        assert isinstance(stake_info.stake, Balance)
+        assert isinstance(stake_info.locked, Balance)
+        assert isinstance(stake_info.emission, Balance)
+    def test_balance_from_rao(self):
+        """Test creating StakeInfo with Balance from rao."""
+        stake_info = StakeInfo(
+            hotkey_ss58=MOCK_HOTKEY,
+            coldkey_ss58=MOCK_COLDKEY,
+            netuid=1,
+            stake=Balance.from_rao(1000000000),
+            locked=Balance.from_rao(100000000),
+            emission=Balance.from_rao(10000000),
+            drain=0,
+            is_registered=True,
+        )
+        assert stake_info.stake.rao == 1000000000
+        assert stake_info.locked.rao == 100000000
+        assert stake_info.emission.rao == 10000000
+    def test_balance_tao_conversion(self):
+        """Test tao conversion in balance fields."""
+        stake_info = StakeInfo(
+            hotkey_ss58=MOCK_HOTKEY,
+            coldkey_ss58=MOCK_COLDKEY,
+            netuid=1,
+            stake=Balance.from_tao(123.456),
+            locked=Balance.from_tao(12.345),
+            emission=Balance.from_tao(1.234),
+            drain=0,
+            is_registered=True,
+        )
+        assert abs(stake_info.stake.tao - 123.456) < 0.001
+        assert abs(stake_info.locked.tao - 12.345) < 0.001
+        assert abs(stake_info.emission.tao - 1.234) < 0.001
+    def test_locked_less_than_stake(self):
+        """Test that locked can be less than or equal to stake."""
+        stake_info = StakeInfo(
+            hotkey_ss58=MOCK_HOTKEY,
+            coldkey_ss58=MOCK_COLDKEY,
+            netuid=1,
+            stake=Balance.from_tao(100.0),
+            locked=Balance.from_tao(50.0),
+            emission=Balance.from_tao(0.5),
+            drain=0,
+            is_registered=True,
+        )
+        assert stake_info.locked.tao <= stake_info.stake.tao
+class TestStakeInfoRegistration:
+    """Tests for registration status in StakeInfo."""
+    def test_registered_stake_info(self):
+        """Test StakeInfo with is_registered=True."""
+        stake_info = StakeInfo(
+            hotkey_ss58=MOCK_HOTKEY,
+            coldkey_ss58=MOCK_COLDKEY,
+            netuid=1,
+            stake=Balance.from_tao(100.0),
+            locked=Balance.from_tao(10.0),
+            emission=Balance.from_tao(0.5),
+            drain=0,
+            is_registered=True,
+        )
+        assert stake_info.is_registered is True
+    def test_unregistered_stake_info(self):
+        """Test StakeInfo with is_registered=False."""
+        stake_info = StakeInfo(
+            hotkey_ss58=MOCK_HOTKEY,
+            coldkey_ss58=MOCK_COLDKEY,
+            netuid=1,
+            stake=Balance.from_tao(100.0),
+            locked=Balance.from_tao(10.0),
+            emission=Balance.from_tao(0.5),
+            drain=0,
+            is_registered=False,
+        )
+        assert stake_info.is_registered is False
+    def test_registration_with_zero_stake(self):
+        """Test that registration status is independent of stake amount."""
+        stake_info_registered = StakeInfo(
+            hotkey_ss58=MOCK_HOTKEY,
+            coldkey_ss58=MOCK_COLDKEY,
+            netuid=1,
+            stake=Balance.from_rao(0),
+            locked=Balance.from_rao(0),
+            emission=Balance.from_rao(0),
+            drain=0,
+            is_registered=True,
+        )
+        stake_info_unregistered = StakeInfo(
+            hotkey_ss58=MOCK_HOTKEY,
+            coldkey_ss58=MOCK_COLDKEY,
+            netuid=1,
+            stake=Balance.from_tao(1000.0),
+            locked=Balance.from_tao(100.0),
+            emission=Balance.from_tao(10.0),
+            drain=0,
+            is_registered=False,
+        )
+        assert stake_info_registered.is_registered is True
+        assert stake_info_unregistered.is_registered is False
+class TestStakeInfoAttributes:
+    """Tests for StakeInfo attribute access."""
+    def test_all_attributes_accessible(self):
+        """Test that all attributes are accessible."""
+        stake_info = StakeInfo(
+            hotkey_ss58=MOCK_HOTKEY,
+            coldkey_ss58=MOCK_COLDKEY,
+            netuid=1,
+            stake=Balance.from_tao(100.0),
+            locked=Balance.from_tao(10.0),
+            emission=Balance.from_tao(0.5),
+            drain=5,
+            is_registered=True,
+        )
+        attrs = [
+            "hotkey_ss58",
+            "coldkey_ss58",
+            "netuid",
+            "stake",
+            "locked",
+            "emission",
+            "drain",
+            "is_registered",
+        ]
+        for attr in attrs:
+            assert hasattr(stake_info, attr)
+            assert getattr(stake_info, attr) is not None
+    def test_hotkey_coldkey_format(self):
+        """Test that hotkey and coldkey are in SS58 format."""
+        stake_info = StakeInfo(
+            hotkey_ss58=MOCK_HOTKEY,
+            coldkey_ss58=MOCK_COLDKEY,
+            netuid=1,
+            stake=Balance.from_tao(100.0),
+            locked=Balance.from_tao(10.0),
+            emission=Balance.from_tao(0.5),
+            drain=0,
+            is_registered=True,
+        )
+        assert stake_info.hotkey_ss58.startswith("5")
+        assert stake_info.coldkey_ss58.startswith("5")
+        assert len(stake_info.hotkey_ss58) == 48
+        assert len(stake_info.coldkey_ss58) == 48
+class TestStakeInfoComparison:
+    """Tests for comparing StakeInfo instances."""
+    def test_same_hotkey_different_netuids(self):
+        """Test StakeInfo with same hotkey but different netuids."""
+        stake_info1 = StakeInfo(
+            hotkey_ss58=MOCK_HOTKEY,
+            coldkey_ss58=MOCK_COLDKEY,
+            netuid=1,
+            stake=Balance.from_tao(100.0),
+            locked=Balance.from_tao(10.0),
+            emission=Balance.from_tao(0.5),
+            drain=0,
+            is_registered=True,
+        )
+        stake_info2 = StakeInfo(
+            hotkey_ss58=MOCK_HOTKEY,
+            coldkey_ss58=MOCK_COLDKEY,
+            netuid=2,
+            stake=Balance.from_tao(200.0),
+            locked=Balance.from_tao(20.0),
+            emission=Balance.from_tao(1.0),
+            drain=0,
+            is_registered=True,
+        )
+        assert stake_info1.hotkey_ss58 == stake_info2.hotkey_ss58
+        assert stake_info1.netuid != stake_info2.netuid
+        assert stake_info1.stake.tao != stake_info2.stake.tao
+    def test_different_hotkeys_same_netuid(self):
+        """Test StakeInfo with different hotkeys on same netuid."""
+        other_hotkey = "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy"
+        stake_info1 = StakeInfo(
+            hotkey_ss58=MOCK_HOTKEY,
+            coldkey_ss58=MOCK_COLDKEY,
+            netuid=1,
+            stake=Balance.from_tao(100.0),
+            locked=Balance.from_tao(10.0),
+            emission=Balance.from_tao(0.5),
+            drain=0,
+            is_registered=True,
+        )
+        stake_info2 = StakeInfo(
+            hotkey_ss58=other_hotkey,
+            coldkey_ss58=MOCK_COLDKEY,
+            netuid=1,
+            stake=Balance.from_tao(100.0),
+            locked=Balance.from_tao(10.0),
+            emission=Balance.from_tao(0.5),
+            drain=0,
+            is_registered=True,
+        )
+        assert stake_info1.hotkey_ss58 != stake_info2.hotkey_ss58
+        assert stake_info1.netuid == stake_info2.netuid

--- a/tests/unit_tests/chain_data/subnet_info_unit.py
+++ b/tests/unit_tests/chain_data/subnet_info_unit.py
@@ -1,0 +1,277 @@
+"""Unit tests for bittensor.core.chain_data.subnet_info module."""
+import pytest
+from unittest.mock import patch
+from bittensor.core.chain_data.subnet_info import SubnetInfo
+from bittensor.utils.balance import Balance
+
+
+MOCK_OWNER = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+
+
+def create_subnet_info(**kwargs):
+    """Helper function to create SubnetInfo with default values."""
+    defaults = {
+        "netuid": 1,
+        "rho": 10,
+        "kappa": 32767,
+        "difficulty": 1000000,
+        "immunity_period": 4096,
+        "max_allowed_validators": 64,
+        "min_allowed_weights": 1,
+        "max_weight_limit": 0.5,
+        "scaling_law_power": 50.0,
+        "subnetwork_n": 256,
+        "max_n": 4096,
+        "blocks_since_epoch": 100,
+        "tempo": 360,
+        "modality": 0,
+        "connection_requirements": {},
+        "emission_value": 1.0,
+        "burn": Balance.from_tao(1.0),
+        "owner_ss58": MOCK_OWNER,
+    }
+    defaults.update(kwargs)
+    return SubnetInfo(**defaults)
+
+
+class TestSubnetInfoCreation:
+    """Tests for SubnetInfo dataclass creation."""
+
+    def test_subnet_info_basic_creation(self):
+        """Test creating a SubnetInfo instance with valid data."""
+        subnet = create_subnet_info()
+        assert subnet.netuid == 1
+        assert subnet.rho == 10
+        assert subnet.kappa == 32767
+        assert subnet.max_allowed_validators == 64
+        assert subnet.tempo == 360
+        assert subnet.owner_ss58 == MOCK_OWNER
+
+    def test_subnet_info_zero_netuid(self):
+        """Test SubnetInfo with netuid 0 (root network)."""
+        subnet = create_subnet_info(netuid=0, emission_value=0.0)
+        assert subnet.netuid == 0
+
+    def test_subnet_info_high_netuid(self):
+        """Test SubnetInfo with high netuid value."""
+        subnet = create_subnet_info(netuid=255, max_n=8192)
+        assert subnet.netuid == 255
+
+    def test_subnet_info_with_connection_requirements(self):
+        """Test SubnetInfo with connection_requirements set."""
+        conn_req = {"1": 0.5, "2": 0.75}
+        subnet = create_subnet_info(connection_requirements=conn_req)
+        assert subnet.connection_requirements == conn_req
+
+
+class TestSubnetInfoParameters:
+    """Tests for SubnetInfo parameter values."""
+
+    def test_rho_values(self):
+        """Test SubnetInfo with various rho values."""
+        for rho in [1, 10, 50, 100]:
+            subnet = create_subnet_info(rho=rho)
+            assert subnet.rho == rho
+
+    def test_kappa_values(self):
+        """Test SubnetInfo with various kappa values."""
+        for kappa in [0, 16384, 32767, 65535]:
+            subnet = create_subnet_info(kappa=kappa)
+            assert subnet.kappa == kappa
+
+    def test_tempo_values(self):
+        """Test SubnetInfo with various tempo values."""
+        for tempo in [99, 360, 720, 1440]:
+            subnet = create_subnet_info(tempo=tempo)
+            assert subnet.tempo == tempo
+
+    def test_difficulty_values(self):
+        """Test SubnetInfo with various difficulty values."""
+        for difficulty in [1000, 1000000, 1000000000]:
+            subnet = create_subnet_info(difficulty=difficulty)
+            assert subnet.difficulty == difficulty
+
+
+class TestSubnetInfoValidators:
+    """Tests for validator-related parameters in SubnetInfo."""
+
+    def test_max_allowed_validators(self):
+        """Test SubnetInfo with various max_allowed_validators values."""
+        for max_validators in [16, 32, 64, 128, 256]:
+            subnet = create_subnet_info(max_allowed_validators=max_validators)
+            assert subnet.max_allowed_validators == max_validators
+
+    def test_min_allowed_weights(self):
+        """Test SubnetInfo with various min_allowed_weights values."""
+        for min_weights in [0, 1, 10, 100]:
+            subnet = create_subnet_info(min_allowed_weights=min_weights)
+            assert subnet.min_allowed_weights == min_weights
+
+    def test_max_weight_limit(self):
+        """Test SubnetInfo with various max_weight_limit values."""
+        for max_weight in [0.1, 0.5, 0.75, 1.0]:
+            subnet = create_subnet_info(max_weight_limit=max_weight)
+            assert subnet.max_weight_limit == max_weight
+
+
+class TestSubnetInfoNetwork:
+    """Tests for network-related parameters in SubnetInfo."""
+
+    def test_subnetwork_n_values(self):
+        """Test SubnetInfo with various subnetwork_n values."""
+        for n in [64, 128, 256, 512, 1024]:
+            subnet = create_subnet_info(subnetwork_n=n)
+            assert subnet.subnetwork_n == n
+
+    def test_max_n_values(self):
+        """Test SubnetInfo with various max_n values."""
+        for max_n in [256, 1024, 4096, 16384]:
+            subnet = create_subnet_info(max_n=max_n)
+            assert subnet.max_n == max_n
+
+    def test_modality_values(self):
+        """Test SubnetInfo with various modality values."""
+        for modality in [0, 1, 2]:
+            subnet = create_subnet_info(modality=modality)
+            assert subnet.modality == modality
+
+
+class TestSubnetInfoEmission:
+    """Tests for emission-related parameters in SubnetInfo."""
+
+    def test_emission_value(self):
+        """Test SubnetInfo with various emission values."""
+        for emission in [0.0, 0.5, 1.0, 2.0]:
+            subnet = create_subnet_info(emission_value=emission)
+            assert subnet.emission_value == emission
+
+    def test_burn_balance(self):
+        """Test SubnetInfo with various burn values."""
+        for burn_tao in [0.0, 0.5, 1.0, 10.0, 100.0]:
+            subnet = create_subnet_info(burn=Balance.from_tao(burn_tao))
+            assert subnet.burn.tao == burn_tao
+
+
+class TestSubnetInfoFromDict:
+    """Tests for SubnetInfo._from_dict method."""
+
+    @patch("bittensor.core.chain_data.subnet_info.decode_account_id")
+    def test_from_dict_basic(self, mock_decode):
+        """Test _from_dict with basic valid data."""
+        mock_decode.return_value = MOCK_OWNER
+        decoded = {
+            "netuid": 1,
+            "rho": 10,
+            "kappa": 32767,
+            "difficulty": 1000000,
+            "immunity_period": 4096,
+            "max_allowed_validators": 64,
+            "min_allowed_weights": 1,
+            "max_weights_limit": 32768,
+            "scaling_law_power": 50,
+            "subnetwork_n": 256,
+            "max_allowed_uids": 4096,
+            "blocks_since_last_step": 100,
+            "tempo": 360,
+            "network_modality": 0,
+            "network_connect": [],
+            "emission_value": 1.0,
+            "burn": 1000000000,
+            "owner": "owner_bytes",
+        }
+        result = SubnetInfo._from_dict(decoded)
+        assert result.netuid == 1
+        assert result.rho == 10
+        assert result.tempo == 360
+        assert result.owner_ss58 == MOCK_OWNER
+
+    @patch("bittensor.core.chain_data.subnet_info.decode_account_id")
+    def test_from_dict_with_network_connect(self, mock_decode):
+        """Test _from_dict with network_connect data."""
+        mock_decode.return_value = MOCK_OWNER
+        decoded = {
+            "netuid": 1,
+            "rho": 10,
+            "kappa": 32767,
+            "difficulty": 1000000,
+            "immunity_period": 4096,
+            "max_allowed_validators": 64,
+            "min_allowed_weights": 1,
+            "max_weights_limit": 32768,
+            "scaling_law_power": 50,
+            "subnetwork_n": 256,
+            "max_allowed_uids": 4096,
+            "blocks_since_last_step": 100,
+            "tempo": 360,
+            "network_modality": 0,
+            "network_connect": [(2, 32768), (3, 16384)],
+            "emission_value": 1.0,
+            "burn": 1000000000,
+            "owner": "owner_bytes",
+        }
+        result = SubnetInfo._from_dict(decoded)
+        assert "2" in result.connection_requirements
+        assert "3" in result.connection_requirements
+
+
+class TestSubnetInfoAttributes:
+    """Tests for SubnetInfo attribute access."""
+
+    def test_all_attributes_accessible(self):
+        """Test that all attributes are accessible."""
+        subnet = create_subnet_info()
+        attrs = [
+            "netuid",
+            "rho",
+            "kappa",
+            "difficulty",
+            "immunity_period",
+            "max_allowed_validators",
+            "min_allowed_weights",
+            "max_weight_limit",
+            "scaling_law_power",
+            "subnetwork_n",
+            "max_n",
+            "blocks_since_epoch",
+            "tempo",
+            "modality",
+            "connection_requirements",
+            "emission_value",
+            "burn",
+            "owner_ss58",
+        ]
+        for attr in attrs:
+            assert hasattr(subnet, attr)
+
+    def test_owner_ss58_format(self):
+        """Test that owner_ss58 is in correct format."""
+        subnet = create_subnet_info()
+        assert subnet.owner_ss58.startswith("5")
+        assert len(subnet.owner_ss58) == 48
+
+    def test_burn_is_balance(self):
+        """Test that burn is a Balance object."""
+        subnet = create_subnet_info()
+        assert isinstance(subnet.burn, Balance)
+
+    def test_connection_requirements_is_dict(self):
+        """Test that connection_requirements is a dict."""
+        subnet = create_subnet_info()
+        assert isinstance(subnet.connection_requirements, dict)
+
+
+class TestSubnetInfoComparison:
+    """Tests for comparing SubnetInfo instances."""
+
+    def test_different_netuids(self):
+        """Test SubnetInfo instances with different netuids."""
+        subnet1 = create_subnet_info(netuid=1)
+        subnet2 = create_subnet_info(netuid=2)
+        assert subnet1.netuid != subnet2.netuid
+
+    def test_same_netuid_different_params(self):
+        """Test SubnetInfo instances with same netuid but different params."""
+        subnet1 = create_subnet_info(netuid=1, tempo=360)
+        subnet2 = create_subnet_info(netuid=1, tempo=720)
+        assert subnet1.netuid == subnet2.netuid
+        assert subnet1.tempo != subnet2.tempo


### PR DESCRIPTION
### Requirements for Adding, Changing, or Removing a Feature

* [x] Fill out the template below
* [x] The pull request must update the test suite to exercise the updated functionality
* [x] After you create the pull request, all status checks must pass

### Description of the Change

This PR adds comprehensive unit tests for multiple `bittensor.core.chain_data` modules that currently lack test coverage. The tests follow the existing testing patterns in the repository and use `unittest.mock.patch` for mocking dependencies.

**Modules tested:**
- `delegate_info.py` - DelegateInfoBase, DelegateInfo, DelegatedInfo classes
- `delegate_info_lite.py` - DelegateInfoLite class
- `neuron_info.py` - NeuronInfo with weights/bonds handling
- `neuron_info_lite.py` - NeuronInfoLite with metrics
- `stake_info.py` - StakeInfo with balance handling
- `subnet_info.py` - SubnetInfo with network parameters

**Test coverage includes:**
- Dataclass creation with valid data
- Edge cases (zero values, large values, empty collections)
- `_from_dict` deserialization methods
- Balance type handling and conversions
- Attribute access and validation
- Comparison between instances

### Alternate Designs

Considered using pytest fixtures but opted for helper functions to maintain consistency with existing test patterns in the repository.

### Possible Drawbacks

None identified. These are additive tests that do not modify existing functionality.

### Verification Process

1. All test files pass syntax validation:
```bash
python3 -m py_compile tests/unit_tests/chain_data/*_unit.py
```

2. Tests follow existing patterns from `tests/unit_tests/chain_data/test_metagraph_info.py`

3. Each test class covers:
   - Basic creation scenarios
   - Edge cases with boundary values
   - Deserialization from dict format
   - Type validation for Balance objects

### Release Notes

N/A - Internal test coverage improvement only.

### Branch Acknowledgement
[x] I am acknowledging that I am opening this branch against `staging`

---

*Contribution by Gittensor, learn more at https://gittensor.io/*