### PR TITLE
Changelog + bumping version to `v10`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## 10.0.0 /2025-12-09
+
+## What's Changed
+
+* [v10] RootClaim update by @basfroman in https://github.com/opentensor/bittensor/pull/3154
+* feat: add comprehensive unit tests for bittensor.core.stream module by @codomposer in https://github.com/opentensor/bittensor/pull/3168
+* [v10] `MEV Shield Protection` support by @basfroman in https://github.com/opentensor/bittensor/pull/3163
+* [v10] Fix `blocks_until` issue in `get_next_epoch_start_block` by @basfroman in https://github.com/opentensor/bittensor/pull/3188
+* [v10] Transaction-has-an-ancient-birth-block by @basfroman in https://github.com/opentensor/bittensor/pull/3189
+* [v10] Add `AdminUtills` pallet support by @basfroman in https://github.com/opentensor/bittensor/pull/3190
+* [v10] `MeV` update by @basfroman in https://github.com/opentensor/bittensor/pull/3192
+* feat: add comprehensive unit tests for bittensor.core.threadpool module by @codomposer in https://github.com/opentensor/bittensor/pull/3169
+* [v10] Subtensor Pallet-Based GenericCall creation logic. by @basfroman in https://github.com/opentensor/bittensor/pull/3136
+* [v10] fix: simplify `AxonInfo.__eq__` method and add type check by @basfroman in https://github.com/opentensor/bittensor/pull/3142
+* [v10] Add Proxy Pallet Support by @basfroman in https://github.com/opentensor/bittensor/pull/3140
+* [v10] New logic + small refactoring by @basfroman in https://github.com/opentensor/bittensor/pull/3145
+* [v10] Improve btlogging by @basfroman in https://github.com/opentensor/bittensor/pull/3143
+* [v10] Improve proxy by @basfroman in https://github.com/opentensor/bittensor/pull/3147
+* [v10] Adds block backwards compatibility for fetching metagraph. by @thewhaleking in https://github.com/opentensor/bittensor/pull/3139
+* [v10] remove nest asyncio + loosen requirements by @thewhaleking in https://github.com/opentensor/bittensor/pull/3149
+* [v10] Add warning and protection to `create_pure_proxy_extrinsic` by @basfroman in https://github.com/opentensor/bittensor/pull/3150
+* [v10] Add `Async/Subtensor.get_stake_info_for_coldkeys` method by @basfroman in https://github.com/opentensor/bittensor/pull/3151
+* [v10] fix: resolve python 3.14 syntax warnings and update deps by @Arthurdw in https://github.com/opentensor/bittensor/pull/3155
+* [v10] Apply default era.period to all extrinsics by @basfroman in https://github.com/opentensor/bittensor/pull/3116
+* [V10] python3.14 by @thewhaleking in https://github.com/opentensor/bittensor/pull/3123
+* [v10] Fix py3.14 tests issue by @basfroman in https://github.com/opentensor/bittensor/pull/3124
+* [v10] `Root claim/ Airdrop` mechanism implementation by @basfroman in https://github.com/opentensor/bittensor/pull/3117
+* [v10] RootClaim fix by @basfroman in https://github.com/opentensor/bittensor/pull/3130
+* [v10] EMA InFlow support by @basfroman in https://github.com/opentensor/bittensor/pull/3131
+* [v10] Remove deprecated `bittensor.version_split` by @basfroman in https://github.com/opentensor/bittensor/pull/3100
+* [v10] Fix `bittensor.core.types.Weights` type annotation by @basfroman in https://github.com/opentensor/bittensor/pull/3103
+* [v10] Integrate Crowdloan by @basfroman in https://github.com/opentensor/bittensor/pull/3098
+* [v10] Rename max_retries to max_attempts to be more obvious by @basfroman in https://github.com/opentensor/bittensor/pull/3108
+* [v10] It includes a full refactor of the extrinsic layer, API standardization across Subtensor, and the introduction of multiple-mechanism (sub-subnet) support.
+* [v10] For a complete list of breaking changes and migration details, see the **MIGRATION_GUIDE.md** file in the repository.
+
+**Full Changelog**: https://github.com/opentensor/bittensor/compare/v9.12.0...v10.0.0
+
 ## 10.0.0rc4 /2025-11-26
 
 ## What's Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bittensor"
-version = "10.0.0rc4"
+version = "10.0.0"
 description = "Bittensor SDK"
 readme = "README.md"
 authors = [
@@ -64,7 +64,7 @@ torch = [
     "torch>=1.13.1,<3.0"
 ]
 cli = [
-    "bittensor-cli>=9.15.3"
+    "bittensor-cli>=9.16.0"
 ]
 
 


### PR DESCRIPTION
## What's Changed

* [v10] Add warning about MeV HK usage by @basfroman in https://github.com/opentensor/bittensor/pull/3204
* [v10] Avoid negative balance to add_stake by @basfroman in https://github.com/opentensor/bittensor/pull/3202
* [v10] Fix: Correct nonce argument usage in MEV shield by ibraheem-abe https://github.com/opentensor/bittensor/pull/3199
* [v10] MeV update by @basfroman in https://github.com/opentensor/bittensor/pull/3192
* [v10] RootClaim update by @basfroman in https://github.com/opentensor/bittensor/pull/3154
* feat: add comprehensive unit tests for bittensor.core.stream module by @codomposer in https://github.com/opentensor/bittensor/pull/3168
* [v10] `MEV Shield Protection` support by @basfroman in https://github.com/opentensor/bittensor/pull/3163
* [v10] Fix `blocks_until` issue in `get_next_epoch_start_block` by @basfroman in https://github.com/opentensor/bittensor/pull/3188
* [v10] Transaction-has-an-ancient-birth-block by @basfroman in https://github.com/opentensor/bittensor/pull/3189
* [v10] Add `AdminUtills` pallet support by @basfroman in https://github.com/opentensor/bittensor/pull/3190
* [v10] `MeV` update by @basfroman in https://github.com/opentensor/bittensor/pull/3192
* feat: add comprehensive unit tests for bittensor.core.threadpool module by @codomposer in https://github.com/opentensor/bittensor/pull/3169
* [v10] Subtensor Pallet-Based GenericCall creation logic. by @basfroman in https://github.com/opentensor/bittensor/pull/3136
* [v10] fix: simplify `AxonInfo.__eq__` method and add type check by @basfroman in https://github.com/opentensor/bittensor/pull/3142
* [v10] Add Proxy Pallet Support by @basfroman in https://github.com/opentensor/bittensor/pull/3140
* [v10] New logic + small refactoring by @basfroman in https://github.com/opentensor/bittensor/pull/3145
* [v10] Improve btlogging by @basfroman in https://github.com/opentensor/bittensor/pull/3143
* [v10] Improve proxy by @basfroman in https://github.com/opentensor/bittensor/pull/3147
* [v10] Adds block backwards compatibility for fetching metagraph. by @thewhaleking in https://github.com/opentensor/bittensor/pull/3139
* [v10] remove nest asyncio + loosen requirements by @thewhaleking in https://github.com/opentensor/bittensor/pull/3149
* [v10] Add warning and protection to `create_pure_proxy_extrinsic` by @basfroman in https://github.com/opentensor/bittensor/pull/3150
* [v10] Add `Async/Subtensor.get_stake_info_for_coldkeys` method by @basfroman in https://github.com/opentensor/bittensor/pull/3151
* [v10] fix: resolve python 3.14 syntax warnings and update deps by @Arthurdw in https://github.com/opentensor/bittensor/pull/3155
* [v10] Apply default era.period to all extrinsics by @basfroman in https://github.com/opentensor/bittensor/pull/3116
* [V10] python3.14 by @thewhaleking in https://github.com/opentensor/bittensor/pull/3123
* [v10] Fix py3.14 tests issue by @basfroman in https://github.com/opentensor/bittensor/pull/3124
* [v10] `Root claim/ Airdrop` mechanism implementation by @basfroman in https://github.com/opentensor/bittensor/pull/3117
* [v10] RootClaim fix by @basfroman in https://github.com/opentensor/bittensor/pull/3130
* [v10] EMA InFlow support by @basfroman in https://github.com/opentensor/bittensor/pull/3131
* [v10] Remove deprecated `bittensor.version_split` by @basfroman in https://github.com/opentensor/bittensor/pull/3100
* [v10] Fix `bittensor.core.types.Weights` type annotation by @basfroman in https://github.com/opentensor/bittensor/pull/3103
* [v10] Integrate Crowdloan by @basfroman in https://github.com/opentensor/bittensor/pull/3098
* [v10] Rename max_retries to max_attempts to be more obvious by @basfroman in https://github.com/opentensor/bittensor/pull/3108
* [v10] It includes a full refactor of the extrinsic layer, API standardization across Subtensor, and the introduction of multiple-mechanism (sub-subnet) support.
* [v10] For a complete list of breaking changes and migration details, see the **MIGRATION_GUIDE.md** file in the repository.