### PR TITLE
Improve GH workflows

### DIFF
--- a/.github/workflows/e2e-subtensor-tests.yaml
+++ b/.github/workflows/e2e-subtensor-tests.yaml
@@ -205,7 +205,7 @@ jobs:
       - read-python-versions
     strategy:
       fail-fast: false
-      max-parallel: 16
+      max-parallel: 64
       matrix:
         include: ${{ fromJson(needs.find-tests.outputs.test-files) }}
     uses: ./.github/workflows/_run-e2e-single.yaml

--- a/.github/workflows/unit-and-integration-tests.yml
+++ b/.github/workflows/unit-and-integration-tests.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Sync dev deps (idempotent; fast on cache hit)
         run: |
           uv sync --extra dev --dev
-          pip install .[torch]
+          uv run pip install .[torch]
 
       - name: Unit tests
         timeout-minutes: 20

--- a/.github/workflows/unit-and-integration-tests.yml
+++ b/.github/workflows/unit-and-integration-tests.yml
@@ -54,7 +54,9 @@ jobs:
             uv-${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-
 
       - name: Sync dev deps (idempotent; fast on cache hit)
-        run: uv sync --extra dev --dev
+        run: |
+          uv sync --extra dev --dev
+          pip install .[torch]
 
       - name: Unit tests
         timeout-minutes: 20

--- a/.github/workflows/unit-and-integration-tests.yml
+++ b/.github/workflows/unit-and-integration-tests.yml
@@ -54,9 +54,7 @@ jobs:
             uv-${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-
 
       - name: Sync dev deps (idempotent; fast on cache hit)
-        run: |
-          uv sync --extra dev --dev
-          uv run pip install .[torch]
+        run: uv sync --extra dev --dev --extra torch
 
       - name: Unit tests
         timeout-minutes: 20

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bittensor"
-version = "10.0.0"
+version = "10.0.1"
 description = "Bittensor SDK"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bittensor"
-version = "10.0.1"
+version = "10.0.0"
 description = "Bittensor SDK"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ dev = [
     "aioresponses==0.7.6",
     "factory-boy==3.3.0",
     "types-requests",
-    "torch>=1.13.1,<3.0"
 ]
 torch = [
     "torch>=1.13.1,<3.0"


### PR DESCRIPTION
Includes:
- `torch` removed from `[dev]` deps
- increased parallel-max for e2e tests

Result:
- e2e took **46 mins** before changes https://github.com/opentensor/bittensor/actions/runs/20077252636
- e2e takes **~6 mins** after changes https://github.com/opentensor/bittensor/actions/runs/20088854019