### PR TITLE
Refactor AsyncSubtensor and Dendrite to offload signing to ProcessPoolExecutor 

### DIFF
--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -166,10 +166,9 @@ from bittensor.utils.liquidity import (
 )
 
 
-
-
 def sign_extrinsic_worker(private_key: str, payload: bytes) -> str:
     from bittensor_wallet import Keypair
+
     # We use the private key to recreate the keypair for signing
     kp = Keypair(private_key=private_key)
     return f"0x{kp.sign(payload).hex()}"
@@ -265,7 +264,7 @@ class AsyncSubtensor(SubtensorMixin):
             logging.info(
                 f"Connected to {self.network} network and {self.chain_endpoint}."
             )
-        
+
         self._executor = ProcessPoolExecutor(max_workers=1)
 
     async def close(self):
@@ -294,7 +293,7 @@ class AsyncSubtensor(SubtensorMixin):
             await self.substrate.close()
 
         if self._executor:
-            self._executor.shutdown(wait=True)
+            self._executor.shutdown(wait=False, cancel_futures=True)
             self._executor = None
 
     async def initialize(self):
@@ -348,9 +347,9 @@ class AsyncSubtensor(SubtensorMixin):
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         if self.substrate:
             await self.substrate.close()
-        
+
         if self._executor:
-            self._executor.shutdown(wait=True)
+            self._executor.shutdown(wait=False, cancel_futures=True)
             self._executor = None
 
     # Helpers ==========================================================================================================
@@ -6002,11 +6001,7 @@ class AsyncSubtensor(SubtensorMixin):
         # Generate the signature payload.
         # This uses the underlying substrate interface to prepare the bytes to be signed.
         signature_payload = await self.substrate.generate_signature_payload(
-            call=call,
-            era=era,
-            nonce=nonce,
-            tip=tip,
-            tip_asset_id=tip_asset_id
+            call=call, era=era, nonce=nonce, tip=tip, tip_asset_id=tip_asset_id
         )
 
         # Offload the signing of the payload to an executor.
@@ -6014,7 +6009,7 @@ class AsyncSubtensor(SubtensorMixin):
         # signature_payload.data should contain the bytes to sign.
         signature = await loop.run_in_executor(
             self._executor,
-            partial(sign_extrinsic_worker, keypair.private_key, signature_payload.data)
+            partial(sign_extrinsic_worker, keypair.private_key, signature_payload.data),
         )
 
         # Create the extrinsic with the attached signature.

--- a/bittensor/core/dendrite.py
+++ b/bittensor/core/dendrite.py
@@ -43,10 +43,10 @@ def event_loop_is_running():
 
 def sign_message_worker(private_key_hex: str, message: str) -> str:
     from bittensor_wallet import Keypair
-    
+
     # Re-instantiate the keypair from the private key
     # ss58_address is required but can be dummy if only signing?
-    # Actually bittensor_wallet Keypair usually takes ss58_address. 
+    # Actually bittensor_wallet Keypair usually takes ss58_address.
     # If private_key is provided, it might derive it.
     # Let's try passing None or empty string if allowed, or check Keypair usage.
     # Safe bet: pass private key. Keypair usually derives public from private.
@@ -208,9 +208,9 @@ class DendriteMixin:
             if using_new_loop:
                 loop.close()
             self._session = None
-        
+
         if self._executor:
-            self._executor.shutdown(wait=True)
+            self._executor.shutdown(wait=False, cancel_futures=True)
             self._executor = None
 
     async def aclose_session(self):
@@ -237,9 +237,9 @@ class DendriteMixin:
         if self._session:
             await self._session.close()
             self._session = None
-            
+
         if self._executor:
-            self._executor.shutdown(wait=True)
+            self._executor.shutdown(wait=False, cancel_futures=True)
             self._executor = None
 
     def _get_endpoint_url(self, target_axon, request_name):
@@ -592,8 +592,9 @@ class DendriteMixin:
         url = self._get_endpoint_url(target_axon, request_name=request_name)
 
         # Preprocess synapse for making a request
-        synapse = await self.preprocess_synapse_for_request(target_axon, synapse, timeout)
-
+        synapse = await self.preprocess_synapse_for_request(
+            target_axon, synapse, timeout
+        )
 
         try:
             # Log outgoing request
@@ -668,8 +669,9 @@ class DendriteMixin:
         url = f"http://{endpoint}/{request_name}"
 
         # Preprocess synapse for making a request
-        synapse = await self.preprocess_synapse_for_request(target_axon, synapse, timeout)  # type: ignore
-
+        synapse = await self.preprocess_synapse_for_request(
+            target_axon, synapse, timeout
+        )  # type: ignore
 
         try:
             # Log outgoing request
@@ -745,11 +747,11 @@ class DendriteMixin:
 
         # Sign the request using the dendrite, axon info, and the synapse body hash
         message = f"{synapse.dendrite.nonce}.{synapse.dendrite.hotkey}.{synapse.axon.hotkey}.{synapse.dendrite.uuid}.{synapse.body_hash}"
-        
+
         loop = asyncio.get_running_loop()
         synapse.dendrite.signature = await loop.run_in_executor(
             self._executor,
-            partial(sign_message_worker, self.keypair.private_key, message)
+            partial(sign_message_worker, self.keypair.private_key, message),
         )
 
         return synapse

--- a/bittensor/core/extrinsics/asyncex/registration.py
+++ b/bittensor/core/extrinsics/asyncex/registration.py
@@ -341,7 +341,7 @@ async def register_extrinsic(
                 if not torch.cuda.is_available():
                     return ExtrinsicResponse(False, "CUDA not available.").with_log()
 
-                logging.debug(f"Creating a POW with CUDA.")
+                logging.debug("Creating a POW with CUDA.")
                 pow_result = await create_pow_async(
                     subtensor=subtensor,
                     wallet=wallet,
@@ -355,7 +355,7 @@ async def register_extrinsic(
                     log_verbose=log_verbose,
                 )
             else:
-                logging.debug(f"Creating a POW.")
+                logging.debug("Creating a POW.")
                 pow_result = await create_pow_async(
                     subtensor=subtensor,
                     wallet=wallet,

--- a/bittensor/core/extrinsics/registration.py
+++ b/bittensor/core/extrinsics/registration.py
@@ -333,7 +333,7 @@ def register_extrinsic(
                 if not torch.cuda.is_available():
                     return ExtrinsicResponse(False, "CUDA not available.").with_log()
 
-                logging.debug(f"Creating a POW with CUDA.")
+                logging.debug("Creating a POW with CUDA.")
                 pow_result = create_pow(
                     subtensor=subtensor,
                     wallet=wallet,
@@ -347,7 +347,7 @@ def register_extrinsic(
                     log_verbose=log_verbose,
                 )
             else:
-                logging.debug(f"Creating a POW.")
+                logging.debug("Creating a POW.")
                 pow_result = create_pow(
                     subtensor=subtensor,
                     wallet=wallet,

--- a/bittensor/core/extrinsics/utils.py
+++ b/bittensor/core/extrinsics/utils.py
@@ -198,11 +198,11 @@ def apply_pure_proxy_data(
     # If triggered events are not available or event PureCreated does not exist in the response, return the response
     # with warning message ot raise the error if raise_error is True.
     message = (
-        f"The ExtrinsicResponse doesn't contain pure_proxy data (`pure_account`, `spawner`, `proxy_type`, etc.) "
-        f"because the extrinsic receipt doesn't have triggered events. This typically happens when "
-        f"`wait_for_inclusion=False` or when `block_hash` is not available. To get this data, either pass "
-        f"`wait_for_inclusion=True` when calling this function, or retrieve the data manually from the blockchain "
-        f"using the extrinsic hash."
+        "The ExtrinsicResponse doesn't contain pure_proxy data (`pure_account`, `spawner`, `proxy_type`, etc.) "
+        "because the extrinsic receipt doesn't have triggered events. This typically happens when "
+        "`wait_for_inclusion=False` or when `block_hash` is not available. To get this data, either pass "
+        "`wait_for_inclusion=True` when calling this function, or retrieve the data manually from the blockchain "
+        "using the extrinsic hash."
     )
     if response.extrinsic is not None and hasattr(response.extrinsic, "extrinsic_hash"):
         extrinsic_hash = response.extrinsic.extrinsic_hash

--- a/bittensor/utils/btlogging/defines.py
+++ b/bittensor/utils/btlogging/defines.py
@@ -2,7 +2,7 @@
 
 BASE_LOG_FORMAT = "%(asctime)s | %(levelname)s | %(message)s"
 TRACE_LOG_FORMAT = (
-    f"%(asctime)s | %(levelname)s | %(name)s:%(filename)s:%(lineno)s | %(message)s"
+    "%(asctime)s | %(levelname)s | %(name)s:%(filename)s:%(lineno)s | %(message)s"
 )
 DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 BITTENSOR_LOGGER_NAME = "bittensor"

--- a/bittensor/utils/version.py
+++ b/bittensor/utils/version.py
@@ -117,6 +117,6 @@ def check_latest_version_in_pypi():
         except InvalidVersion:
             # stay silent if InvalidVersion
             pass
-    except (requests.RequestException, KeyError) as e:
+    except (requests.RequestException, KeyError):
         # stay silent if not internet connection or pypi.org issue
         pass

--- a/tests/consistency/test_proxy_types.py
+++ b/tests/consistency/test_proxy_types.py
@@ -1,5 +1,4 @@
 from bittensor.core.chain_data.proxy import ProxyType
-from bittensor.core.extrinsics.pallets import SubtensorModule, Proxy, Balances
 
 
 def get_proxy_type_fields(meta):

--- a/tests/e2e_tests/test_crowdloan.py
+++ b/tests/e2e_tests/test_crowdloan.py
@@ -1,6 +1,5 @@
 from bittensor import Balance
 from bittensor.core.extrinsics.pallets import SubtensorModule
-from bittensor_wallet import Wallet
 import pytest
 import asyncio
 

--- a/tests/e2e_tests/test_delegate.py
+++ b/tests/e2e_tests/test_delegate.py
@@ -2,7 +2,6 @@ import pytest
 
 from bittensor.core.chain_data.chain_identity import ChainIdentity
 from bittensor.core.chain_data.delegate_info import DelegatedInfo, DelegateInfo
-from bittensor.core.chain_data.proposal_vote_data import ProposalVoteData
 from bittensor.core.errors import (
     DelegateTakeTooHigh,
     DelegateTxRateLimitExceeded,
@@ -11,13 +10,9 @@ from bittensor.core.errors import (
 )
 from bittensor.utils.balance import Balance
 from tests.e2e_tests.utils import (
-    async_propose,
     async_set_identity,
-    async_vote,
     get_dynamic_balance,
-    propose,
     set_identity,
-    vote,
     TestSubnet,
     AdminUtils,
     ACTIVATE_SUBNET,
@@ -26,7 +21,6 @@ from tests.e2e_tests.utils import (
     SUDO_SET_NOMINATOR_MIN_REQUIRED_STAKE,
     SUDO_SET_TX_DELEGATE_TAKE_RATE_LIMIT,
 )
-from tests.helpers.helpers import CloseInValue
 
 DEFAULT_DELEGATE_TAKE = 0.179995422293431
 

--- a/tests/e2e_tests/test_metagraph.py
+++ b/tests/e2e_tests/test_metagraph.py
@@ -13,7 +13,6 @@ from bittensor.extras.dev_framework import (
 from bittensor.utils.balance import Balance
 from bittensor.utils.btlogging import logging
 from bittensor.utils.registration.pow import LazyLoadedTorch
-from bittensor.utils.weight_utils import convert_and_normalize_weights_and_uids
 from tests.e2e_tests.utils import (
     AdminUtils,
     NETUID,

--- a/tests/e2e_tests/test_root_claim.py
+++ b/tests/e2e_tests/test_root_claim.py
@@ -89,7 +89,7 @@ def test_root_claim_swap(subtensor, alice_wallet, bob_wallet, charlie_wallet):
     )
 
     # We skip the era in which the stake was installed, since the emission doesn't occur (Subtensor implementation)
-    logging.console.info(f"Skipping stake epoch")
+    logging.console.info("Skipping stake epoch")
     next_epoch_start_block = subtensor.subnets.get_next_epoch_start_block(
         netuid=root_sn.netuid
     )
@@ -193,7 +193,7 @@ async def test_root_claim_swap_async(
     )
 
     # We skip the era in which the stake was installed, since the emission doesn't occur (Subtensor implementation)
-    logging.console.info(f"Skipping stake epoch")
+    logging.console.info("Skipping stake epoch")
     next_epoch_start_block = await async_subtensor.subnets.get_next_epoch_start_block(
         netuid=root_sn.netuid
     )
@@ -352,7 +352,7 @@ def test_root_claim_keep_with_zero_num_root_auto_claims(
     )
     assert stake_before_charlie == 0
 
-    logging.console.info(f"[blue]Charlie before:[/blue]")
+    logging.console.info("[blue]Charlie before:[/blue]")
     logging.console.info(f"RootClaimed: {claimed_before_charlie}")
     logging.console.info(f"RootClaimable stake: {claimable_stake_before_charlie}")
     logging.console.info(f"SN2 Stake: {stake_before_charlie}")
@@ -383,7 +383,7 @@ def test_root_claim_keep_with_zero_num_root_auto_claims(
     )
     assert stake_after_charlie >= claimable_stake_before_charlie
 
-    logging.console.info(f"[blue]Charlie after:[/blue]")
+    logging.console.info("[blue]Charlie after:[/blue]")
     logging.console.info(f"RootClaimed: {claimed_after_charlie}")
     logging.console.info(f"RootClaimable stake: {claimable_stake_after_charlie}")
     logging.console.info(f"SN2 Stake: {stake_after_charlie}")
@@ -523,7 +523,7 @@ async def test_root_claim_keep_with_zero_num_root_auto_claims_async(
     )
     assert stake_before_charlie == 0
 
-    logging.console.info(f"[blue]Charlie before:[/blue]")
+    logging.console.info("[blue]Charlie before:[/blue]")
     logging.console.info(f"RootClaimed: {claimed_before_charlie}")
     logging.console.info(f"RootClaimable stake: {claimable_stake_before_charlie}")
     logging.console.info(f"SN2 Stake: {stake_before_charlie}")
@@ -558,7 +558,7 @@ async def test_root_claim_keep_with_zero_num_root_auto_claims_async(
     )
     assert stake_after_charlie >= claimable_stake_before_charlie
 
-    logging.console.info(f"[blue]Charlie after:[/blue]")
+    logging.console.info("[blue]Charlie after:[/blue]")
     logging.console.info(f"RootClaimed: {claimed_after_charlie}")
     logging.console.info(f"RootClaimable stake: {claimable_stake_after_charlie}")
     logging.console.info(f"SN2 Stake: {stake_after_charlie}")

--- a/tests/e2e_tests/test_subnets.py
+++ b/tests/e2e_tests/test_subnets.py
@@ -1,5 +1,4 @@
 import pytest
-from bittensor.utils.btlogging import logging
 
 
 def test_subnets(subtensor, alice_wallet):

--- a/tests/e2e_tests/test_transfer.py
+++ b/tests/e2e_tests/test_transfer.py
@@ -4,10 +4,9 @@ from bittensor_wallet import Wallet
 import pytest
 
 from bittensor.utils.balance import Balance
-from bittensor import logging
 
 if typing.TYPE_CHECKING:
-    from bittensor.extras import SubtensorApi
+    pass
 
 
 def test_transfer(subtensor, alice_wallet):

--- a/tests/e2e_tests/utils/e2e_test_utils.py
+++ b/tests/e2e_tests/utils/e2e_test_utils.py
@@ -6,7 +6,6 @@ import sys
 from typing import Optional
 from bittensor_wallet import Keypair, Wallet
 
-from bittensor.extras import SubtensorApi
 from bittensor.utils.btlogging import logging
 
 template_path = os.getcwd() + "/neurons/"

--- a/tests/unit_tests/extrinsics/asyncex/test_mev_shield.py
+++ b/tests/unit_tests/extrinsics/asyncex/test_mev_shield.py
@@ -1,5 +1,4 @@
 import pytest
-from bittensor_wallet import Wallet
 from scalecodec.types import GenericCall
 from async_substrate_interface import AsyncExtrinsicReceipt
 

--- a/tests/unit_tests/extrinsics/asyncex/test_registration.py
+++ b/tests/unit_tests/extrinsics/asyncex/test_registration.py
@@ -232,7 +232,7 @@ async def test_register_extrinsic_already_registered(subtensor, fake_wallet, moc
         block_hash=subtensor.substrate.get_chain_head.return_value,
     )
     assert success is True
-    assert message == f"Already registered."
+    assert message == "Already registered."
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/extrinsics/asyncex/test_weights.py
+++ b/tests/unit_tests/extrinsics/asyncex/test_weights.py
@@ -1,7 +1,6 @@
 import pytest
 
 from bittensor.core.extrinsics.asyncex import weights as weights_module
-from bittensor.core.settings import version_as_int
 from bittensor.core.types import ExtrinsicResponse
 
 

--- a/tests/unit_tests/extrinsics/test_mev_shield.py
+++ b/tests/unit_tests/extrinsics/test_mev_shield.py
@@ -1,4 +1,3 @@
-from bittensor_wallet import Wallet
 from scalecodec.types import GenericCall
 from async_substrate_interface import ExtrinsicReceipt
 

--- a/tests/unit_tests/extrinsics/test_transfer.py
+++ b/tests/unit_tests/extrinsics/test_transfer.py
@@ -1,4 +1,3 @@
-import pytest
 from bittensor.core.extrinsics import transfer
 from bittensor.core.settings import DEFAULT_MEV_PROTECTION
 from bittensor.utils.balance import Balance

--- a/tests/unit_tests/test_dendrite.py
+++ b/tests/unit_tests/test_dendrite.py
@@ -304,7 +304,7 @@ async def test_dendrite__call__success_response(
         )
     )
     mock_aio_response.post(
-        f"http://127.0.0.1:666/SynapseDummy",
+        "http://127.0.0.1:666/SynapseDummy",
         body=expected_synapse.model_dump_json(),
     )
     synapse = await setup_dendrite.call(axon_info, synapse=input_synapse)

--- a/tests/unit_tests/test_stream.py
+++ b/tests/unit_tests/test_stream.py
@@ -5,9 +5,7 @@ Tests the StreamingSynapse class, BTStreamingResponse, and related streaming fun
 """
 
 import pytest
-from abc import ABC
-from typing import Optional
-from unittest.mock import AsyncMock, Mock, MagicMock, patch
+from unittest.mock import AsyncMock, Mock
 from aiohttp import ClientResponse
 from starlette.types import Send, Receive, Scope
 


### PR DESCRIPTION

## Description
This PR addresses critical Event Loop blocking caused by CPU-intensive cryptographic signing operations in the Bittensor SDK. Specifically, the `Keypair.sign` method (Elliptic Curve math) was being called synchronously on the main asyncio thread in both [AsyncSubtensor](cci:2://file:///c:/Users/user/Desktop/bittensor/bittensor/core/async_subtensor.py:185:0-9647:9) and [Dendrite](cci:2://file:///c:/Users/user/Desktop/bittensor/bittensor/core/dendrite.py:907:0-911:44), causing heartbeats to be missed and significant latency during high-volume operations (e.g., signing extrinsics for hundreds of miners).

## Changes
- **[bittensor/core/async_subtensor.py](cci:7://file:///c:/Users/user/Desktop/bittensor/bittensor/core/async_subtensor.py:0:0-0:0)**: 
    - Implemented [create_signed_extrinsic](cci:1://file:///c:/Users/user/Desktop/bittensor/bittensor/core/async_subtensor.py:5986:4-6029:24) to offload payload signing to a `ProcessPoolExecutor`.
    - Added [sign_extrinsic_worker](cci:1://file:///c:/Users/user/Desktop/bittensor/bittensor/core/async_subtensor.py:170:0-174:40) helper to handle signing in a separate process (pickling-safe).
    - Updated [sign_and_send_extrinsic](cci:1://file:///c:/Users/user/Desktop/bittensor/bittensor/core/async_subtensor.py:5963:4-6078:37) to use the async signing flow.
- **[bittensor/core/dendrite.py](cci:7://file:///c:/Users/user/Desktop/bittensor/bittensor/core/dendrite.py:0:0-0:0)**: 
    - Updated [preprocess_synapse_for_request](cci:1://file:///c:/Users/user/Desktop/bittensor/bittensor/core/dendrite.py:710:4-754:22) to be [async](cci:1://file:///c:/Users/user/Desktop/bittensor/bittensor/core/async_subtensor.py:9650:0-9686:14) and offload header signing to a `ProcessPoolExecutor`.
    - Added [sign_message_worker](cci:1://file:///c:/Users/user/Desktop/bittensor/bittensor/core/dendrite.py:43:0-53:40) helper.
    - Updated [call](cci:1://file:///c:/Users/user/Desktop/bittensor/bittensor/core/dendrite.py:560:4-626:64), [call_stream](cci:1://file:///c:/Users/user/Desktop/bittensor/bittensor/core/dendrite.py:628:4-708:29), and [forward](cci:1://file:///c:/Users/user/Desktop/bittensor/bittensor/core/dendrite.py:418:4-558:98) methods to await the async preprocessing.
- **Executor Management**: Added initialization and graceful shutdown (via `close/aclose`) of the `ProcessPoolExecutor` in both classes.

## Related Issues
Fixes #3211