### PR TITLE
Add insufficient balance transfer tests

### DIFF
--- a/tests/e2e_tests/test_transfer.py
+++ b/tests/e2e_tests/test_transfer.py
@@ -10,6 +10,32 @@ if typing.TYPE_CHECKING:
     from bittensor.extras import SubtensorApi
 
 
+def test_transfer_insufficient_balance(subtensor, alice_wallet):
+    """
+    Test that a transfer fails when the wallet has insufficient balance.
+    """
+
+    # Gets current balance
+    balance = subtensor.wallets.get_balance(
+        alice_wallet.coldkeypub.ss58_address
+    )
+
+    # Attempt to transfer more than available balance
+    transfer_value = balance + Balance.from_tao(1)
+    dest_coldkey = "5GpzQgpiAKHMWNSH3RN4GLf96GVTDct9QxYEFAY7LWcVzTbx"
+
+    response = subtensor.extrinsics.transfer(
+        wallet=alice_wallet,
+        destination_ss58=dest_coldkey,
+        amount=transfer_value,
+        wait_for_finalization=True,
+        wait_for_inclusion=True,
+    )
+
+    assert not response.success
+    assert "insufficient" in response.message.lower()
+
+
 def test_transfer(subtensor, alice_wallet):
     """
     Test the transfer mechanism on the chain
@@ -130,6 +156,7 @@ def test_transfer_all(subtensor, alice_wallet):
     assert balance_after == Balance(0)
 
 
+
 @pytest.mark.asyncio
 async def test_transfer_all_async(async_subtensor, alice_wallet):
     # create two dummy accounts we can drain
@@ -180,3 +207,30 @@ async def test_transfer_all_async(async_subtensor, alice_wallet):
         dummy_account_2.coldkeypub.ss58_address
     )
     assert balance_after == Balance(0)
+
+
+# insufficient balance async
+
+@pytest.mark.asyncio
+async def test_transfer_insufficient_balance_async(async_subtensor, alice_wallet):
+    """
+    Test that an async transfer fails when the wallet has insufficient balance.
+    """
+
+    balance = await async_subtensor.wallets.get_balance(
+        alice_wallet.coldkeypub.ss58_address
+    )
+
+    transfer_value = balance + Balance.from_tao(1)
+    dest_coldkey = "5GpzQgpiAKHMWNSH3RN4GLf96GVTDct9QxYEFAY7LWcVzTbx"
+
+    response = await async_subtensor.extrinsics.transfer(
+        wallet=alice_wallet,
+        destination_ss58=dest_coldkey,
+        amount=transfer_value,
+        wait_for_finalization=True,
+        wait_for_inclusion=True,
+    )
+
+    assert not response.success
+    assert "insufficient" in response.message.lower()

--- a/tests/e2e_tests/test_transfer.py
+++ b/tests/e2e_tests/test_transfer.py
@@ -10,24 +10,30 @@ if typing.TYPE_CHECKING:
     from bittensor.extras import SubtensorApi
 
 
-def test_transfer_insufficient_balance(subtensor, alice_wallet):
+def test_transfer(subtensor, alice_wallet):
     """
-    Test that a transfer fails when the wallet has insufficient balance.
+    Test the transfer mechanism on the chain.
+
+    Steps:
+        1. Attempt transfer with insufficient balance (should fail)
+        2. Transfer 2 Tao successfully
+        3. Verify balance calculations
     """
 
-    # Gets current balance
-    balance = subtensor.wallets.get_balance(
+    dest_coldkey = "5GpzQgpiAKHMWNSH3RN4GLf96GVTDct9QxYEFAY7LWcVzTbx"
+
+    # Account balance before any transfer
+    balance_before = subtensor.wallets.get_balance(
         alice_wallet.coldkeypub.ss58_address
     )
 
-    # Attempt to transfer more than available balance
-    transfer_value = balance + Balance.from_tao(1)
-    dest_coldkey = "5GpzQgpiAKHMWNSH3RN4GLf96GVTDct9QxYEFAY7LWcVzTbx"
+    # --- Insufficient balance case (NEW) ---
+    insufficient_amount = balance_before + Balance.from_tao(1)
 
     response = subtensor.extrinsics.transfer(
         wallet=alice_wallet,
         destination_ss58=dest_coldkey,
-        amount=transfer_value,
+        amount=insufficient_amount,
         wait_for_finalization=True,
         wait_for_inclusion=True,
     )
@@ -35,24 +41,9 @@ def test_transfer_insufficient_balance(subtensor, alice_wallet):
     assert not response.success
     assert "insufficient" in response.message.lower()
 
-
-def test_transfer(subtensor, alice_wallet):
-    """
-    Test the transfer mechanism on the chain
-
-    Steps:
-        1. Calculate existing balance and transfer 2 Tao
-        2. Calculate balance after transfer call and verify calculations
-    Raises:
-        AssertionError: If any of the checks or verifications fail
-    """
+    # --- Successful transfer (EXISTING FLOW) ---
     transfer_value = Balance.from_tao(2)
-    dest_coldkey = "5GpzQgpiAKHMWNSH3RN4GLf96GVTDct9QxYEFAY7LWcVzTbx"
 
-    # Account details before transfer
-    balance_before = subtensor.wallets.get_balance(alice_wallet.coldkeypub.ss58_address)
-
-    # Transfer Tao
     response = subtensor.extrinsics.transfer(
         wallet=alice_wallet,
         destination_ss58=dest_coldkey,
@@ -60,12 +51,13 @@ def test_transfer(subtensor, alice_wallet):
         wait_for_finalization=True,
         wait_for_inclusion=True,
     )
+
     assert response.success, response.message
 
-    # Account details after transfer
-    balance_after = subtensor.wallets.get_balance(alice_wallet.coldkeypub.ss58_address)
+    balance_after = subtensor.wallets.get_balance(
+        alice_wallet.coldkeypub.ss58_address
+    )
 
-    # Assert correct transfer calculations
     assert balance_before - response.extrinsic_fee - transfer_value == balance_after, (
         f"Expected {balance_before - transfer_value - response.extrinsic_fee}, got {balance_after}"
     )
@@ -74,23 +66,37 @@ def test_transfer(subtensor, alice_wallet):
 @pytest.mark.asyncio
 async def test_transfer_async(async_subtensor, alice_wallet):
     """
-    Test the transfer mechanism on the chain
+    Async version of transfer test.
 
     Steps:
-        1. Calculate existing balance and transfer 2 Tao
-        2. Calculate balance after transfer call and verify calculations
-    Raises:
-        AssertionError: If any of the checks or verifications fail
+        1. Attempt transfer with insufficient balance (should fail)
+        2. Transfer 2 Tao successfully
+        3. Verify balance calculations
     """
-    transfer_value = Balance.from_tao(2)
+
     dest_coldkey = "5GpzQgpiAKHMWNSH3RN4GLf96GVTDct9QxYEFAY7LWcVzTbx"
 
-    # Account details before transfer
     balance_before = await async_subtensor.wallets.get_balance(
         alice_wallet.coldkeypub.ss58_address
     )
 
-    # Transfer Tao
+    # --- Insufficient balance case (NEW) ---
+    insufficient_amount = balance_before + Balance.from_tao(1)
+
+    response = await async_subtensor.extrinsics.transfer(
+        wallet=alice_wallet,
+        destination_ss58=dest_coldkey,
+        amount=insufficient_amount,
+        wait_for_finalization=True,
+        wait_for_inclusion=True,
+    )
+
+    assert not response.success
+    assert "insufficient" in response.message.lower()
+
+    # --- Successful transfer (EXISTING FLOW) ---
+    transfer_value = Balance.from_tao(2)
+
     response = await async_subtensor.extrinsics.transfer(
         wallet=alice_wallet,
         destination_ss58=dest_coldkey,
@@ -98,14 +104,13 @@ async def test_transfer_async(async_subtensor, alice_wallet):
         wait_for_finalization=True,
         wait_for_inclusion=True,
     )
+
     assert response.success, response.message
 
-    # Account details after transfer
     balance_after = await async_subtensor.wallets.get_balance(
         alice_wallet.coldkeypub.ss58_address
     )
 
-    # Assert correct transfer calculations
     assert balance_before - response.extrinsic_fee - transfer_value == balance_after, (
         f"Expected {balance_before - transfer_value - response.extrinsic_fee}, got {balance_after}"
     )
@@ -126,8 +131,9 @@ def test_transfer_all(subtensor, alice_wallet):
         wait_for_finalization=True,
         wait_for_inclusion=True,
     ).success
-    # Account details before transfer
+
     existential_deposit = subtensor.chain.get_existential_deposit()
+
     assert subtensor.extrinsics.transfer(
         wallet=dummy_account_1,
         destination_ss58=dummy_account_2.coldkeypub.ss58_address,
@@ -137,10 +143,12 @@ def test_transfer_all(subtensor, alice_wallet):
         wait_for_inclusion=True,
         keep_alive=True,
     ).success
+
     balance_after = subtensor.wallets.get_balance(
         dummy_account_1.coldkeypub.ss58_address
     )
     assert balance_after == existential_deposit
+
     assert subtensor.extrinsics.transfer(
         wallet=dummy_account_2,
         destination_ss58=alice_wallet.coldkeypub.ss58_address,
@@ -150,22 +158,20 @@ def test_transfer_all(subtensor, alice_wallet):
         wait_for_finalization=True,
         keep_alive=False,
     ).success
+
     balance_after = subtensor.wallets.get_balance(
         dummy_account_2.coldkeypub.ss58_address
     )
     assert balance_after == Balance(0)
 
 
-
 @pytest.mark.asyncio
 async def test_transfer_all_async(async_subtensor, alice_wallet):
-    # create two dummy accounts we can drain
     dummy_account_1 = Wallet(path="/tmp/bittensor-dummy-account-3")
     dummy_account_2 = Wallet(path="/tmp/bittensor-dummy-account-4")
     dummy_account_1.create_new_coldkey(use_password=False, overwrite=True)
     dummy_account_2.create_new_coldkey(use_password=False, overwrite=True)
 
-    # fund the first dummy account
     assert (
         await async_subtensor.extrinsics.transfer(
             wallet=alice_wallet,
@@ -175,8 +181,9 @@ async def test_transfer_all_async(async_subtensor, alice_wallet):
             wait_for_inclusion=True,
         )
     ).success
-    # Account details before transfer
+
     existential_deposit = await async_subtensor.chain.get_existential_deposit()
+
     assert (
         await async_subtensor.extrinsics.transfer(
             wallet=dummy_account_1,
@@ -188,10 +195,12 @@ async def test_transfer_all_async(async_subtensor, alice_wallet):
             keep_alive=True,
         )
     ).success
+
     balance_after = await async_subtensor.wallets.get_balance(
         dummy_account_1.coldkeypub.ss58_address
     )
     assert balance_after == existential_deposit
+
     assert (
         await async_subtensor.extrinsics.transfer(
             wallet=dummy_account_2,
@@ -203,34 +212,8 @@ async def test_transfer_all_async(async_subtensor, alice_wallet):
             keep_alive=False,
         )
     ).success
+
     balance_after = await async_subtensor.wallets.get_balance(
         dummy_account_2.coldkeypub.ss58_address
     )
     assert balance_after == Balance(0)
-
-
-# insufficient balance async
-
-@pytest.mark.asyncio
-async def test_transfer_insufficient_balance_async(async_subtensor, alice_wallet):
-    """
-    Test that an async transfer fails when the wallet has insufficient balance.
-    """
-
-    balance = await async_subtensor.wallets.get_balance(
-        alice_wallet.coldkeypub.ss58_address
-    )
-
-    transfer_value = balance + Balance.from_tao(1)
-    dest_coldkey = "5GpzQgpiAKHMWNSH3RN4GLf96GVTDct9QxYEFAY7LWcVzTbx"
-
-    response = await async_subtensor.extrinsics.transfer(
-        wallet=alice_wallet,
-        destination_ss58=dest_coldkey,
-        amount=transfer_value,
-        wait_for_finalization=True,
-        wait_for_inclusion=True,
-    )
-
-    assert not response.success
-    assert "insufficient" in response.message.lower()


### PR DESCRIPTION
Problem:
Transfer behavior when wallet balance is insufficient was not explicitly covered
by unit tests.

Solution:
Added sync and async tests ensuring transfers fail safely when the wallet balance
is insufficient.

Testing:
pytest tests/unit_tests/test_transfer.py
