### PR TITLE
feat: Enable opt-in type checking for additional core modules

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,11 @@
 [mypy]
+# Global settings
 ignore_missing_imports = True
-ignore_errors = True
+ignore_errors = True  # Keep as default to avoid breaking builds
+
+# Opt-in type checking for specific modules
+# These modules have been verified to pass type checking and gradually
+# enable stricter type validation across the codebase.
 
 [mypy-*.axon.*]
 ignore_errors = False
@@ -16,3 +21,24 @@ ignore_errors = False
 
 [mypy-*.synapse.*]
 ignore_errors = False
+
+# Additional core modules enabled for type checking:
+[mypy-bittensor.core.types.*]
+ignore_errors = False
+
+[mypy-bittensor.core.tensor.*]
+ignore_errors = False
+
+[mypy-bittensor.core.config.*]
+ignore_errors = False
+
+[mypy-bittensor.core.threadpool.*]
+ignore_errors = False
+
+[mypy-bittensor.utils.weight_utils.*]
+ignore_errors = False
+
+# To add more modules to type checking:
+# 1. Ensure the module passes mypy validation
+# 2. Add a new section: [mypy-module.path.*]
+# 3. Set: ignore_errors = False


### PR DESCRIPTION
## Problem
The current mypy.ini has `ignore_errors = True` globally, which disables type checking for most of the codebase. However, removing this setting entirely would cause build failures due to existing type errors in unchecked modules.

## Solution
**Opt-in Approach:**
- KEEP `ignore_errors = True` as the global default (maintains stability)
- EXPLICITLY enable type checking for specific verified modules
- Added 5 new modules to the type-checked list:
  - `bittensor.core.types.*`
  - `bittensor.core.tensor.*`
  - `bittensor.core.config.*`
  - `bittensor.core.threadpool.*`
  - `bittensor.utils.weight_utils.*`

This approach:
✅ Doesn't break existing builds
✅ Gradually expands type coverage
✅ Allows incremental adoption
✅ Provides clear migration path

## Benefits
- Static type validation for 10 total modules (5 existing + 5 new)
- Safer than global "opt-out" approach
- Enables gradual improvement without disruption
- Clear documentation for adding more modules

## Testing
- No functional changes
- Existing tests continue to pass
- New modules can be validated with: `mypy bittensor/core/types/ --config-file mypy.ini`

## Migration Strategy
To add more modules:
1. Fix type errors in target module
2. Add `[mypy-module.path.*]` section
3. Set `ignore_errors = False`

Welcome!

Due to [GitHub limitations](https://github.com/orgs/community/discussions/4620),
please switch to **Preview** for links to render properly.

Please choose the right template for your pull request:

- 🐛 Are you fixing a bug? [Bug fix](?expand=1&template=bug_fix.md)
- 📈 Are you improving performance? [Performance improvement](?expand=1&template=performance_improvement.md)
- 💻 Are you changing functionality? [Feature change](?expand=1&template=feature_change.md)
