### PR TITLE
MeV: fix for weird edge case

### DIFF
--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -7002,7 +7002,7 @@ class AsyncSubtensor(SubtensorMixin):
                 have successfully decrypted and executed the inner call. If True, the function will poll subsequent
                 blocks for the event matching this submission's commitment.
             blocks_for_revealed_execution: Maximum number of blocks to poll for the executed event after
-                inclusion. The function checks blocks from start_block+1 to start_block + blocks_for_revealed_execution.
+                inclusion. The function checks blocks from start_block to start_block + blocks_for_revealed_execution.
                 Returns immediately if the event is found before the block limit is reached.
 
         Returns:

--- a/bittensor/core/extrinsics/asyncex/mev_shield.py
+++ b/bittensor/core/extrinsics/asyncex/mev_shield.py
@@ -40,14 +40,14 @@ async def wait_for_extrinsic_by_hash(
         extrinsic_hash: The hash of the inner extrinsic to find.
         shield_id: The wrapper ID from EncryptedSubmitted event (for detecting decryption failures).
         submit_block_hash: Block hash where submit_encrypted was included.
-        timeout_blocks: Max blocks to wait (default 3).
+        timeout_blocks: Max blocks to wait.
 
     Returns:
         Optional ExtrinsicReceipt.
     """
 
     starting_block = await subtensor.substrate.get_block_number(submit_block_hash)
-    current_block = starting_block + 1
+    current_block = starting_block
 
     while current_block - starting_block <= timeout_blocks:
         logging.debug(
@@ -127,7 +127,7 @@ async def submit_encrypted_extrinsic(
             successfully decrypted and executed the inner call. If True, the function will poll subsequent blocks for
             the event matching this submission's commitment.
         blocks_for_revealed_execution: Maximum number of blocks to poll for the executed event after inclusion.
-            The function checks blocks from start_block + 1 to start_block + blocks_for_revealed_execution. Returns
+            The function checks blocks from start_block to start_block + blocks_for_revealed_execution. Returns
             immediately if the event is found before the block limit is reached.
 
     Returns:

--- a/bittensor/core/extrinsics/mev_shield.py
+++ b/bittensor/core/extrinsics/mev_shield.py
@@ -39,14 +39,14 @@ def wait_for_extrinsic_by_hash(
         extrinsic_hash: The hash of the inner extrinsic to find.
         shield_id: The wrapper ID from EncryptedSubmitted event (for detecting decryption failures).
         submit_block_hash: Block hash where submit_encrypted was included.
-        timeout_blocks: Max blocks to wait (default 3).
+        timeout_blocks: Max blocks to wait.
 
     Returns:
         Optional ExtrinsicReceipt.
     """
 
     starting_block = subtensor.substrate.get_block_number(submit_block_hash)
-    current_block = starting_block + 1
+    current_block = starting_block
 
     while current_block - starting_block <= timeout_blocks:
         logging.debug(
@@ -126,7 +126,7 @@ def submit_encrypted_extrinsic(
             successfully decrypted and executed the inner call. If True, the function will poll subsequent blocks for
             the event matching this submission's commitment.
         blocks_for_revealed_execution: Maximum number of blocks to poll for the executed event after inclusion.
-            The function checks blocks from start_block + 1 to start_block + blocks_for_revealed_execution. Returns
+            The function checks blocks from start_block to start_block + blocks_for_revealed_execution. Returns
             immediately if the event is found before the block limit is reached.
 
     Returns:

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -5847,7 +5847,7 @@ class Subtensor(SubtensorMixin):
                 have successfully decrypted and executed the inner call. If True, the function will poll subsequent
                 blocks for the event matching this submission's commitment.
             blocks_for_revealed_execution: Maximum number of blocks to poll for the executed event after inclusion. The
-                function checks blocks from start_block+1 to start_block + blocks_for_revealed_execution. Returns
+                function checks blocks from start_block to start_block + blocks_for_revealed_execution. Returns
                 immediately if the event is found before the block limit is reached.
 
         Returns:

--- a/tests/unit_tests/extrinsics/asyncex/test_mev_shield.py
+++ b/tests/unit_tests/extrinsics/asyncex/test_mev_shield.py
@@ -15,7 +15,7 @@ async def test_wait_for_extrinsic_by_hash_success(subtensor, mocker):
     shield_id = "shield_id_123"
     submit_block_hash = "0xblockhash"
     starting_block = 100
-    current_block = 101
+    current_block = 100
 
     mocked_get_block_number = mocker.patch.object(
         subtensor.substrate,
@@ -76,7 +76,7 @@ async def test_wait_for_extrinsic_by_hash_decryption_failed(subtensor, mocker):
     shield_id = "shield_id_123"
     submit_block_hash = "0xblockhash"
     starting_block = 100
-    current_block = 101
+    current_block = 100
 
     mocked_get_block_number = mocker.patch.object(
         subtensor.substrate,
@@ -174,9 +174,9 @@ async def test_wait_for_extrinsic_by_hash_timeout(subtensor, mocker):
 
     # Asserts
     mocked_get_block_number.assert_awaited_once_with(submit_block_hash)
-    assert mocked_wait_for_block.await_count == 3
-    assert mocked_get_block_hash.await_count == 3
-    assert mocked_get_extrinsics.await_count == 3
+    assert mocked_wait_for_block.await_count == 4
+    assert mocked_get_block_hash.await_count == 4
+    assert mocked_get_extrinsics.await_count == 4
     assert result is None
 
 

--- a/tests/unit_tests/extrinsics/test_mev_shield.py
+++ b/tests/unit_tests/extrinsics/test_mev_shield.py
@@ -13,7 +13,7 @@ def test_wait_for_extrinsic_by_hash_success(subtensor, mocker):
     shield_id = "shield_id_123"
     submit_block_hash = "0xblockhash"
     starting_block = 100
-    current_block = 101
+    current_block = 100
 
     mocked_get_block_number = mocker.patch.object(
         subtensor.substrate, "get_block_number", return_value=starting_block
@@ -67,7 +67,7 @@ def test_wait_for_extrinsic_by_hash_decryption_failed(subtensor, mocker):
     shield_id = "shield_id_123"
     submit_block_hash = "0xblockhash"
     starting_block = 100
-    current_block = 101
+    current_block = 100
 
     mocked_get_block_number = mocker.patch.object(
         subtensor.substrate, "get_block_number", return_value=starting_block
@@ -152,9 +152,9 @@ def test_wait_for_extrinsic_by_hash_timeout(subtensor, mocker):
 
     # Asserts
     mocked_get_block_number.assert_called_once_with(submit_block_hash)
-    assert mocked_wait_for_block.call_count == 3
-    assert mocked_get_block_hash.call_count == 3
-    assert mocked_get_extrinsics.call_count == 3
+    assert mocked_wait_for_block.call_count == 4
+    assert mocked_get_block_hash.call_count == 4
+    assert mocked_get_extrinsics.call_count == 4
     assert result is None
 
 


### PR DESCRIPTION
case: `block X` contains an `EncryptedSubmitted` event and in the same `block X` there is an `AddStake` event that was MeV executed