### PR TITLE
Changelog/10.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 10.1.0 /2026-01-15
+
+## What's Changed
+* Fix for async metagraph initialization by @basfroman in https://github.com/opentensor/bittensor/pull/3236
+* Clarify return ordering and units for `get_revealed_commitment_by_hotkey` by @Dairus01 in https://github.com/opentensor/bittensor/pull/3231
+* Skips user liquidity e2e test pending the rework by @basfroman in https://github.com/opentensor/bittensor/pull/3239
+* chore: fix incorrect Optional type annotation in utils by @Olexandr88 in https://github.com/opentensor/bittensor/pull/3238
+* chore: remove unused test helper by @Olexandr88 in https://github.com/opentensor/bittensor/pull/3241
+* Add `start_call_delay_hyperparameter` support by @basfroman in https://github.com/opentensor/bittensor/pull/3234
+* Improve `is_fast_blocks` by @basfroman in https://github.com/opentensor/bittensor/pull/3243
+
+## New Contributors
+* @Dairus01 made their first contribution in https://github.com/opentensor/bittensor/pull/3231
+* @Olexandr88 made their first contribution in https://github.com/opentensor/bittensor/pull/3238
+
+**Full Changelog**: https://github.com/opentensor/bittensor/compare/v10.1.0...v10.0.2
+
 ## 10.0.1 /2025-12-22
 
 ## What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * chore: remove unused test helper by @Olexandr88 in https://github.com/opentensor/bittensor/pull/3241
 * Add `start_call_delay_hyperparameter` support by @basfroman in https://github.com/opentensor/bittensor/pull/3234
 * Improve `is_fast_blocks` by @basfroman in https://github.com/opentensor/bittensor/pull/3243
+* Adds note about block 5611654 decoding by @thewhaleking in https://github.com/opentensor/bittensor/pull/3246
 
 ## New Contributors
 * @Dairus01 made their first contribution in https://github.com/opentensor/bittensor/pull/3231

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bittensor"
-version = "10.0.1"
+version = "10.1.0"
 description = "Bittensor SDK"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "uvicorn",
     "bittensor-drand>=1.2.0,<2.0.0",
     "bittensor-wallet>=4.0.0,<5.0",
-    "async-substrate-interface>=1.5.14"
+    "async-substrate-interface>=1.5.15"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## 10.1.0 /2026-01-15

## What's Changed
* Fix for async metagraph initialization by @basfroman in https://github.com/opentensor/bittensor/pull/3236
* Clarify return ordering and units for `get_revealed_commitment_by_hotkey` by @Dairus01 in https://github.com/opentensor/bittensor/pull/3231
* Skips user liquidity e2e test pending the rework by @basfroman in https://github.com/opentensor/bittensor/pull/3239
* chore: fix incorrect Optional type annotation in utils by @Olexandr88 in https://github.com/opentensor/bittensor/pull/3238
* chore: remove unused test helper by @Olexandr88 in https://github.com/opentensor/bittensor/pull/3241
* Add `start_call_delay_hyperparameter` support by @basfroman in https://github.com/opentensor/bittensor/pull/3234
* Improve `is_fast_blocks` by @basfroman in https://github.com/opentensor/bittensor/pull/3243

## New Contributors
* @Dairus01 made their first contribution in https://github.com/opentensor/bittensor/pull/3231
* @Olexandr88 made their first contribution in https://github.com/opentensor/bittensor/pull/3238

**Full Changelog**: https://github.com/opentensor/bittensor/compare/v10.1.0...v10.0.2