### PR TITLE
Adds note about block 5611654 decoding

### DIFF
--- a/contrib/DEBUGGING.md
+++ b/contrib/DEBUGGING.md
@@ -160,3 +160,13 @@ $ ag "query_subtensor"
 ```
 
 Remember, debugging involves a lot of trial and error. Don't be discouraged if things don't work right away. Keep trying different things, and don't hesitate to ask for help if you need it.
+
+## Problem With Block 5611654
+
+If you are having problems decoding the extrinsics or events on block 5611654 of finney, it is due to a your Python 
+interpreter's default recursion limit. Simply change your system recursion limit:
+
+```python
+import sys
+sys.setrecursionlimit(100_000)
+```

--- a/contrib/DEBUGGING.md
+++ b/contrib/DEBUGGING.md
@@ -163,10 +163,11 @@ Remember, debugging involves a lot of trial and error. Don't be discouraged if t
 
 ## Problem With Block 5611654
 
-If you are having problems decoding the extrinsics or events on block 5611654 of finney, it is due to a your Python 
-interpreter's default recursion limit. Simply change your system recursion limit:
+If you are having problems decoding the extrinsics on block 5611654 of finney, it is due to a your Python 
+interpreter's default recursion limit. Simply change your system recursion limit, by setting it (default 1_000) to 
+any integer greater than or equal to 3049
 
 ```python
 import sys
-sys.setrecursionlimit(100_000)
+sys.setrecursionlimit(3050)  # works
 ```


### PR DESCRIPTION
Frequently annoys me. Felt it should be somewhere in the docs.
