### PR TITLE
Add subnet buyback extrinsic support to SDK

### DIFF
--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -114,6 +114,7 @@ from bittensor.core.extrinsics.asyncex.staking import (
     add_stake_extrinsic,
     add_stake_multiple_extrinsic,
     set_auto_stake_extrinsic,
+    subnet_buyback_extrinsic,
 )
 from bittensor.core.extrinsics.asyncex.start_call import start_call_extrinsic
 from bittensor.core.extrinsics.asyncex.take import set_take_extrinsic
@@ -9120,6 +9121,64 @@ class AsyncSubtensor(SubtensorMixin):
             subtensor=self,
             wallet=wallet,
             netuid=netuid,
+            mev_protection=mev_protection,
+            period=period,
+            raise_error=raise_error,
+            wait_for_inclusion=wait_for_inclusion,
+            wait_for_finalization=wait_for_finalization,
+            wait_for_revealed_execution=wait_for_revealed_execution,
+        )
+
+    async def subnet_buyback(
+        self,
+        wallet: "Wallet",
+        netuid: int,
+        hotkey_ss58: str,
+        amount: Balance,
+        limit_price: Optional[Balance] = None,
+        *,
+        mev_protection: bool = DEFAULT_MEV_PROTECTION,
+        period: Optional[int] = DEFAULT_PERIOD,
+        raise_error: bool = False,
+        wait_for_inclusion: bool = True,
+        wait_for_finalization: bool = True,
+        wait_for_revealed_execution: bool = True,
+    ) -> ExtrinsicResponse:
+        """
+        Executes a subnet buyback by staking TAO and immediately burning the resulting Alpha.
+
+        Only the subnet owner can call this method, and it is rate-limited to one call per subnet tempo.
+
+        Parameters:
+            wallet: The wallet used to sign the extrinsic (must be the subnet owner).
+            netuid: The unique identifier of the subnet.
+            hotkey_ss58: The `SS58` address of the hotkey account to stake to.
+            amount: The amount of TAO to use for the buyback.
+            limit_price: Optional limit price expressed in units of RAO per one Alpha.
+            mev_protection: If `True`, encrypts and submits the transaction through the MEV Shield pallet to protect
+                against front-running and MEV attacks. The transaction remains encrypted in the mempool until validators
+                decrypt and execute it. If `False`, submits the transaction directly without encryption.
+            period: The number of blocks during which the transaction will remain valid after it's submitted. If the
+                transaction is not included in a block within that number of blocks, it will expire and be rejected. You
+                can think of it as an expiration date for the transaction.
+            raise_error: Raises a relevant exception rather than returning `False` if unsuccessful.
+            wait_for_inclusion: Whether to wait for the inclusion of the transaction.
+            wait_for_finalization: Whether to wait for the finalization of the transaction.
+            wait_for_revealed_execution: Whether to wait for the revealed execution of transaction if mev_protection used.
+
+        Returns:
+            ExtrinsicResponse: The result object of the extrinsic execution.
+        """
+        check_balance_amount(amount)
+        if limit_price is not None:
+            check_balance_amount(limit_price)
+        return await subnet_buyback_extrinsic(
+            subtensor=self,
+            wallet=wallet,
+            netuid=netuid,
+            hotkey_ss58=hotkey_ss58,
+            amount=amount,
+            limit_price=limit_price,
             mev_protection=mev_protection,
             period=period,
             raise_error=raise_error,

--- a/bittensor/core/extrinsics/asyncex/staking.py
+++ b/bittensor/core/extrinsics/asyncex/staking.py
@@ -452,6 +452,189 @@ async def add_stake_multiple_extrinsic(
         return ExtrinsicResponse.from_exception(raise_error=raise_error, error=error)
 
 
+async def subnet_buyback_extrinsic(
+    subtensor: "AsyncSubtensor",
+    wallet: "Wallet",
+    netuid: int,
+    hotkey_ss58: str,
+    amount: Balance,
+    limit_price: Optional[Balance] = None,
+    *,
+    mev_protection: bool = DEFAULT_MEV_PROTECTION,
+    period: Optional[int] = None,
+    raise_error: bool = False,
+    wait_for_inclusion: bool = True,
+    wait_for_finalization: bool = True,
+    wait_for_revealed_execution: bool = True,
+) -> ExtrinsicResponse:
+    """
+    Executes a subnet buyback by staking TAO and immediately burning the resulting Alpha.
+
+    Parameters:
+        subtensor: Subtensor instance with the connection to the chain.
+        wallet: Bittensor wallet object.
+        netuid: The unique identifier of the subnet.
+        hotkey_ss58: The `ss58` address of the hotkey account to stake to.
+        amount: Amount to stake as Bittensor balance in TAO always.
+        limit_price: Optional limit price expressed in units of RAO per one Alpha.
+        mev_protection: If True, encrypts and submits the transaction through the MEV Shield pallet to protect
+            against front-running and MEV attacks. The transaction remains encrypted in the mempool until validators
+            decrypt and execute it. If False, submits the transaction directly without encryption.
+        period: The number of blocks during which the transaction will remain valid after it's submitted. If the
+            transaction is not included in a block within that number of blocks, it will expire and be rejected. You can
+            think of it as an expiration date for the transaction.
+        raise_error: Raises a relevant exception rather than returning `False` if unsuccessful.
+        wait_for_inclusion: Whether to wait for the inclusion of the transaction.
+        wait_for_finalization: Whether to wait for the finalization of the transaction.
+        wait_for_revealed_execution: Whether to wait for the revealed execution of transaction if mev_protection used.
+
+    Returns:
+        ExtrinsicResponse: The result object of the extrinsic execution.
+
+    Raises:
+        SubstrateRequestException: Raised if the extrinsic fails to be included in the block within the timeout.
+
+    Notes:
+        The `data` field in the returned `ExtrinsicResponse` contains extra information about the extrinsic execution.
+    """
+    try:
+        if not (
+            unlocked := ExtrinsicResponse.unlock_wallet(wallet, raise_error)
+        ).success:
+            return unlocked
+
+        if not isinstance(amount, Balance):
+            raise BalanceTypeError("`amount` must be an instance of Balance.")
+
+        if limit_price is not None and not isinstance(limit_price, Balance):
+            raise BalanceTypeError("`limit_price` must be an instance of Balance.")
+
+        old_balance = await subtensor.get_balance(wallet.coldkeypub.ss58_address)
+        block_hash = await subtensor.substrate.get_chain_head()
+
+        # Get current stake and existential deposit
+        old_stake, existential_deposit = await asyncio.gather(
+            subtensor.get_stake(
+                hotkey_ss58=hotkey_ss58,
+                coldkey_ss58=wallet.coldkeypub.ss58_address,
+                netuid=netuid,
+                block_hash=block_hash,
+            ),
+            subtensor.get_existential_deposit(block_hash=block_hash),
+        )
+
+        # Leave existential balance to keep key alive.
+        if old_balance <= existential_deposit:
+            return ExtrinsicResponse(
+                False,
+                f"Balance ({old_balance}) is not enough to cover existential deposit `{existential_deposit}`.",
+            ).with_log()
+
+        # Leave existential balance to keep key alive.
+        if amount > old_balance - existential_deposit:
+            # If we are staking all, we need to leave at least the existential deposit.
+            amount = old_balance - existential_deposit
+
+        # Check enough to stake.
+        if amount > old_balance:
+            message = "Not enough stake"
+            logging.debug(f":cross_mark: [red]{message}:[/red]")
+            logging.debug(f"\t\tbalance:{old_balance}")
+            logging.debug(f"\t\tamount: {amount}")
+            logging.debug(f"\t\twallet: {wallet.name}")
+            return ExtrinsicResponse(False, f"{message}.").with_log()
+
+        if limit_price is None:
+            logging.debug(
+                f"Subnet buyback on: [blue]netuid: [green]{netuid}[/green], amount: [green]{amount}[/green], "
+                f"hotkey: [green]{hotkey_ss58}[/green] on [blue]{subtensor.network}[/blue]."
+            )
+        else:
+            logging.debug(
+                f"Subnet buyback with limit: [blue]netuid: [green]{netuid}[/green], "
+                f"amount: [green]{amount}[/green], "
+                f"limit price: [green]{limit_price}[/green], "
+                f"hotkey: [green]{hotkey_ss58}[/green] on [blue]{subtensor.network}[/blue]."
+            )
+
+        call = await SubtensorModule(subtensor).subnet_buyback(
+            netuid=netuid,
+            hotkey=hotkey_ss58,
+            amount=amount.rao,
+            limit=None if limit_price is None else limit_price.rao,
+        )
+
+        block_hash_before = await subtensor.get_block_hash()
+        if mev_protection:
+            response = await submit_encrypted_extrinsic(
+                subtensor=subtensor,
+                wallet=wallet,
+                call=call,
+                period=period,
+                raise_error=raise_error,
+                wait_for_inclusion=wait_for_inclusion,
+                wait_for_finalization=wait_for_finalization,
+                wait_for_revealed_execution=wait_for_revealed_execution,
+            )
+        else:
+            response = await subtensor.sign_and_send_extrinsic(
+                call=call,
+                wallet=wallet,
+                wait_for_inclusion=wait_for_inclusion,
+                wait_for_finalization=wait_for_finalization,
+                nonce_key="coldkeypub",
+                use_nonce=True,
+                period=period,
+                raise_error=raise_error,
+            )
+        if response.success:
+            sim_swap = await subtensor.sim_swap(
+                origin_netuid=0,
+                destination_netuid=netuid,
+                amount=amount,
+                block_hash=block_hash_before,
+            )
+            response.transaction_tao_fee = sim_swap.tao_fee
+            response.transaction_alpha_fee = sim_swap.alpha_fee.set_unit(netuid)
+
+            if not wait_for_finalization and not wait_for_inclusion:
+                return response
+            logging.debug("[green]Finalized.[/green]")
+
+            new_block_hash = await subtensor.substrate.get_chain_head()
+            new_balance, new_stake = await asyncio.gather(
+                subtensor.get_balance(
+                    wallet.coldkeypub.ss58_address, block_hash=new_block_hash
+                ),
+                subtensor.get_stake(
+                    coldkey_ss58=wallet.coldkeypub.ss58_address,
+                    hotkey_ss58=hotkey_ss58,
+                    netuid=netuid,
+                    block_hash=new_block_hash,
+                ),
+            )
+
+            logging.debug(
+                f"Balance: [blue]{old_balance}[/blue] :arrow_right: [green]{new_balance}[/green]"
+            )
+            logging.debug(
+                f"Stake: [blue]{old_stake}[/blue] :arrow_right: [green]{new_stake}[/green]"
+            )
+            response.data = {
+                "balance_before": old_balance,
+                "balance_after": new_balance,
+                "stake_before": old_stake,
+                "stake_after": new_stake,
+            }
+            return response
+
+        logging.error(f"[red]{response.message}[/red]")
+        return response
+
+    except Exception as error:
+        return ExtrinsicResponse.from_exception(raise_error=raise_error, error=error)
+
+
 async def set_auto_stake_extrinsic(
     subtensor: "AsyncSubtensor",
     wallet: "Wallet",

--- a/bittensor/core/extrinsics/pallets/subtensor_module.py
+++ b/bittensor/core/extrinsics/pallets/subtensor_module.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 from typing import Literal, Optional
-from bittensor.utils import deprecated_message
+
 from bittensor.core.types import Salt, UIDs, Weights
-from bittensor.utils import Certificate
+from bittensor.utils import Certificate, deprecated_message
 
 from .base import Call
 from .base import CallBuilder as _BasePallet
@@ -662,6 +662,31 @@ class SubtensorModule(_BasePallet):
             GenericCall instance.
         """
         return self.create_composed_call(netuid=netuid)
+
+    def subnet_buyback(
+        self,
+        netuid: int,
+        hotkey: str,
+        amount: int,
+        limit: Optional[int] = None,
+    ) -> Call:
+        """Returns GenericCall instance for Subtensor function SubtensorModule.subnet_buyback.
+
+        Parameters:
+            netuid: The netuid of the subnet to buy back on.
+            hotkey: The hotkey SS58 address associated with the buyback.
+            amount: Amount of TAO in RAO to use for the buyback.
+            limit: Optional limit price expressed in units of RAO per one Alpha.
+
+        Returns:
+            GenericCall instance.
+        """
+        return self.create_composed_call(
+            netuid=netuid,
+            hotkey=hotkey,
+            amount=amount,
+            limit=limit,
+        )
 
     def swap_stake(
         self,

--- a/bittensor/core/extrinsics/staking.py
+++ b/bittensor/core/extrinsics/staking.py
@@ -443,6 +443,185 @@ def add_stake_multiple_extrinsic(
         return ExtrinsicResponse.from_exception(raise_error=raise_error, error=error)
 
 
+def subnet_buyback_extrinsic(
+    subtensor: "Subtensor",
+    wallet: "Wallet",
+    netuid: int,
+    hotkey_ss58: str,
+    amount: Balance,
+    limit_price: Optional[Balance] = None,
+    *,
+    mev_protection: bool = DEFAULT_MEV_PROTECTION,
+    period: Optional[int] = None,
+    raise_error: bool = False,
+    wait_for_inclusion: bool = True,
+    wait_for_finalization: bool = True,
+    wait_for_revealed_execution: bool = True,
+) -> ExtrinsicResponse:
+    """
+    Executes a subnet buyback by staking TAO and immediately burning the resulting Alpha.
+
+    Parameters:
+        subtensor: Subtensor instance with the connection to the chain.
+        wallet: Bittensor wallet object.
+        netuid: The unique identifier of the subnet.
+        hotkey_ss58: The `ss58` address of the hotkey account to stake to.
+        amount: Amount to stake as Bittensor balance in TAO always.
+        limit_price: Optional limit price expressed in units of RAO per one Alpha.
+        mev_protection: If True, encrypts and submits the transaction through the MEV Shield pallet to protect
+            against front-running and MEV attacks. The transaction remains encrypted in the mempool until validators
+            decrypt and execute it. If False, submits the transaction directly without encryption.
+        period: The number of blocks during which the transaction will remain valid after it's submitted. If the
+            transaction is not included in a block within that number of blocks, it will expire and be rejected. You can
+            think of it as an expiration date for the transaction.
+        raise_error: Raises a relevant exception rather than returning `False` if unsuccessful.
+        wait_for_inclusion: Whether to wait for the inclusion of the transaction.
+        wait_for_finalization: Whether to wait for the finalization of the transaction.
+        wait_for_revealed_execution: Whether to wait for the revealed execution of transaction if mev_protection used.
+
+    Returns:
+        ExtrinsicResponse: The result object of the extrinsic execution.
+
+    Raises:
+        SubstrateRequestException: Raised if the extrinsic fails to be included in the block within the timeout.
+
+    Notes:
+        The `data` field in the returned `ExtrinsicResponse` contains extra information about the extrinsic execution.
+    """
+    try:
+        if not (
+            unlocked := ExtrinsicResponse.unlock_wallet(wallet, raise_error)
+        ).success:
+            return unlocked
+
+        if not isinstance(amount, Balance):
+            raise BalanceTypeError("`amount` must be an instance of Balance.")
+
+        if limit_price is not None and not isinstance(limit_price, Balance):
+            raise BalanceTypeError("`limit_price` must be an instance of Balance.")
+
+        old_balance = subtensor.get_balance(wallet.coldkeypub.ss58_address)
+        block = subtensor.get_current_block()
+
+        # Get current stake and existential deposit
+        old_stake = subtensor.get_stake(
+            hotkey_ss58=hotkey_ss58,
+            coldkey_ss58=wallet.coldkeypub.ss58_address,
+            netuid=netuid,
+            block=block,
+        )
+        existential_deposit = subtensor.get_existential_deposit(block=block)
+
+        # Leave existential balance to keep key alive.
+        if old_balance <= existential_deposit:
+            return ExtrinsicResponse(
+                False,
+                f"Balance ({old_balance}) is not enough to cover existential deposit `{existential_deposit}`.",
+            ).with_log()
+
+        # Leave existential balance to keep key alive.
+        if amount > old_balance - existential_deposit:
+            # If we are staking all, we need to leave at least the existential deposit.
+            amount = old_balance - existential_deposit
+
+        # Check enough to stake.
+        if amount > old_balance:
+            message = "Not enough stake"
+            logging.debug(f":cross_mark: [red]{message}:[/red]")
+            logging.debug(f"\t\tbalance:{old_balance}")
+            logging.debug(f"\t\tamount: {amount}")
+            logging.debug(f"\t\twallet: {wallet.name}")
+            return ExtrinsicResponse(False, f"{message}.").with_log()
+
+        if limit_price is None:
+            logging.debug(
+                f"Subnet buyback on: [blue]netuid: [green]{netuid}[/green], amount: [green]{amount}[/green], "
+                f"hotkey: [green]{hotkey_ss58}[/green] on [blue]{subtensor.network}[/blue]."
+            )
+        else:
+            logging.debug(
+                f"Subnet buyback with limit: [blue]netuid: [green]{netuid}[/green], "
+                f"amount: [green]{amount}[/green], "
+                f"limit price: [green]{limit_price}[/green], "
+                f"hotkey: [green]{hotkey_ss58}[/green] on [blue]{subtensor.network}[/blue]."
+            )
+
+        call = SubtensorModule(subtensor).subnet_buyback(
+            netuid=netuid,
+            hotkey=hotkey_ss58,
+            amount=amount.rao,
+            limit=None if limit_price is None else limit_price.rao,
+        )
+
+        block_before = subtensor.block
+        if mev_protection:
+            response = submit_encrypted_extrinsic(
+                subtensor=subtensor,
+                wallet=wallet,
+                call=call,
+                period=period,
+                raise_error=raise_error,
+                wait_for_inclusion=wait_for_inclusion,
+                wait_for_finalization=wait_for_finalization,
+                wait_for_revealed_execution=wait_for_revealed_execution,
+            )
+        else:
+            response = subtensor.sign_and_send_extrinsic(
+                call=call,
+                wallet=wallet,
+                wait_for_inclusion=wait_for_inclusion,
+                wait_for_finalization=wait_for_finalization,
+                use_nonce=True,
+                nonce_key="coldkeypub",
+                period=period,
+                raise_error=raise_error,
+            )
+        if response.success:
+            sim_swap = subtensor.sim_swap(
+                origin_netuid=0,
+                destination_netuid=netuid,
+                amount=amount,
+                block=block_before,
+            )
+            response.transaction_tao_fee = sim_swap.tao_fee
+            response.transaction_alpha_fee = sim_swap.alpha_fee.set_unit(netuid)
+
+            if not wait_for_finalization and not wait_for_inclusion:
+                return response
+            logging.debug("[green]Finalized.[/green]")
+
+            new_block = subtensor.get_current_block()
+            new_balance = subtensor.get_balance(
+                wallet.coldkeypub.ss58_address, block=new_block
+            )
+            new_stake = subtensor.get_stake(
+                coldkey_ss58=wallet.coldkeypub.ss58_address,
+                hotkey_ss58=hotkey_ss58,
+                netuid=netuid,
+                block=new_block,
+            )
+
+            logging.debug(
+                f"Balance: [blue]{old_balance}[/blue] :arrow_right: [green]{new_balance}[/green]"
+            )
+            logging.debug(
+                f"Stake: [blue]{old_stake}[/blue] :arrow_right: [green]{new_stake}[/green]"
+            )
+            response.data = {
+                "balance_before": old_balance,
+                "balance_after": new_balance,
+                "stake_before": old_stake,
+                "stake_after": new_stake,
+            }
+            return response
+
+        logging.error(f"[red]{response.message}[/red]")
+        return response
+
+    except Exception as error:
+        return ExtrinsicResponse.from_exception(raise_error=raise_error, error=error)
+
+
 def set_auto_stake_extrinsic(
     subtensor: "Subtensor",
     wallet: "Wallet",

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -113,6 +113,7 @@ from bittensor.core.extrinsics.staking import (
     add_stake_extrinsic,
     add_stake_multiple_extrinsic,
     set_auto_stake_extrinsic,
+    subnet_buyback_extrinsic,
 )
 from bittensor.core.extrinsics.start_call import start_call_extrinsic
 from bittensor.core.extrinsics.take import set_take_extrinsic
@@ -7836,6 +7837,64 @@ class Subtensor(SubtensorMixin):
             subtensor=self,
             wallet=wallet,
             netuid=netuid,
+            mev_protection=mev_protection,
+            period=period,
+            raise_error=raise_error,
+            wait_for_inclusion=wait_for_inclusion,
+            wait_for_finalization=wait_for_finalization,
+            wait_for_revealed_execution=wait_for_revealed_execution,
+        )
+
+    def subnet_buyback(
+        self,
+        wallet: "Wallet",
+        netuid: int,
+        hotkey_ss58: str,
+        amount: Balance,
+        limit_price: Optional[Balance] = None,
+        *,
+        mev_protection: bool = DEFAULT_MEV_PROTECTION,
+        period: Optional[int] = DEFAULT_PERIOD,
+        raise_error: bool = False,
+        wait_for_inclusion: bool = True,
+        wait_for_finalization: bool = True,
+        wait_for_revealed_execution: bool = True,
+    ) -> ExtrinsicResponse:
+        """
+        Executes a subnet buyback by staking TAO and immediately burning the resulting Alpha.
+
+        Only the subnet owner can call this method, and it is rate-limited to one call per subnet tempo.
+
+        Parameters:
+            wallet: The wallet used to sign the extrinsic (must be the subnet owner).
+            netuid: The unique identifier of the subnet.
+            hotkey_ss58: The `SS58` address of the hotkey account to stake to.
+            amount: The amount of TAO to use for the buyback.
+            limit_price: Optional limit price expressed in units of RAO per one Alpha.
+            mev_protection: If `True`, encrypts and submits the transaction through the MEV Shield pallet to protect
+                against front-running and MEV attacks. The transaction remains encrypted in the mempool until validators
+                decrypt and execute it. If `False`, submits the transaction directly without encryption.
+            period: The number of blocks during which the transaction will remain valid after it's submitted. If the
+                transaction is not included in a block within that number of blocks, it will expire and be rejected. You
+                can think of it as an expiration date for the transaction.
+            raise_error: Raises a relevant exception rather than returning `False` if unsuccessful.
+            wait_for_inclusion: Whether to wait for the inclusion of the transaction.
+            wait_for_finalization: Whether to wait for the finalization of the transaction.
+            wait_for_revealed_execution: Whether to wait for the revealed execution of transaction if mev_protection used.
+
+        Returns:
+            ExtrinsicResponse: The result object of the extrinsic execution.
+        """
+        check_balance_amount(amount)
+        if limit_price is not None:
+            check_balance_amount(limit_price)
+        return subnet_buyback_extrinsic(
+            subtensor=self,
+            wallet=wallet,
+            netuid=netuid,
+            hotkey_ss58=hotkey_ss58,
+            amount=amount,
+            limit_price=limit_price,
             mev_protection=mev_protection,
             period=period,
             raise_error=raise_error,

--- a/bittensor/extras/dev_framework/calls/non_sudo_calls.py
+++ b/bittensor/extras/dev_framework/calls/non_sudo_calls.py
@@ -11,830 +11,191 @@ For developers:
 
 Note:
     Any manual changes will be overwritten the next time the generator is run.
-    Subtensor spec version: 365
+    Subtensor spec version: 375
 """
 
 from collections import namedtuple
 
 
-ADD_LIQUIDITY = namedtuple(
-    "ADD_LIQUIDITY",
-    ["wallet", "pallet", "hotkey", "netuid", "tick_low", "tick_high", "liquidity"],
-)  # args: [hotkey: T::AccountId, netuid: NetUid, tick_low: TickIndex, tick_high: TickIndex, liquidity: u64]  | Pallet: Swap
-ADD_PROXY = namedtuple(
-    "ADD_PROXY", ["wallet", "pallet", "delegate", "proxy_type", "delay"]
-)  # args: [delegate: AccountIdLookupOf<T>, proxy_type: T::ProxyType, delay: BlockNumberFor<T>]  | Pallet: Proxy
-ADD_STAKE = namedtuple(
-    "ADD_STAKE", ["wallet", "pallet", "hotkey", "netuid", "amount_staked"]
-)  # args: [hotkey: T::AccountId, netuid: NetUid, amount_staked: TaoCurrency]  | Pallet: SubtensorModule
-ADD_STAKE_LIMIT = namedtuple(
-    "ADD_STAKE_LIMIT",
-    [
-        "wallet",
-        "pallet",
-        "hotkey",
-        "netuid",
-        "amount_staked",
-        "limit_price",
-        "allow_partial",
-    ],
-)  # args: [hotkey: T::AccountId, netuid: NetUid, amount_staked: TaoCurrency, limit_price: TaoCurrency, allow_partial: bool]  | Pallet: SubtensorModule
-ANNOUNCE = namedtuple(
-    "ANNOUNCE", ["wallet", "pallet", "real", "call_hash"]
-)  # args: [real: AccountIdLookupOf<T>, call_hash: CallHashOf<T>]  | Pallet: Proxy
-ANNOUNCE_NEXT_KEY = namedtuple(
-    "ANNOUNCE_NEXT_KEY", ["wallet", "pallet", "public_key"]
-)  # args: [public_key: BoundedVec<u8, ConstU32<2048>>]  | Pallet: MevShield
-APPLY_AUTHORIZED_UPGRADE = namedtuple(
-    "APPLY_AUTHORIZED_UPGRADE", ["wallet", "pallet", "code"]
-)  # args: [code: Vec<u8>]  | Pallet: System
-APPROVE_AS_MULTI = namedtuple(
-    "APPROVE_AS_MULTI",
-    [
-        "wallet",
-        "pallet",
-        "threshold",
-        "other_signatories",
-        "maybe_timepoint",
-        "call_hash",
-        "max_weight",
-    ],
-)  # args: [threshold: u16, other_signatories: Vec<T::AccountId>, maybe_timepoint: Option<Timepoint<BlockNumberFor<T>>>, call_hash: [u8; 32], max_weight: Weight]  | Pallet: Multisig
-ASSOCIATE_EVM_KEY = namedtuple(
-    "ASSOCIATE_EVM_KEY",
-    ["wallet", "pallet", "netuid", "evm_key", "block_number", "signature"],
-)  # args: [netuid: NetUid, evm_key: H160, block_number: u64, signature: Signature]  | Pallet: SubtensorModule
-AS_DERIVATIVE = namedtuple(
-    "AS_DERIVATIVE", ["wallet", "pallet", "index", "call"]
-)  # args: [index: u16, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Utility
-AS_MULTI = namedtuple(
-    "AS_MULTI",
-    [
-        "wallet",
-        "pallet",
-        "threshold",
-        "other_signatories",
-        "maybe_timepoint",
-        "call",
-        "max_weight",
-    ],
-)  # args: [threshold: u16, other_signatories: Vec<T::AccountId>, maybe_timepoint: Option<Timepoint<BlockNumberFor<T>>>, call: Box<<T as Config>::RuntimeCall>, max_weight: Weight]  | Pallet: Multisig
-AS_MULTI_THRESHOLD_1 = namedtuple(
-    "AS_MULTI_THRESHOLD_1", ["wallet", "pallet", "other_signatories", "call"]
-)  # args: [other_signatories: Vec<T::AccountId>, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Multisig
-AUTHORIZE_UPGRADE = namedtuple(
-    "AUTHORIZE_UPGRADE", ["wallet", "pallet", "code_hash"]
-)  # args: [code_hash: T::Hash]  | Pallet: System
-AUTHORIZE_UPGRADE_WITHOUT_CHECKS = namedtuple(
-    "AUTHORIZE_UPGRADE_WITHOUT_CHECKS", ["wallet", "pallet", "code_hash"]
-)  # args: [code_hash: T::Hash]  | Pallet: System
-BATCH = namedtuple(
-    "BATCH", ["wallet", "pallet", "calls"]
-)  # args: [calls: Vec<<T as Config>::RuntimeCall>]  | Pallet: Utility
-BATCH_ALL = namedtuple(
-    "BATCH_ALL", ["wallet", "pallet", "calls"]
-)  # args: [calls: Vec<<T as Config>::RuntimeCall>]  | Pallet: Utility
-BATCH_COMMIT_WEIGHTS = namedtuple(
-    "BATCH_COMMIT_WEIGHTS", ["wallet", "pallet", "netuids", "commit_hashes"]
-)  # args: [netuids: Vec<Compact<NetUid>>, commit_hashes: Vec<H256>]  | Pallet: SubtensorModule
-BATCH_REVEAL_WEIGHTS = namedtuple(
-    "BATCH_REVEAL_WEIGHTS",
-    [
-        "wallet",
-        "pallet",
-        "netuid",
-        "uids_list",
-        "values_list",
-        "salts_list",
-        "version_keys",
-    ],
-)  # args: [netuid: NetUid, uids_list: Vec<Vec<u16>>, values_list: Vec<Vec<u16>>, salts_list: Vec<Vec<u16>>, version_keys: Vec<u64>]  | Pallet: SubtensorModule
-BATCH_SET_WEIGHTS = namedtuple(
-    "BATCH_SET_WEIGHTS", ["wallet", "pallet", "netuids", "weights", "version_keys"]
-)  # args: [netuids: Vec<Compact<NetUid>>, weights: Vec<Vec<(Compact<u16>, Compact<u16>)>>, version_keys: Vec<Compact<u64>>]  | Pallet: SubtensorModule
-BURN = namedtuple(
-    "BURN", ["wallet", "pallet", "value", "keep_alive"]
-)  # args: [value: T::Balance, keep_alive: bool]  | Pallet: Balances
-BURNED_REGISTER = namedtuple(
-    "BURNED_REGISTER", ["wallet", "pallet", "netuid", "hotkey"]
-)  # args: [netuid: NetUid, hotkey: T::AccountId]  | Pallet: SubtensorModule
-BURN_ALPHA = namedtuple(
-    "BURN_ALPHA", ["wallet", "pallet", "hotkey", "amount", "netuid"]
-)  # args: [hotkey: T::AccountId, amount: AlphaCurrency, netuid: NetUid]  | Pallet: SubtensorModule
-CALL = namedtuple(
-    "CALL",
-    ["wallet", "pallet", "dest", "value", "gas_limit", "storage_deposit_limit", "data"],
-)  # args: [dest: AccountIdLookupOf<T>, value: BalanceOf<T>, gas_limit: Weight, storage_deposit_limit: Option<<BalanceOf<T> as codec::HasCompact>::Type>, data: Vec<u8>]  | Pallet: Contracts
-CALL = namedtuple(
-    "CALL",
-    [
-        "wallet",
-        "pallet",
-        "source",
-        "target",
-        "input",
-        "value",
-        "gas_limit",
-        "max_fee_per_gas",
-        "max_priority_fee_per_gas",
-        "nonce",
-        "access_list",
-        "authorization_list",
-    ],
-)  # args: [source: H160, target: H160, input: Vec<u8>, value: U256, gas_limit: u64, max_fee_per_gas: U256, max_priority_fee_per_gas: Option<U256>, nonce: Option<U256>, access_list: Vec<(H160, Vec<H256>)>, authorization_list: AuthorizationList]  | Pallet: EVM
-CALL_OLD_WEIGHT = namedtuple(
-    "CALL_OLD_WEIGHT",
-    ["wallet", "pallet", "dest", "value", "gas_limit", "storage_deposit_limit", "data"],
-)  # args: [dest: AccountIdLookupOf<T>, value: BalanceOf<T>, gas_limit: OldWeight, storage_deposit_limit: Option<<BalanceOf<T> as codec::HasCompact>::Type>, data: Vec<u8>]  | Pallet: Contracts
-CANCEL = namedtuple(
-    "CANCEL", ["wallet", "pallet", "when", "index"]
-)  # args: [when: BlockNumberFor<T>, index: u32]  | Pallet: Scheduler
-CANCEL_AS_MULTI = namedtuple(
-    "CANCEL_AS_MULTI",
-    ["wallet", "pallet", "threshold", "other_signatories", "timepoint", "call_hash"],
-)  # args: [threshold: u16, other_signatories: Vec<T::AccountId>, timepoint: Timepoint<BlockNumberFor<T>>, call_hash: [u8; 32]]  | Pallet: Multisig
-CANCEL_NAMED = namedtuple(
-    "CANCEL_NAMED", ["wallet", "pallet", "id"]
-)  # args: [id: TaskName]  | Pallet: Scheduler
-CANCEL_RETRY = namedtuple(
-    "CANCEL_RETRY", ["wallet", "pallet", "task"]
-)  # args: [task: TaskAddress<BlockNumberFor<T>>]  | Pallet: Scheduler
-CANCEL_RETRY_NAMED = namedtuple(
-    "CANCEL_RETRY_NAMED", ["wallet", "pallet", "id"]
-)  # args: [id: TaskName]  | Pallet: Scheduler
-CLAIM_ROOT = namedtuple(
-    "CLAIM_ROOT", ["wallet", "pallet", "subnets"]
-)  # args: [subnets: BTreeSet<NetUid>]  | Pallet: SubtensorModule
-CLEAR_IDENTITY = namedtuple(
-    "CLEAR_IDENTITY", ["wallet", "pallet", "identified"]
-)  # args: [identified: T::AccountId]  | Pallet: Registry
-COMMIT_CRV3_MECHANISM_WEIGHTS = namedtuple(
-    "COMMIT_CRV3_MECHANISM_WEIGHTS",
-    ["wallet", "pallet", "netuid", "mecid", "commit", "reveal_round"],
-)  # args: [netuid: NetUid, mecid: MechId, commit: BoundedVec<u8, ConstU32<MAX_CRV3_COMMIT_SIZE_BYTES>>, reveal_round: u64]  | Pallet: SubtensorModule
-COMMIT_MECHANISM_WEIGHTS = namedtuple(
-    "COMMIT_MECHANISM_WEIGHTS", ["wallet", "pallet", "netuid", "mecid", "commit_hash"]
-)  # args: [netuid: NetUid, mecid: MechId, commit_hash: H256]  | Pallet: SubtensorModule
-COMMIT_TIMELOCKED_MECHANISM_WEIGHTS = namedtuple(
-    "COMMIT_TIMELOCKED_MECHANISM_WEIGHTS",
-    [
-        "wallet",
-        "pallet",
-        "netuid",
-        "mecid",
-        "commit",
-        "reveal_round",
-        "commit_reveal_version",
-    ],
-)  # args: [netuid: NetUid, mecid: MechId, commit: BoundedVec<u8, ConstU32<MAX_CRV3_COMMIT_SIZE_BYTES>>, reveal_round: u64, commit_reveal_version: u16]  | Pallet: SubtensorModule
-COMMIT_TIMELOCKED_WEIGHTS = namedtuple(
-    "COMMIT_TIMELOCKED_WEIGHTS",
-    ["wallet", "pallet", "netuid", "commit", "reveal_round", "commit_reveal_version"],
-)  # args: [netuid: NetUid, commit: BoundedVec<u8, ConstU32<MAX_CRV3_COMMIT_SIZE_BYTES>>, reveal_round: u64, commit_reveal_version: u16]  | Pallet: SubtensorModule
-COMMIT_WEIGHTS = namedtuple(
-    "COMMIT_WEIGHTS", ["wallet", "pallet", "netuid", "commit_hash"]
-)  # args: [netuid: NetUid, commit_hash: H256]  | Pallet: SubtensorModule
-CONTRIBUTE = namedtuple(
-    "CONTRIBUTE", ["wallet", "pallet", "crowdloan_id", "amount"]
-)  # args: [crowdloan_id: CrowdloanId, amount: BalanceOf<T>]  | Pallet: Crowdloan
-CREATE = namedtuple(
-    "CREATE",
-    [
-        "wallet",
-        "pallet",
-        "deposit",
-        "min_contribution",
-        "cap",
-        "end",
-        "call",
-        "target_address",
-    ],
-)  # args: [deposit: BalanceOf<T>, min_contribution: BalanceOf<T>, cap: BalanceOf<T>, end: BlockNumberFor<T>, call: Option<Box<<T as Config>::RuntimeCall>>, target_address: Option<T::AccountId>]  | Pallet: Crowdloan
-CREATE = namedtuple(
-    "CREATE",
-    [
-        "wallet",
-        "pallet",
-        "source",
-        "init",
-        "value",
-        "gas_limit",
-        "max_fee_per_gas",
-        "max_priority_fee_per_gas",
-        "nonce",
-        "access_list",
-        "authorization_list",
-    ],
-)  # args: [source: H160, init: Vec<u8>, value: U256, gas_limit: u64, max_fee_per_gas: U256, max_priority_fee_per_gas: Option<U256>, nonce: Option<U256>, access_list: Vec<(H160, Vec<H256>)>, authorization_list: AuthorizationList]  | Pallet: EVM
-CREATE2 = namedtuple(
-    "CREATE2",
-    [
-        "wallet",
-        "pallet",
-        "source",
-        "init",
-        "salt",
-        "value",
-        "gas_limit",
-        "max_fee_per_gas",
-        "max_priority_fee_per_gas",
-        "nonce",
-        "access_list",
-        "authorization_list",
-    ],
-)  # args: [source: H160, init: Vec<u8>, salt: H256, value: U256, gas_limit: u64, max_fee_per_gas: U256, max_priority_fee_per_gas: Option<U256>, nonce: Option<U256>, access_list: Vec<(H160, Vec<H256>)>, authorization_list: AuthorizationList]  | Pallet: EVM
-CREATE_PURE = namedtuple(
-    "CREATE_PURE", ["wallet", "pallet", "proxy_type", "delay", "index"]
-)  # args: [proxy_type: T::ProxyType, delay: BlockNumberFor<T>, index: u16]  | Pallet: Proxy
-DECREASE_TAKE = namedtuple(
-    "DECREASE_TAKE", ["wallet", "pallet", "hotkey", "take"]
-)  # args: [hotkey: T::AccountId, take: u16]  | Pallet: SubtensorModule
-DISABLE_LP = namedtuple(
-    "DISABLE_LP",
-    [
-        "wallet",
-        "pallet",
-    ],
-)  # args: []  | Pallet: Swap
-DISABLE_WHITELIST = namedtuple(
-    "DISABLE_WHITELIST", ["wallet", "pallet", "disabled"]
-)  # args: [disabled: bool]  | Pallet: EVM
-DISPATCH_AS = namedtuple(
-    "DISPATCH_AS", ["wallet", "pallet", "as_origin", "call"]
-)  # args: [as_origin: Box<T::PalletsOrigin>, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Utility
-DISPATCH_AS_FALLIBLE = namedtuple(
-    "DISPATCH_AS_FALLIBLE", ["wallet", "pallet", "as_origin", "call"]
-)  # args: [as_origin: Box<T::PalletsOrigin>, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Utility
-DISSOLVE = namedtuple(
-    "DISSOLVE", ["wallet", "pallet", "crowdloan_id"]
-)  # args: [crowdloan_id: CrowdloanId]  | Pallet: Crowdloan
-DISSOLVE_NETWORK = namedtuple(
-    "DISSOLVE_NETWORK", ["wallet", "pallet", "coldkey", "netuid"]
-)  # args: [coldkey: T::AccountId, netuid: NetUid]  | Pallet: SubtensorModule
-ENSURE_UPDATED = namedtuple(
-    "ENSURE_UPDATED", ["wallet", "pallet", "hashes"]
-)  # args: [hashes: Vec<T::Hash>]  | Pallet: Preimage
-ENTER = namedtuple(
-    "ENTER",
-    [
-        "wallet",
-        "pallet",
-    ],
-)  # args: []  | Pallet: SafeMode
-EXTEND = namedtuple(
-    "EXTEND",
-    [
-        "wallet",
-        "pallet",
-    ],
-)  # args: []  | Pallet: SafeMode
-FAUCET = namedtuple(
-    "FAUCET", ["wallet", "pallet", "block_number", "nonce", "work"]
-)  # args: [block_number: u64, nonce: u64, work: Vec<u8>]  | Pallet: SubtensorModule
-FINALIZE = namedtuple(
-    "FINALIZE", ["wallet", "pallet", "crowdloan_id"]
-)  # args: [crowdloan_id: CrowdloanId]  | Pallet: Crowdloan
-FORCE_ADJUST_TOTAL_ISSUANCE = namedtuple(
-    "FORCE_ADJUST_TOTAL_ISSUANCE", ["wallet", "pallet", "direction", "delta"]
-)  # args: [direction: AdjustmentDirection, delta: T::Balance]  | Pallet: Balances
-FORCE_BATCH = namedtuple(
-    "FORCE_BATCH", ["wallet", "pallet", "calls"]
-)  # args: [calls: Vec<<T as Config>::RuntimeCall>]  | Pallet: Utility
-FORCE_ENTER = namedtuple(
-    "FORCE_ENTER",
-    [
-        "wallet",
-        "pallet",
-    ],
-)  # args: []  | Pallet: SafeMode
-FORCE_EXIT = namedtuple(
-    "FORCE_EXIT",
-    [
-        "wallet",
-        "pallet",
-    ],
-)  # args: []  | Pallet: SafeMode
-FORCE_EXTEND = namedtuple(
-    "FORCE_EXTEND",
-    [
-        "wallet",
-        "pallet",
-    ],
-)  # args: []  | Pallet: SafeMode
-FORCE_RELEASE_DEPOSIT = namedtuple(
-    "FORCE_RELEASE_DEPOSIT", ["wallet", "pallet", "account", "block"]
-)  # args: [account: T::AccountId, block: BlockNumberFor<T>]  | Pallet: SafeMode
-FORCE_SET_BALANCE = namedtuple(
-    "FORCE_SET_BALANCE", ["wallet", "pallet", "who", "new_free"]
-)  # args: [who: AccountIdLookupOf<T>, new_free: T::Balance]  | Pallet: Balances
-FORCE_SLASH_DEPOSIT = namedtuple(
-    "FORCE_SLASH_DEPOSIT", ["wallet", "pallet", "account", "block"]
-)  # args: [account: T::AccountId, block: BlockNumberFor<T>]  | Pallet: SafeMode
-FORCE_TRANSFER = namedtuple(
-    "FORCE_TRANSFER", ["wallet", "pallet", "source", "dest", "value"]
-)  # args: [source: AccountIdLookupOf<T>, dest: AccountIdLookupOf<T>, value: T::Balance]  | Pallet: Balances
-FORCE_UNRESERVE = namedtuple(
-    "FORCE_UNRESERVE", ["wallet", "pallet", "who", "amount"]
-)  # args: [who: AccountIdLookupOf<T>, amount: T::Balance]  | Pallet: Balances
-IF_ELSE = namedtuple(
-    "IF_ELSE", ["wallet", "pallet", "main", "fallback"]
-)  # args: [main: Box<<T as Config>::RuntimeCall>, fallback: Box<<T as Config>::RuntimeCall>]  | Pallet: Utility
-INCREASE_TAKE = namedtuple(
-    "INCREASE_TAKE", ["wallet", "pallet", "hotkey", "take"]
-)  # args: [hotkey: T::AccountId, take: u16]  | Pallet: SubtensorModule
-INSTANTIATE = namedtuple(
-    "INSTANTIATE",
-    [
-        "wallet",
-        "pallet",
-        "value",
-        "gas_limit",
-        "storage_deposit_limit",
-        "code_hash",
-        "data",
-        "salt",
-    ],
-)  # args: [value: BalanceOf<T>, gas_limit: Weight, storage_deposit_limit: Option<<BalanceOf<T> as codec::HasCompact>::Type>, code_hash: CodeHash<T>, data: Vec<u8>, salt: Vec<u8>]  | Pallet: Contracts
-INSTANTIATE_OLD_WEIGHT = namedtuple(
-    "INSTANTIATE_OLD_WEIGHT",
-    [
-        "wallet",
-        "pallet",
-        "value",
-        "gas_limit",
-        "storage_deposit_limit",
-        "code_hash",
-        "data",
-        "salt",
-    ],
-)  # args: [value: BalanceOf<T>, gas_limit: OldWeight, storage_deposit_limit: Option<<BalanceOf<T> as codec::HasCompact>::Type>, code_hash: CodeHash<T>, data: Vec<u8>, salt: Vec<u8>]  | Pallet: Contracts
-INSTANTIATE_WITH_CODE = namedtuple(
-    "INSTANTIATE_WITH_CODE",
-    [
-        "wallet",
-        "pallet",
-        "value",
-        "gas_limit",
-        "storage_deposit_limit",
-        "code",
-        "data",
-        "salt",
-    ],
-)  # args: [value: BalanceOf<T>, gas_limit: Weight, storage_deposit_limit: Option<<BalanceOf<T> as codec::HasCompact>::Type>, code: Vec<u8>, data: Vec<u8>, salt: Vec<u8>]  | Pallet: Contracts
-INSTANTIATE_WITH_CODE_OLD_WEIGHT = namedtuple(
-    "INSTANTIATE_WITH_CODE_OLD_WEIGHT",
-    [
-        "wallet",
-        "pallet",
-        "value",
-        "gas_limit",
-        "storage_deposit_limit",
-        "code",
-        "data",
-        "salt",
-    ],
-)  # args: [value: BalanceOf<T>, gas_limit: OldWeight, storage_deposit_limit: Option<<BalanceOf<T> as codec::HasCompact>::Type>, code: Vec<u8>, data: Vec<u8>, salt: Vec<u8>]  | Pallet: Contracts
-KILL_PREFIX = namedtuple(
-    "KILL_PREFIX", ["wallet", "pallet", "prefix", "subkeys"]
-)  # args: [prefix: Key, subkeys: u32]  | Pallet: System
-KILL_PURE = namedtuple(
-    "KILL_PURE",
-    ["wallet", "pallet", "spawner", "proxy_type", "index", "height", "ext_index"],
-)  # args: [spawner: AccountIdLookupOf<T>, proxy_type: T::ProxyType, index: u16, height: BlockNumberFor<T>, ext_index: u32]  | Pallet: Proxy
-KILL_STORAGE = namedtuple(
-    "KILL_STORAGE", ["wallet", "pallet", "keys"]
-)  # args: [keys: Vec<Key>]  | Pallet: System
-MARK_DECRYPTION_FAILED = namedtuple(
-    "MARK_DECRYPTION_FAILED", ["wallet", "pallet", "id", "reason"]
-)  # args: [id: T::Hash, reason: BoundedVec<u8, ConstU32<256>>]  | Pallet: MevShield
-MIGRATE = namedtuple(
-    "MIGRATE", ["wallet", "pallet", "weight_limit"]
-)  # args: [weight_limit: Weight]  | Pallet: Contracts
-MODIFY_POSITION = namedtuple(
-    "MODIFY_POSITION",
-    ["wallet", "pallet", "hotkey", "netuid", "position_id", "liquidity_delta"],
-)  # args: [hotkey: T::AccountId, netuid: NetUid, position_id: PositionId, liquidity_delta: i64]  | Pallet: Swap
-MOVE_STAKE = namedtuple(
-    "MOVE_STAKE",
-    [
-        "wallet",
-        "pallet",
-        "origin_hotkey",
-        "destination_hotkey",
-        "origin_netuid",
-        "destination_netuid",
-        "alpha_amount",
-    ],
-)  # args: [origin_hotkey: T::AccountId, destination_hotkey: T::AccountId, origin_netuid: NetUid, destination_netuid: NetUid, alpha_amount: AlphaCurrency]  | Pallet: SubtensorModule
-NOTE_PREIMAGE = namedtuple(
-    "NOTE_PREIMAGE", ["wallet", "pallet", "bytes"]
-)  # args: [bytes: Vec<u8>]  | Pallet: Preimage
-NOTE_STALLED = namedtuple(
-    "NOTE_STALLED", ["wallet", "pallet", "delay", "best_finalized_block_number"]
-)  # args: [delay: BlockNumberFor<T>, best_finalized_block_number: BlockNumberFor<T>]  | Pallet: Grandpa
-POKE_DEPOSIT = namedtuple(
-    "POKE_DEPOSIT", ["wallet", "pallet", "threshold", "other_signatories", "call_hash"]
-)  # args: [threshold: u16, other_signatories: Vec<T::AccountId>, call_hash: [u8; 32]]  | Pallet: Multisig
-POKE_DEPOSIT = namedtuple(
-    "POKE_DEPOSIT",
-    [
-        "wallet",
-        "pallet",
-    ],
-)  # args: []  | Pallet: Proxy
-PROXY = namedtuple(
-    "PROXY", ["wallet", "pallet", "real", "force_proxy_type", "call"]
-)  # args: [real: AccountIdLookupOf<T>, force_proxy_type: Option<T::ProxyType>, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Proxy
-PROXY_ANNOUNCED = namedtuple(
-    "PROXY_ANNOUNCED",
-    ["wallet", "pallet", "delegate", "real", "force_proxy_type", "call"],
-)  # args: [delegate: AccountIdLookupOf<T>, real: AccountIdLookupOf<T>, force_proxy_type: Option<T::ProxyType>, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Proxy
-RECYCLE_ALPHA = namedtuple(
-    "RECYCLE_ALPHA", ["wallet", "pallet", "hotkey", "amount", "netuid"]
-)  # args: [hotkey: T::AccountId, amount: AlphaCurrency, netuid: NetUid]  | Pallet: SubtensorModule
-REFUND = namedtuple(
-    "REFUND", ["wallet", "pallet", "crowdloan_id"]
-)  # args: [crowdloan_id: CrowdloanId]  | Pallet: Crowdloan
-REGISTER = namedtuple(
-    "REGISTER",
-    [
-        "wallet",
-        "pallet",
-        "netuid",
-        "block_number",
-        "nonce",
-        "work",
-        "hotkey",
-        "coldkey",
-    ],
-)  # args: [netuid: NetUid, block_number: u64, nonce: u64, work: Vec<u8>, hotkey: T::AccountId, coldkey: T::AccountId]  | Pallet: SubtensorModule
-REGISTER_LEASED_NETWORK = namedtuple(
-    "REGISTER_LEASED_NETWORK", ["wallet", "pallet", "emissions_share", "end_block"]
-)  # args: [emissions_share: Percent, end_block: Option<BlockNumberFor<T>>]  | Pallet: SubtensorModule
-REGISTER_NETWORK = namedtuple(
-    "REGISTER_NETWORK", ["wallet", "pallet", "hotkey"]
-)  # args: [hotkey: T::AccountId]  | Pallet: SubtensorModule
-REGISTER_NETWORK_WITH_IDENTITY = namedtuple(
-    "REGISTER_NETWORK_WITH_IDENTITY", ["wallet", "pallet", "hotkey", "identity"]
-)  # args: [hotkey: T::AccountId, identity: Option<SubnetIdentityOfV3>]  | Pallet: SubtensorModule
-REJECT_ANNOUNCEMENT = namedtuple(
-    "REJECT_ANNOUNCEMENT", ["wallet", "pallet", "delegate", "call_hash"]
-)  # args: [delegate: AccountIdLookupOf<T>, call_hash: CallHashOf<T>]  | Pallet: Proxy
-RELEASE_DEPOSIT = namedtuple(
-    "RELEASE_DEPOSIT", ["wallet", "pallet", "account", "block"]
-)  # args: [account: T::AccountId, block: BlockNumberFor<T>]  | Pallet: SafeMode
-REMARK = namedtuple(
-    "REMARK", ["wallet", "pallet", "remark"]
-)  # args: [remark: Vec<u8>]  | Pallet: System
-REMARK_WITH_EVENT = namedtuple(
-    "REMARK_WITH_EVENT", ["wallet", "pallet", "remark"]
-)  # args: [remark: Vec<u8>]  | Pallet: System
-REMOVE_ANNOUNCEMENT = namedtuple(
-    "REMOVE_ANNOUNCEMENT", ["wallet", "pallet", "real", "call_hash"]
-)  # args: [real: AccountIdLookupOf<T>, call_hash: CallHashOf<T>]  | Pallet: Proxy
-REMOVE_CODE = namedtuple(
-    "REMOVE_CODE", ["wallet", "pallet", "code_hash"]
-)  # args: [code_hash: CodeHash<T>]  | Pallet: Contracts
-REMOVE_KEY = namedtuple(
-    "REMOVE_KEY",
-    [
-        "wallet",
-        "pallet",
-    ],
-)  # args: []  | Pallet: Sudo
-REMOVE_LIQUIDITY = namedtuple(
-    "REMOVE_LIQUIDITY", ["wallet", "pallet", "hotkey", "netuid", "position_id"]
-)  # args: [hotkey: T::AccountId, netuid: NetUid, position_id: PositionId]  | Pallet: Swap
-REMOVE_PROXIES = namedtuple(
-    "REMOVE_PROXIES",
-    [
-        "wallet",
-        "pallet",
-    ],
-)  # args: []  | Pallet: Proxy
-REMOVE_PROXY = namedtuple(
-    "REMOVE_PROXY", ["wallet", "pallet", "delegate", "proxy_type", "delay"]
-)  # args: [delegate: AccountIdLookupOf<T>, proxy_type: T::ProxyType, delay: BlockNumberFor<T>]  | Pallet: Proxy
-REMOVE_STAKE = namedtuple(
-    "REMOVE_STAKE", ["wallet", "pallet", "hotkey", "netuid", "amount_unstaked"]
-)  # args: [hotkey: T::AccountId, netuid: NetUid, amount_unstaked: AlphaCurrency]  | Pallet: SubtensorModule
-REMOVE_STAKE_FULL_LIMIT = namedtuple(
-    "REMOVE_STAKE_FULL_LIMIT", ["wallet", "pallet", "hotkey", "netuid", "limit_price"]
-)  # args: [hotkey: T::AccountId, netuid: NetUid, limit_price: Option<TaoCurrency>]  | Pallet: SubtensorModule
-REMOVE_STAKE_LIMIT = namedtuple(
-    "REMOVE_STAKE_LIMIT",
-    [
-        "wallet",
-        "pallet",
-        "hotkey",
-        "netuid",
-        "amount_unstaked",
-        "limit_price",
-        "allow_partial",
-    ],
-)  # args: [hotkey: T::AccountId, netuid: NetUid, amount_unstaked: AlphaCurrency, limit_price: TaoCurrency, allow_partial: bool]  | Pallet: SubtensorModule
-REPORT_EQUIVOCATION = namedtuple(
-    "REPORT_EQUIVOCATION", ["wallet", "pallet", "equivocation_proof", "key_owner_proof"]
-)  # args: [equivocation_proof: Box<EquivocationProof<T::Hash, BlockNumberFor<T>>>, key_owner_proof: T::KeyOwnerProof]  | Pallet: Grandpa
-REPORT_EQUIVOCATION_UNSIGNED = namedtuple(
-    "REPORT_EQUIVOCATION_UNSIGNED",
-    ["wallet", "pallet", "equivocation_proof", "key_owner_proof"],
-)  # args: [equivocation_proof: Box<EquivocationProof<T::Hash, BlockNumberFor<T>>>, key_owner_proof: T::KeyOwnerProof]  | Pallet: Grandpa
-REQUEST_PREIMAGE = namedtuple(
-    "REQUEST_PREIMAGE", ["wallet", "pallet", "hash"]
-)  # args: [hash: T::Hash]  | Pallet: Preimage
-REVEAL_MECHANISM_WEIGHTS = namedtuple(
-    "REVEAL_MECHANISM_WEIGHTS",
-    ["wallet", "pallet", "netuid", "mecid", "uids", "values", "salt", "version_key"],
-)  # args: [netuid: NetUid, mecid: MechId, uids: Vec<u16>, values: Vec<u16>, salt: Vec<u16>, version_key: u64]  | Pallet: SubtensorModule
-REVEAL_WEIGHTS = namedtuple(
-    "REVEAL_WEIGHTS",
-    ["wallet", "pallet", "netuid", "uids", "values", "salt", "version_key"],
-)  # args: [netuid: NetUid, uids: Vec<u16>, values: Vec<u16>, salt: Vec<u16>, version_key: u64]  | Pallet: SubtensorModule
-ROOT_DISSOLVE_NETWORK = namedtuple(
-    "ROOT_DISSOLVE_NETWORK", ["wallet", "pallet", "netuid"]
-)  # args: [netuid: NetUid]  | Pallet: SubtensorModule
-ROOT_REGISTER = namedtuple(
-    "ROOT_REGISTER", ["wallet", "pallet", "hotkey"]
-)  # args: [hotkey: T::AccountId]  | Pallet: SubtensorModule
-SCHEDULE = namedtuple(
-    "SCHEDULE", ["wallet", "pallet", "when", "maybe_periodic", "priority", "call"]
-)  # args: [when: BlockNumberFor<T>, maybe_periodic: Option<schedule::Period<BlockNumberFor<T>>>, priority: schedule::Priority, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Scheduler
-SCHEDULE_AFTER = namedtuple(
-    "SCHEDULE_AFTER",
-    ["wallet", "pallet", "after", "maybe_periodic", "priority", "call"],
-)  # args: [after: BlockNumberFor<T>, maybe_periodic: Option<schedule::Period<BlockNumberFor<T>>>, priority: schedule::Priority, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Scheduler
-SCHEDULE_GRANDPA_CHANGE = namedtuple(
-    "SCHEDULE_GRANDPA_CHANGE",
-    ["wallet", "pallet", "next_authorities", "in_blocks", "forced"],
-)  # args: [next_authorities: AuthorityList, in_blocks: BlockNumberFor<T>, forced: Option<BlockNumberFor<T>>]  | Pallet: AdminUtils
-SCHEDULE_NAMED = namedtuple(
-    "SCHEDULE_NAMED",
-    ["wallet", "pallet", "id", "when", "maybe_periodic", "priority", "call"],
-)  # args: [id: TaskName, when: BlockNumberFor<T>, maybe_periodic: Option<schedule::Period<BlockNumberFor<T>>>, priority: schedule::Priority, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Scheduler
-SCHEDULE_NAMED_AFTER = namedtuple(
-    "SCHEDULE_NAMED_AFTER",
-    ["wallet", "pallet", "id", "after", "maybe_periodic", "priority", "call"],
-)  # args: [id: TaskName, after: BlockNumberFor<T>, maybe_periodic: Option<schedule::Period<BlockNumberFor<T>>>, priority: schedule::Priority, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Scheduler
-SCHEDULE_SWAP_COLDKEY = namedtuple(
-    "SCHEDULE_SWAP_COLDKEY", ["wallet", "pallet", "new_coldkey"]
-)  # args: [new_coldkey: T::AccountId]  | Pallet: SubtensorModule
-SERVE_AXON = namedtuple(
-    "SERVE_AXON",
-    [
-        "wallet",
-        "pallet",
-        "netuid",
-        "version",
-        "ip",
-        "port",
-        "ip_type",
-        "protocol",
-        "placeholder1",
-        "placeholder2",
-    ],
-)  # args: [netuid: NetUid, version: u32, ip: u128, port: u16, ip_type: u8, protocol: u8, placeholder1: u8, placeholder2: u8]  | Pallet: SubtensorModule
-SERVE_AXON_TLS = namedtuple(
-    "SERVE_AXON_TLS",
-    [
-        "wallet",
-        "pallet",
-        "netuid",
-        "version",
-        "ip",
-        "port",
-        "ip_type",
-        "protocol",
-        "placeholder1",
-        "placeholder2",
-        "certificate",
-    ],
-)  # args: [netuid: NetUid, version: u32, ip: u128, port: u16, ip_type: u8, protocol: u8, placeholder1: u8, placeholder2: u8, certificate: Vec<u8>]  | Pallet: SubtensorModule
-SERVE_PROMETHEUS = namedtuple(
-    "SERVE_PROMETHEUS",
-    ["wallet", "pallet", "netuid", "version", "ip", "port", "ip_type"],
-)  # args: [netuid: NetUid, version: u32, ip: u128, port: u16, ip_type: u8]  | Pallet: SubtensorModule
-SET = namedtuple(
-    "SET", ["wallet", "pallet", "now"]
-)  # args: [now: T::Moment]  | Pallet: Timestamp
-SET_BASE_FEE_PER_GAS = namedtuple(
-    "SET_BASE_FEE_PER_GAS", ["wallet", "pallet", "fee"]
-)  # args: [fee: U256]  | Pallet: BaseFee
-SET_BEACON_CONFIG = namedtuple(
-    "SET_BEACON_CONFIG", ["wallet", "pallet", "config_payload", "signature"]
-)  # args: [config_payload: BeaconConfigurationPayload<T::Public, BlockNumberFor<T>>, signature: Option<T::Signature>]  | Pallet: Drand
-SET_CHILDKEY_TAKE = namedtuple(
-    "SET_CHILDKEY_TAKE", ["wallet", "pallet", "hotkey", "netuid", "take"]
-)  # args: [hotkey: T::AccountId, netuid: NetUid, take: u16]  | Pallet: SubtensorModule
-SET_CHILDREN = namedtuple(
-    "SET_CHILDREN", ["wallet", "pallet", "hotkey", "netuid", "children"]
-)  # args: [hotkey: T::AccountId, netuid: NetUid, children: Vec<(u64, T::AccountId)>]  | Pallet: SubtensorModule
-SET_CODE = namedtuple(
-    "SET_CODE", ["wallet", "pallet", "code"]
-)  # args: [code: Vec<u8>]  | Pallet: System
-SET_CODE = namedtuple(
-    "SET_CODE", ["wallet", "pallet", "dest", "code_hash"]
-)  # args: [dest: AccountIdLookupOf<T>, code_hash: CodeHash<T>]  | Pallet: Contracts
-SET_CODE_WITHOUT_CHECKS = namedtuple(
-    "SET_CODE_WITHOUT_CHECKS", ["wallet", "pallet", "code"]
-)  # args: [code: Vec<u8>]  | Pallet: System
-SET_COLDKEY_AUTO_STAKE_HOTKEY = namedtuple(
-    "SET_COLDKEY_AUTO_STAKE_HOTKEY", ["wallet", "pallet", "netuid", "hotkey"]
-)  # args: [netuid: NetUid, hotkey: T::AccountId]  | Pallet: SubtensorModule
-SET_COMMITMENT = namedtuple(
-    "SET_COMMITMENT", ["wallet", "pallet", "netuid", "info"]
-)  # args: [netuid: NetUid, info: Box<CommitmentInfo<T::MaxFields>>]  | Pallet: Commitments
-SET_ELASTICITY = namedtuple(
-    "SET_ELASTICITY", ["wallet", "pallet", "elasticity"]
-)  # args: [elasticity: Permill]  | Pallet: BaseFee
-SET_FEE_RATE = namedtuple(
-    "SET_FEE_RATE", ["wallet", "pallet", "netuid", "rate"]
-)  # args: [netuid: NetUid, rate: u16]  | Pallet: Swap
-SET_HEAP_PAGES = namedtuple(
-    "SET_HEAP_PAGES", ["wallet", "pallet", "pages"]
-)  # args: [pages: u64]  | Pallet: System
-SET_IDENTITY = namedtuple(
-    "SET_IDENTITY", ["wallet", "pallet", "identified", "info"]
-)  # args: [identified: T::AccountId, info: Box<IdentityInfo<T::MaxAdditionalFields>>]  | Pallet: Registry
-SET_IDENTITY = namedtuple(
-    "SET_IDENTITY",
-    [
-        "wallet",
-        "pallet",
-        "name",
-        "url",
-        "github_repo",
-        "image",
-        "discord",
-        "description",
-        "additional",
-    ],
-)  # args: [name: Vec<u8>, url: Vec<u8>, github_repo: Vec<u8>, image: Vec<u8>, discord: Vec<u8>, description: Vec<u8>, additional: Vec<u8>]  | Pallet: SubtensorModule
-SET_KEY = namedtuple(
-    "SET_KEY", ["wallet", "pallet", "new"]
-)  # args: [new: AccountIdLookupOf<T>]  | Pallet: Sudo
-SET_MAX_SPACE = namedtuple(
-    "SET_MAX_SPACE", ["wallet", "pallet", "new_limit"]
-)  # args: [new_limit: u32]  | Pallet: Commitments
-SET_MECHANISM_WEIGHTS = namedtuple(
-    "SET_MECHANISM_WEIGHTS",
-    ["wallet", "pallet", "netuid", "mecid", "dests", "weights", "version_key"],
-)  # args: [netuid: NetUid, mecid: MechId, dests: Vec<u16>, weights: Vec<u16>, version_key: u64]  | Pallet: SubtensorModule
-SET_OLDEST_STORED_ROUND = namedtuple(
-    "SET_OLDEST_STORED_ROUND", ["wallet", "pallet", "oldest_round"]
-)  # args: [oldest_round: u64]  | Pallet: Drand
-SET_PENDING_CHILDKEY_COOLDOWN = namedtuple(
-    "SET_PENDING_CHILDKEY_COOLDOWN", ["wallet", "pallet", "cooldown"]
-)  # args: [cooldown: u64]  | Pallet: SubtensorModule
-SET_RETRY = namedtuple(
-    "SET_RETRY", ["wallet", "pallet", "task", "retries", "period"]
-)  # args: [task: TaskAddress<BlockNumberFor<T>>, retries: u8, period: BlockNumberFor<T>]  | Pallet: Scheduler
-SET_RETRY_NAMED = namedtuple(
-    "SET_RETRY_NAMED", ["wallet", "pallet", "id", "retries", "period"]
-)  # args: [id: TaskName, retries: u8, period: BlockNumberFor<T>]  | Pallet: Scheduler
-SET_ROOT_CLAIM_TYPE = namedtuple(
-    "SET_ROOT_CLAIM_TYPE", ["wallet", "pallet", "new_root_claim_type"]
-)  # args: [new_root_claim_type: RootClaimTypeEnum]  | Pallet: SubtensorModule
-SET_STORAGE = namedtuple(
-    "SET_STORAGE", ["wallet", "pallet", "items"]
-)  # args: [items: Vec<KeyValue>]  | Pallet: System
-SET_SUBNET_IDENTITY = namedtuple(
-    "SET_SUBNET_IDENTITY",
-    [
-        "wallet",
-        "pallet",
-        "netuid",
-        "subnet_name",
-        "github_repo",
-        "subnet_contact",
-        "subnet_url",
-        "discord",
-        "description",
-        "logo_url",
-        "additional",
-    ],
-)  # args: [netuid: NetUid, subnet_name: Vec<u8>, github_repo: Vec<u8>, subnet_contact: Vec<u8>, subnet_url: Vec<u8>, discord: Vec<u8>, description: Vec<u8>, logo_url: Vec<u8>, additional: Vec<u8>]  | Pallet: SubtensorModule
-SET_WEIGHTS = namedtuple(
-    "SET_WEIGHTS", ["wallet", "pallet", "netuid", "dests", "weights", "version_key"]
-)  # args: [netuid: NetUid, dests: Vec<u16>, weights: Vec<u16>, version_key: u64]  | Pallet: SubtensorModule
-SET_WHITELIST = namedtuple(
-    "SET_WHITELIST", ["wallet", "pallet", "new"]
-)  # args: [new: Vec<H160>]  | Pallet: EVM
-START_CALL = namedtuple(
-    "START_CALL", ["wallet", "pallet", "netuid"]
-)  # args: [netuid: NetUid]  | Pallet: SubtensorModule
-SUBMIT_ENCRYPTED = namedtuple(
-    "SUBMIT_ENCRYPTED", ["wallet", "pallet", "commitment", "ciphertext"]
-)  # args: [commitment: T::Hash, ciphertext: BoundedVec<u8, ConstU32<8192>>]  | Pallet: MevShield
-SUDO = namedtuple(
-    "SUDO", ["wallet", "pallet", "call"]
-)  # args: [call: Box<<T as Config>::RuntimeCall>]  | Pallet: Sudo
-SWAP_AUTHORITIES = namedtuple(
-    "SWAP_AUTHORITIES", ["wallet", "pallet", "new_authorities"]
-)  # args: [new_authorities: BoundedVec<<T as Config>::AuthorityId, T::MaxAuthorities>]  | Pallet: AdminUtils
-SWAP_COLDKEY = namedtuple(
-    "SWAP_COLDKEY", ["wallet", "pallet", "old_coldkey", "new_coldkey", "swap_cost"]
-)  # args: [old_coldkey: T::AccountId, new_coldkey: T::AccountId, swap_cost: TaoCurrency]  | Pallet: SubtensorModule
-SWAP_HOTKEY = namedtuple(
-    "SWAP_HOTKEY", ["wallet", "pallet", "hotkey", "new_hotkey", "netuid"]
-)  # args: [hotkey: T::AccountId, new_hotkey: T::AccountId, netuid: Option<NetUid>]  | Pallet: SubtensorModule
-SWAP_STAKE = namedtuple(
-    "SWAP_STAKE",
-    [
-        "wallet",
-        "pallet",
-        "hotkey",
-        "origin_netuid",
-        "destination_netuid",
-        "alpha_amount",
-    ],
-)  # args: [hotkey: T::AccountId, origin_netuid: NetUid, destination_netuid: NetUid, alpha_amount: AlphaCurrency]  | Pallet: SubtensorModule
-SWAP_STAKE_LIMIT = namedtuple(
-    "SWAP_STAKE_LIMIT",
-    [
-        "wallet",
-        "pallet",
-        "hotkey",
-        "origin_netuid",
-        "destination_netuid",
-        "alpha_amount",
-        "limit_price",
-        "allow_partial",
-    ],
-)  # args: [hotkey: T::AccountId, origin_netuid: NetUid, destination_netuid: NetUid, alpha_amount: AlphaCurrency, limit_price: TaoCurrency, allow_partial: bool]  | Pallet: SubtensorModule
-TERMINATE_LEASE = namedtuple(
-    "TERMINATE_LEASE", ["wallet", "pallet", "lease_id", "hotkey"]
-)  # args: [lease_id: LeaseId, hotkey: T::AccountId]  | Pallet: SubtensorModule
-TOGGLE_USER_LIQUIDITY = namedtuple(
-    "TOGGLE_USER_LIQUIDITY", ["wallet", "pallet", "netuid", "enable"]
-)  # args: [netuid: NetUid, enable: bool]  | Pallet: Swap
-TRANSACT = namedtuple(
-    "TRANSACT", ["wallet", "pallet", "transaction"]
-)  # args: [transaction: Transaction]  | Pallet: Ethereum
-TRANSFER_ALL = namedtuple(
-    "TRANSFER_ALL", ["wallet", "pallet", "dest", "keep_alive"]
-)  # args: [dest: AccountIdLookupOf<T>, keep_alive: bool]  | Pallet: Balances
-TRANSFER_ALLOW_DEATH = namedtuple(
-    "TRANSFER_ALLOW_DEATH", ["wallet", "pallet", "dest", "value"]
-)  # args: [dest: AccountIdLookupOf<T>, value: T::Balance]  | Pallet: Balances
-TRANSFER_KEEP_ALIVE = namedtuple(
-    "TRANSFER_KEEP_ALIVE", ["wallet", "pallet", "dest", "value"]
-)  # args: [dest: AccountIdLookupOf<T>, value: T::Balance]  | Pallet: Balances
-TRANSFER_STAKE = namedtuple(
-    "TRANSFER_STAKE",
-    [
-        "wallet",
-        "pallet",
-        "destination_coldkey",
-        "hotkey",
-        "origin_netuid",
-        "destination_netuid",
-        "alpha_amount",
-    ],
-)  # args: [destination_coldkey: T::AccountId, hotkey: T::AccountId, origin_netuid: NetUid, destination_netuid: NetUid, alpha_amount: AlphaCurrency]  | Pallet: SubtensorModule
-TRY_ASSOCIATE_HOTKEY = namedtuple(
-    "TRY_ASSOCIATE_HOTKEY", ["wallet", "pallet", "hotkey"]
-)  # args: [hotkey: T::AccountId]  | Pallet: SubtensorModule
-UNNOTE_PREIMAGE = namedtuple(
-    "UNNOTE_PREIMAGE", ["wallet", "pallet", "hash"]
-)  # args: [hash: T::Hash]  | Pallet: Preimage
-UNREQUEST_PREIMAGE = namedtuple(
-    "UNREQUEST_PREIMAGE", ["wallet", "pallet", "hash"]
-)  # args: [hash: T::Hash]  | Pallet: Preimage
-UNSTAKE_ALL = namedtuple(
-    "UNSTAKE_ALL", ["wallet", "pallet", "hotkey"]
-)  # args: [hotkey: T::AccountId]  | Pallet: SubtensorModule
-UNSTAKE_ALL_ALPHA = namedtuple(
-    "UNSTAKE_ALL_ALPHA", ["wallet", "pallet", "hotkey"]
-)  # args: [hotkey: T::AccountId]  | Pallet: SubtensorModule
-UPDATE_CAP = namedtuple(
-    "UPDATE_CAP", ["wallet", "pallet", "crowdloan_id", "new_cap"]
-)  # args: [crowdloan_id: CrowdloanId, new_cap: BalanceOf<T>]  | Pallet: Crowdloan
-UPDATE_END = namedtuple(
-    "UPDATE_END", ["wallet", "pallet", "crowdloan_id", "new_end"]
-)  # args: [crowdloan_id: CrowdloanId, new_end: BlockNumberFor<T>]  | Pallet: Crowdloan
-UPDATE_MIN_CONTRIBUTION = namedtuple(
-    "UPDATE_MIN_CONTRIBUTION",
-    ["wallet", "pallet", "crowdloan_id", "new_min_contribution"],
-)  # args: [crowdloan_id: CrowdloanId, new_min_contribution: BalanceOf<T>]  | Pallet: Crowdloan
-UPDATE_SYMBOL = namedtuple(
-    "UPDATE_SYMBOL", ["wallet", "pallet", "netuid", "symbol"]
-)  # args: [netuid: NetUid, symbol: Vec<u8>]  | Pallet: SubtensorModule
-UPGRADE_ACCOUNTS = namedtuple(
-    "UPGRADE_ACCOUNTS", ["wallet", "pallet", "who"]
-)  # args: [who: Vec<T::AccountId>]  | Pallet: Balances
-UPLOAD_CODE = namedtuple(
-    "UPLOAD_CODE", ["wallet", "pallet", "code", "storage_deposit_limit", "determinism"]
-)  # args: [code: Vec<u8>, storage_deposit_limit: Option<<BalanceOf<T> as codec::HasCompact>::Type>, determinism: Determinism]  | Pallet: Contracts
-WITHDRAW = namedtuple(
-    "WITHDRAW", ["wallet", "pallet", "address", "value"]
-)  # args: [address: H160, value: BalanceOf<T>]  | Pallet: EVM
-WITHDRAW = namedtuple(
-    "WITHDRAW", ["wallet", "pallet", "crowdloan_id"]
-)  # args: [crowdloan_id: CrowdloanId]  | Pallet: Crowdloan
-WITH_WEIGHT = namedtuple(
-    "WITH_WEIGHT", ["wallet", "pallet", "call", "weight"]
-)  # args: [call: Box<<T as Config>::RuntimeCall>, weight: Weight]  | Pallet: Utility
-WRITE_PULSE = namedtuple(
-    "WRITE_PULSE", ["wallet", "pallet", "pulses_payload", "signature"]
-)  # args: [pulses_payload: PulsesPayload<T::Public, BlockNumberFor<T>>, signature: Option<T::Signature>]  | Pallet: Drand
+ADD_LIQUIDITY = namedtuple("ADD_LIQUIDITY", ["wallet", "pallet", "hotkey", "netuid", "tick_low", "tick_high", "liquidity"])  # args: [hotkey: T::AccountId, netuid: NetUid, tick_low: TickIndex, tick_high: TickIndex, liquidity: u64]  | Pallet: Swap
+ADD_PROXY = namedtuple("ADD_PROXY", ["wallet", "pallet", "delegate", "proxy_type", "delay"])  # args: [delegate: AccountIdLookupOf<T>, proxy_type: T::ProxyType, delay: BlockNumberFor<T>]  | Pallet: Proxy
+ADD_STAKE = namedtuple("ADD_STAKE", ["wallet", "pallet", "hotkey", "netuid", "amount_staked"])  # args: [hotkey: T::AccountId, netuid: NetUid, amount_staked: TaoCurrency]  | Pallet: SubtensorModule
+ADD_STAKE_LIMIT = namedtuple("ADD_STAKE_LIMIT", ["wallet", "pallet", "hotkey", "netuid", "amount_staked", "limit_price", "allow_partial"])  # args: [hotkey: T::AccountId, netuid: NetUid, amount_staked: TaoCurrency, limit_price: TaoCurrency, allow_partial: bool]  | Pallet: SubtensorModule
+ANNOUNCE = namedtuple("ANNOUNCE", ["wallet", "pallet", "real", "call_hash"])  # args: [real: AccountIdLookupOf<T>, call_hash: CallHashOf<T>]  | Pallet: Proxy
+ANNOUNCE_COLDKEY_SWAP = namedtuple("ANNOUNCE_COLDKEY_SWAP", ["wallet", "pallet", "new_coldkey_hash"])  # args: [new_coldkey_hash: T::Hash]  | Pallet: SubtensorModule
+ANNOUNCE_NEXT_KEY = namedtuple("ANNOUNCE_NEXT_KEY", ["wallet", "pallet", "public_key"])  # args: [public_key: BoundedVec<u8, ConstU32<2048>>]  | Pallet: MevShield
+APPLY_AUTHORIZED_UPGRADE = namedtuple("APPLY_AUTHORIZED_UPGRADE", ["wallet", "pallet", "code"])  # args: [code: Vec<u8>]  | Pallet: System
+APPROVE_AS_MULTI = namedtuple("APPROVE_AS_MULTI", ["wallet", "pallet", "threshold", "other_signatories", "maybe_timepoint", "call_hash", "max_weight"])  # args: [threshold: u16, other_signatories: Vec<T::AccountId>, maybe_timepoint: Option<Timepoint<BlockNumberFor<T>>>, call_hash: [u8; 32], max_weight: Weight]  | Pallet: Multisig
+ASSOCIATE_EVM_KEY = namedtuple("ASSOCIATE_EVM_KEY", ["wallet", "pallet", "netuid", "evm_key", "block_number", "signature"])  # args: [netuid: NetUid, evm_key: H160, block_number: u64, signature: Signature]  | Pallet: SubtensorModule
+AS_DERIVATIVE = namedtuple("AS_DERIVATIVE", ["wallet", "pallet", "index", "call"])  # args: [index: u16, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Utility
+AS_MULTI = namedtuple("AS_MULTI", ["wallet", "pallet", "threshold", "other_signatories", "maybe_timepoint", "call", "max_weight"])  # args: [threshold: u16, other_signatories: Vec<T::AccountId>, maybe_timepoint: Option<Timepoint<BlockNumberFor<T>>>, call: Box<<T as Config>::RuntimeCall>, max_weight: Weight]  | Pallet: Multisig
+AS_MULTI_THRESHOLD_1 = namedtuple("AS_MULTI_THRESHOLD_1", ["wallet", "pallet", "other_signatories", "call"])  # args: [other_signatories: Vec<T::AccountId>, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Multisig
+AUTHORIZE_UPGRADE = namedtuple("AUTHORIZE_UPGRADE", ["wallet", "pallet", "code_hash"])  # args: [code_hash: T::Hash]  | Pallet: System
+AUTHORIZE_UPGRADE_WITHOUT_CHECKS = namedtuple("AUTHORIZE_UPGRADE_WITHOUT_CHECKS", ["wallet", "pallet", "code_hash"])  # args: [code_hash: T::Hash]  | Pallet: System
+BATCH = namedtuple("BATCH", ["wallet", "pallet", "calls"])  # args: [calls: Vec<<T as Config>::RuntimeCall>]  | Pallet: Utility
+BATCH_ALL = namedtuple("BATCH_ALL", ["wallet", "pallet", "calls"])  # args: [calls: Vec<<T as Config>::RuntimeCall>]  | Pallet: Utility
+BATCH_COMMIT_WEIGHTS = namedtuple("BATCH_COMMIT_WEIGHTS", ["wallet", "pallet", "netuids", "commit_hashes"])  # args: [netuids: Vec<Compact<NetUid>>, commit_hashes: Vec<H256>]  | Pallet: SubtensorModule
+BATCH_REVEAL_WEIGHTS = namedtuple("BATCH_REVEAL_WEIGHTS", ["wallet", "pallet", "netuid", "uids_list", "values_list", "salts_list", "version_keys"])  # args: [netuid: NetUid, uids_list: Vec<Vec<u16>>, values_list: Vec<Vec<u16>>, salts_list: Vec<Vec<u16>>, version_keys: Vec<u64>]  | Pallet: SubtensorModule
+BATCH_SET_WEIGHTS = namedtuple("BATCH_SET_WEIGHTS", ["wallet", "pallet", "netuids", "weights", "version_keys"])  # args: [netuids: Vec<Compact<NetUid>>, weights: Vec<Vec<(Compact<u16>, Compact<u16>)>>, version_keys: Vec<Compact<u64>>]  | Pallet: SubtensorModule
+BURN = namedtuple("BURN", ["wallet", "pallet", "value", "keep_alive"])  # args: [value: T::Balance, keep_alive: bool]  | Pallet: Balances
+BURNED_REGISTER = namedtuple("BURNED_REGISTER", ["wallet", "pallet", "netuid", "hotkey"])  # args: [netuid: NetUid, hotkey: T::AccountId]  | Pallet: SubtensorModule
+BURN_ALPHA = namedtuple("BURN_ALPHA", ["wallet", "pallet", "hotkey", "amount", "netuid"])  # args: [hotkey: T::AccountId, amount: AlphaCurrency, netuid: NetUid]  | Pallet: SubtensorModule
+CALL = namedtuple("CALL", ["wallet", "pallet", "dest", "value", "gas_limit", "storage_deposit_limit", "data"])  # args: [dest: AccountIdLookupOf<T>, value: BalanceOf<T>, gas_limit: Weight, storage_deposit_limit: Option<<BalanceOf<T> as codec::HasCompact>::Type>, data: Vec<u8>]  | Pallet: Contracts
+CALL = namedtuple("CALL", ["wallet", "pallet", "source", "target", "input", "value", "gas_limit", "max_fee_per_gas", "max_priority_fee_per_gas", "nonce", "access_list", "authorization_list"])  # args: [source: H160, target: H160, input: Vec<u8>, value: U256, gas_limit: u64, max_fee_per_gas: U256, max_priority_fee_per_gas: Option<U256>, nonce: Option<U256>, access_list: Vec<(H160, Vec<H256>)>, authorization_list: AuthorizationList]  | Pallet: EVM
+CALL_OLD_WEIGHT = namedtuple("CALL_OLD_WEIGHT", ["wallet", "pallet", "dest", "value", "gas_limit", "storage_deposit_limit", "data"])  # args: [dest: AccountIdLookupOf<T>, value: BalanceOf<T>, gas_limit: OldWeight, storage_deposit_limit: Option<<BalanceOf<T> as codec::HasCompact>::Type>, data: Vec<u8>]  | Pallet: Contracts
+CANCEL = namedtuple("CANCEL", ["wallet", "pallet", "when", "index"])  # args: [when: BlockNumberFor<T>, index: u32]  | Pallet: Scheduler
+CANCEL_AS_MULTI = namedtuple("CANCEL_AS_MULTI", ["wallet", "pallet", "threshold", "other_signatories", "timepoint", "call_hash"])  # args: [threshold: u16, other_signatories: Vec<T::AccountId>, timepoint: Timepoint<BlockNumberFor<T>>, call_hash: [u8; 32]]  | Pallet: Multisig
+CANCEL_NAMED = namedtuple("CANCEL_NAMED", ["wallet", "pallet", "id"])  # args: [id: TaskName]  | Pallet: Scheduler
+CANCEL_RETRY = namedtuple("CANCEL_RETRY", ["wallet", "pallet", "task"])  # args: [task: TaskAddress<BlockNumberFor<T>>]  | Pallet: Scheduler
+CANCEL_RETRY_NAMED = namedtuple("CANCEL_RETRY_NAMED", ["wallet", "pallet", "id"])  # args: [id: TaskName]  | Pallet: Scheduler
+CLAIM_ROOT = namedtuple("CLAIM_ROOT", ["wallet", "pallet", "subnets"])  # args: [subnets: BTreeSet<NetUid>]  | Pallet: SubtensorModule
+CLEAR_IDENTITY = namedtuple("CLEAR_IDENTITY", ["wallet", "pallet", "identified"])  # args: [identified: T::AccountId]  | Pallet: Registry
+COMMIT_CRV3_MECHANISM_WEIGHTS = namedtuple("COMMIT_CRV3_MECHANISM_WEIGHTS", ["wallet", "pallet", "netuid", "mecid", "commit", "reveal_round"])  # args: [netuid: NetUid, mecid: MechId, commit: BoundedVec<u8, ConstU32<MAX_CRV3_COMMIT_SIZE_BYTES>>, reveal_round: u64]  | Pallet: SubtensorModule
+COMMIT_MECHANISM_WEIGHTS = namedtuple("COMMIT_MECHANISM_WEIGHTS", ["wallet", "pallet", "netuid", "mecid", "commit_hash"])  # args: [netuid: NetUid, mecid: MechId, commit_hash: H256]  | Pallet: SubtensorModule
+COMMIT_TIMELOCKED_MECHANISM_WEIGHTS = namedtuple("COMMIT_TIMELOCKED_MECHANISM_WEIGHTS", ["wallet", "pallet", "netuid", "mecid", "commit", "reveal_round", "commit_reveal_version"])  # args: [netuid: NetUid, mecid: MechId, commit: BoundedVec<u8, ConstU32<MAX_CRV3_COMMIT_SIZE_BYTES>>, reveal_round: u64, commit_reveal_version: u16]  | Pallet: SubtensorModule
+COMMIT_TIMELOCKED_WEIGHTS = namedtuple("COMMIT_TIMELOCKED_WEIGHTS", ["wallet", "pallet", "netuid", "commit", "reveal_round", "commit_reveal_version"])  # args: [netuid: NetUid, commit: BoundedVec<u8, ConstU32<MAX_CRV3_COMMIT_SIZE_BYTES>>, reveal_round: u64, commit_reveal_version: u16]  | Pallet: SubtensorModule
+COMMIT_WEIGHTS = namedtuple("COMMIT_WEIGHTS", ["wallet", "pallet", "netuid", "commit_hash"])  # args: [netuid: NetUid, commit_hash: H256]  | Pallet: SubtensorModule
+CONTRIBUTE = namedtuple("CONTRIBUTE", ["wallet", "pallet", "crowdloan_id", "amount"])  # args: [crowdloan_id: CrowdloanId, amount: BalanceOf<T>]  | Pallet: Crowdloan
+CREATE = namedtuple("CREATE", ["wallet", "pallet", "deposit", "min_contribution", "cap", "end", "call", "target_address"])  # args: [deposit: BalanceOf<T>, min_contribution: BalanceOf<T>, cap: BalanceOf<T>, end: BlockNumberFor<T>, call: Option<Box<<T as Config>::RuntimeCall>>, target_address: Option<T::AccountId>]  | Pallet: Crowdloan
+CREATE = namedtuple("CREATE", ["wallet", "pallet", "source", "init", "value", "gas_limit", "max_fee_per_gas", "max_priority_fee_per_gas", "nonce", "access_list", "authorization_list"])  # args: [source: H160, init: Vec<u8>, value: U256, gas_limit: u64, max_fee_per_gas: U256, max_priority_fee_per_gas: Option<U256>, nonce: Option<U256>, access_list: Vec<(H160, Vec<H256>)>, authorization_list: AuthorizationList]  | Pallet: EVM
+CREATE2 = namedtuple("CREATE2", ["wallet", "pallet", "source", "init", "salt", "value", "gas_limit", "max_fee_per_gas", "max_priority_fee_per_gas", "nonce", "access_list", "authorization_list"])  # args: [source: H160, init: Vec<u8>, salt: H256, value: U256, gas_limit: u64, max_fee_per_gas: U256, max_priority_fee_per_gas: Option<U256>, nonce: Option<U256>, access_list: Vec<(H160, Vec<H256>)>, authorization_list: AuthorizationList]  | Pallet: EVM
+CREATE_PURE = namedtuple("CREATE_PURE", ["wallet", "pallet", "proxy_type", "delay", "index"])  # args: [proxy_type: T::ProxyType, delay: BlockNumberFor<T>, index: u16]  | Pallet: Proxy
+DECREASE_TAKE = namedtuple("DECREASE_TAKE", ["wallet", "pallet", "hotkey", "take"])  # args: [hotkey: T::AccountId, take: u16]  | Pallet: SubtensorModule
+DISABLE_LP = namedtuple("DISABLE_LP", ["wallet", "pallet", ])  # args: []  | Pallet: Swap
+DISABLE_VOTING_POWER_TRACKING = namedtuple("DISABLE_VOTING_POWER_TRACKING", ["wallet", "pallet", "netuid"])  # args: [netuid: NetUid]  | Pallet: SubtensorModule
+DISABLE_WHITELIST = namedtuple("DISABLE_WHITELIST", ["wallet", "pallet", "disabled"])  # args: [disabled: bool]  | Pallet: EVM
+DISPATCH_AS = namedtuple("DISPATCH_AS", ["wallet", "pallet", "as_origin", "call"])  # args: [as_origin: Box<T::PalletsOrigin>, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Utility
+DISPATCH_AS_FALLIBLE = namedtuple("DISPATCH_AS_FALLIBLE", ["wallet", "pallet", "as_origin", "call"])  # args: [as_origin: Box<T::PalletsOrigin>, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Utility
+DISPUTE_COLDKEY_SWAP = namedtuple("DISPUTE_COLDKEY_SWAP", ["wallet", "pallet", ])  # args: []  | Pallet: SubtensorModule
+DISSOLVE = namedtuple("DISSOLVE", ["wallet", "pallet", "crowdloan_id"])  # args: [crowdloan_id: CrowdloanId]  | Pallet: Crowdloan
+DISSOLVE_NETWORK = namedtuple("DISSOLVE_NETWORK", ["wallet", "pallet", "coldkey", "netuid"])  # args: [coldkey: T::AccountId, netuid: NetUid]  | Pallet: SubtensorModule
+ENABLE_VOTING_POWER_TRACKING = namedtuple("ENABLE_VOTING_POWER_TRACKING", ["wallet", "pallet", "netuid"])  # args: [netuid: NetUid]  | Pallet: SubtensorModule
+ENSURE_UPDATED = namedtuple("ENSURE_UPDATED", ["wallet", "pallet", "hashes"])  # args: [hashes: Vec<T::Hash>]  | Pallet: Preimage
+ENTER = namedtuple("ENTER", ["wallet", "pallet", ])  # args: []  | Pallet: SafeMode
+EXTEND = namedtuple("EXTEND", ["wallet", "pallet", ])  # args: []  | Pallet: SafeMode
+FAUCET = namedtuple("FAUCET", ["wallet", "pallet", "block_number", "nonce", "work"])  # args: [block_number: u64, nonce: u64, work: Vec<u8>]  | Pallet: SubtensorModule
+FINALIZE = namedtuple("FINALIZE", ["wallet", "pallet", "crowdloan_id"])  # args: [crowdloan_id: CrowdloanId]  | Pallet: Crowdloan
+FORCE_ADJUST_TOTAL_ISSUANCE = namedtuple("FORCE_ADJUST_TOTAL_ISSUANCE", ["wallet", "pallet", "direction", "delta"])  # args: [direction: AdjustmentDirection, delta: T::Balance]  | Pallet: Balances
+FORCE_BATCH = namedtuple("FORCE_BATCH", ["wallet", "pallet", "calls"])  # args: [calls: Vec<<T as Config>::RuntimeCall>]  | Pallet: Utility
+FORCE_ENTER = namedtuple("FORCE_ENTER", ["wallet", "pallet", ])  # args: []  | Pallet: SafeMode
+FORCE_EXIT = namedtuple("FORCE_EXIT", ["wallet", "pallet", ])  # args: []  | Pallet: SafeMode
+FORCE_EXTEND = namedtuple("FORCE_EXTEND", ["wallet", "pallet", ])  # args: []  | Pallet: SafeMode
+FORCE_RELEASE_DEPOSIT = namedtuple("FORCE_RELEASE_DEPOSIT", ["wallet", "pallet", "account", "block"])  # args: [account: T::AccountId, block: BlockNumberFor<T>]  | Pallet: SafeMode
+FORCE_SET_BALANCE = namedtuple("FORCE_SET_BALANCE", ["wallet", "pallet", "who", "new_free"])  # args: [who: AccountIdLookupOf<T>, new_free: T::Balance]  | Pallet: Balances
+FORCE_SLASH_DEPOSIT = namedtuple("FORCE_SLASH_DEPOSIT", ["wallet", "pallet", "account", "block"])  # args: [account: T::AccountId, block: BlockNumberFor<T>]  | Pallet: SafeMode
+FORCE_TRANSFER = namedtuple("FORCE_TRANSFER", ["wallet", "pallet", "source", "dest", "value"])  # args: [source: AccountIdLookupOf<T>, dest: AccountIdLookupOf<T>, value: T::Balance]  | Pallet: Balances
+FORCE_UNRESERVE = namedtuple("FORCE_UNRESERVE", ["wallet", "pallet", "who", "amount"])  # args: [who: AccountIdLookupOf<T>, amount: T::Balance]  | Pallet: Balances
+IF_ELSE = namedtuple("IF_ELSE", ["wallet", "pallet", "main", "fallback"])  # args: [main: Box<<T as Config>::RuntimeCall>, fallback: Box<<T as Config>::RuntimeCall>]  | Pallet: Utility
+INCREASE_TAKE = namedtuple("INCREASE_TAKE", ["wallet", "pallet", "hotkey", "take"])  # args: [hotkey: T::AccountId, take: u16]  | Pallet: SubtensorModule
+INSTANTIATE = namedtuple("INSTANTIATE", ["wallet", "pallet", "value", "gas_limit", "storage_deposit_limit", "code_hash", "data", "salt"])  # args: [value: BalanceOf<T>, gas_limit: Weight, storage_deposit_limit: Option<<BalanceOf<T> as codec::HasCompact>::Type>, code_hash: CodeHash<T>, data: Vec<u8>, salt: Vec<u8>]  | Pallet: Contracts
+INSTANTIATE_OLD_WEIGHT = namedtuple("INSTANTIATE_OLD_WEIGHT", ["wallet", "pallet", "value", "gas_limit", "storage_deposit_limit", "code_hash", "data", "salt"])  # args: [value: BalanceOf<T>, gas_limit: OldWeight, storage_deposit_limit: Option<<BalanceOf<T> as codec::HasCompact>::Type>, code_hash: CodeHash<T>, data: Vec<u8>, salt: Vec<u8>]  | Pallet: Contracts
+INSTANTIATE_WITH_CODE = namedtuple("INSTANTIATE_WITH_CODE", ["wallet", "pallet", "value", "gas_limit", "storage_deposit_limit", "code", "data", "salt"])  # args: [value: BalanceOf<T>, gas_limit: Weight, storage_deposit_limit: Option<<BalanceOf<T> as codec::HasCompact>::Type>, code: Vec<u8>, data: Vec<u8>, salt: Vec<u8>]  | Pallet: Contracts
+INSTANTIATE_WITH_CODE_OLD_WEIGHT = namedtuple("INSTANTIATE_WITH_CODE_OLD_WEIGHT", ["wallet", "pallet", "value", "gas_limit", "storage_deposit_limit", "code", "data", "salt"])  # args: [value: BalanceOf<T>, gas_limit: OldWeight, storage_deposit_limit: Option<<BalanceOf<T> as codec::HasCompact>::Type>, code: Vec<u8>, data: Vec<u8>, salt: Vec<u8>]  | Pallet: Contracts
+KILL_PREFIX = namedtuple("KILL_PREFIX", ["wallet", "pallet", "prefix", "subkeys"])  # args: [prefix: Key, subkeys: u32]  | Pallet: System
+KILL_PURE = namedtuple("KILL_PURE", ["wallet", "pallet", "spawner", "proxy_type", "index", "height", "ext_index"])  # args: [spawner: AccountIdLookupOf<T>, proxy_type: T::ProxyType, index: u16, height: BlockNumberFor<T>, ext_index: u32]  | Pallet: Proxy
+KILL_STORAGE = namedtuple("KILL_STORAGE", ["wallet", "pallet", "keys"])  # args: [keys: Vec<Key>]  | Pallet: System
+MARK_DECRYPTION_FAILED = namedtuple("MARK_DECRYPTION_FAILED", ["wallet", "pallet", "id", "reason"])  # args: [id: T::Hash, reason: BoundedVec<u8, ConstU32<256>>]  | Pallet: MevShield
+MIGRATE = namedtuple("MIGRATE", ["wallet", "pallet", "weight_limit"])  # args: [weight_limit: Weight]  | Pallet: Contracts
+MODIFY_POSITION = namedtuple("MODIFY_POSITION", ["wallet", "pallet", "hotkey", "netuid", "position_id", "liquidity_delta"])  # args: [hotkey: T::AccountId, netuid: NetUid, position_id: PositionId, liquidity_delta: i64]  | Pallet: Swap
+MOVE_STAKE = namedtuple("MOVE_STAKE", ["wallet", "pallet", "origin_hotkey", "destination_hotkey", "origin_netuid", "destination_netuid", "alpha_amount"])  # args: [origin_hotkey: T::AccountId, destination_hotkey: T::AccountId, origin_netuid: NetUid, destination_netuid: NetUid, alpha_amount: AlphaCurrency]  | Pallet: SubtensorModule
+NOTE_PREIMAGE = namedtuple("NOTE_PREIMAGE", ["wallet", "pallet", "bytes"])  # args: [bytes: Vec<u8>]  | Pallet: Preimage
+NOTE_STALLED = namedtuple("NOTE_STALLED", ["wallet", "pallet", "delay", "best_finalized_block_number"])  # args: [delay: BlockNumberFor<T>, best_finalized_block_number: BlockNumberFor<T>]  | Pallet: Grandpa
+POKE_DEPOSIT = namedtuple("POKE_DEPOSIT", ["wallet", "pallet", "threshold", "other_signatories", "call_hash"])  # args: [threshold: u16, other_signatories: Vec<T::AccountId>, call_hash: [u8; 32]]  | Pallet: Multisig
+POKE_DEPOSIT = namedtuple("POKE_DEPOSIT", ["wallet", "pallet", ])  # args: []  | Pallet: Proxy
+PROXY = namedtuple("PROXY", ["wallet", "pallet", "real", "force_proxy_type", "call"])  # args: [real: AccountIdLookupOf<T>, force_proxy_type: Option<T::ProxyType>, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Proxy
+PROXY_ANNOUNCED = namedtuple("PROXY_ANNOUNCED", ["wallet", "pallet", "delegate", "real", "force_proxy_type", "call"])  # args: [delegate: AccountIdLookupOf<T>, real: AccountIdLookupOf<T>, force_proxy_type: Option<T::ProxyType>, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Proxy
+RECYCLE_ALPHA = namedtuple("RECYCLE_ALPHA", ["wallet", "pallet", "hotkey", "amount", "netuid"])  # args: [hotkey: T::AccountId, amount: AlphaCurrency, netuid: NetUid]  | Pallet: SubtensorModule
+REFUND = namedtuple("REFUND", ["wallet", "pallet", "crowdloan_id"])  # args: [crowdloan_id: CrowdloanId]  | Pallet: Crowdloan
+REGISTER = namedtuple("REGISTER", ["wallet", "pallet", "netuid", "block_number", "nonce", "work", "hotkey", "coldkey"])  # args: [netuid: NetUid, block_number: u64, nonce: u64, work: Vec<u8>, hotkey: T::AccountId, coldkey: T::AccountId]  | Pallet: SubtensorModule
+REGISTER_LEASED_NETWORK = namedtuple("REGISTER_LEASED_NETWORK", ["wallet", "pallet", "emissions_share", "end_block"])  # args: [emissions_share: Percent, end_block: Option<BlockNumberFor<T>>]  | Pallet: SubtensorModule
+REGISTER_NETWORK = namedtuple("REGISTER_NETWORK", ["wallet", "pallet", "hotkey"])  # args: [hotkey: T::AccountId]  | Pallet: SubtensorModule
+REGISTER_NETWORK_WITH_IDENTITY = namedtuple("REGISTER_NETWORK_WITH_IDENTITY", ["wallet", "pallet", "hotkey", "identity"])  # args: [hotkey: T::AccountId, identity: Option<SubnetIdentityOfV3>]  | Pallet: SubtensorModule
+REJECT_ANNOUNCEMENT = namedtuple("REJECT_ANNOUNCEMENT", ["wallet", "pallet", "delegate", "call_hash"])  # args: [delegate: AccountIdLookupOf<T>, call_hash: CallHashOf<T>]  | Pallet: Proxy
+RELEASE_DEPOSIT = namedtuple("RELEASE_DEPOSIT", ["wallet", "pallet", "account", "block"])  # args: [account: T::AccountId, block: BlockNumberFor<T>]  | Pallet: SafeMode
+REMARK = namedtuple("REMARK", ["wallet", "pallet", "remark"])  # args: [remark: Vec<u8>]  | Pallet: System
+REMARK_WITH_EVENT = namedtuple("REMARK_WITH_EVENT", ["wallet", "pallet", "remark"])  # args: [remark: Vec<u8>]  | Pallet: System
+REMOVE_ANNOUNCEMENT = namedtuple("REMOVE_ANNOUNCEMENT", ["wallet", "pallet", "real", "call_hash"])  # args: [real: AccountIdLookupOf<T>, call_hash: CallHashOf<T>]  | Pallet: Proxy
+REMOVE_CODE = namedtuple("REMOVE_CODE", ["wallet", "pallet", "code_hash"])  # args: [code_hash: CodeHash<T>]  | Pallet: Contracts
+REMOVE_KEY = namedtuple("REMOVE_KEY", ["wallet", "pallet", ])  # args: []  | Pallet: Sudo
+REMOVE_LIQUIDITY = namedtuple("REMOVE_LIQUIDITY", ["wallet", "pallet", "hotkey", "netuid", "position_id"])  # args: [hotkey: T::AccountId, netuid: NetUid, position_id: PositionId]  | Pallet: Swap
+REMOVE_PROXIES = namedtuple("REMOVE_PROXIES", ["wallet", "pallet", ])  # args: []  | Pallet: Proxy
+REMOVE_PROXY = namedtuple("REMOVE_PROXY", ["wallet", "pallet", "delegate", "proxy_type", "delay"])  # args: [delegate: AccountIdLookupOf<T>, proxy_type: T::ProxyType, delay: BlockNumberFor<T>]  | Pallet: Proxy
+REMOVE_STAKE = namedtuple("REMOVE_STAKE", ["wallet", "pallet", "hotkey", "netuid", "amount_unstaked"])  # args: [hotkey: T::AccountId, netuid: NetUid, amount_unstaked: AlphaCurrency]  | Pallet: SubtensorModule
+REMOVE_STAKE_FULL_LIMIT = namedtuple("REMOVE_STAKE_FULL_LIMIT", ["wallet", "pallet", "hotkey", "netuid", "limit_price"])  # args: [hotkey: T::AccountId, netuid: NetUid, limit_price: Option<TaoCurrency>]  | Pallet: SubtensorModule
+REMOVE_STAKE_LIMIT = namedtuple("REMOVE_STAKE_LIMIT", ["wallet", "pallet", "hotkey", "netuid", "amount_unstaked", "limit_price", "allow_partial"])  # args: [hotkey: T::AccountId, netuid: NetUid, amount_unstaked: AlphaCurrency, limit_price: TaoCurrency, allow_partial: bool]  | Pallet: SubtensorModule
+REPORT_EQUIVOCATION = namedtuple("REPORT_EQUIVOCATION", ["wallet", "pallet", "equivocation_proof", "key_owner_proof"])  # args: [equivocation_proof: Box<EquivocationProof<T::Hash, BlockNumberFor<T>>>, key_owner_proof: T::KeyOwnerProof]  | Pallet: Grandpa
+REPORT_EQUIVOCATION_UNSIGNED = namedtuple("REPORT_EQUIVOCATION_UNSIGNED", ["wallet", "pallet", "equivocation_proof", "key_owner_proof"])  # args: [equivocation_proof: Box<EquivocationProof<T::Hash, BlockNumberFor<T>>>, key_owner_proof: T::KeyOwnerProof]  | Pallet: Grandpa
+REQUEST_PREIMAGE = namedtuple("REQUEST_PREIMAGE", ["wallet", "pallet", "hash"])  # args: [hash: T::Hash]  | Pallet: Preimage
+RESET_COLDKEY_SWAP = namedtuple("RESET_COLDKEY_SWAP", ["wallet", "pallet", "coldkey"])  # args: [coldkey: T::AccountId]  | Pallet: SubtensorModule
+REVEAL_MECHANISM_WEIGHTS = namedtuple("REVEAL_MECHANISM_WEIGHTS", ["wallet", "pallet", "netuid", "mecid", "uids", "values", "salt", "version_key"])  # args: [netuid: NetUid, mecid: MechId, uids: Vec<u16>, values: Vec<u16>, salt: Vec<u16>, version_key: u64]  | Pallet: SubtensorModule
+REVEAL_WEIGHTS = namedtuple("REVEAL_WEIGHTS", ["wallet", "pallet", "netuid", "uids", "values", "salt", "version_key"])  # args: [netuid: NetUid, uids: Vec<u16>, values: Vec<u16>, salt: Vec<u16>, version_key: u64]  | Pallet: SubtensorModule
+ROOT_DISSOLVE_NETWORK = namedtuple("ROOT_DISSOLVE_NETWORK", ["wallet", "pallet", "netuid"])  # args: [netuid: NetUid]  | Pallet: SubtensorModule
+ROOT_REGISTER = namedtuple("ROOT_REGISTER", ["wallet", "pallet", "hotkey"])  # args: [hotkey: T::AccountId]  | Pallet: SubtensorModule
+SCHEDULE = namedtuple("SCHEDULE", ["wallet", "pallet", "when", "maybe_periodic", "priority", "call"])  # args: [when: BlockNumberFor<T>, maybe_periodic: Option<schedule::Period<BlockNumberFor<T>>>, priority: schedule::Priority, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Scheduler
+SCHEDULE_AFTER = namedtuple("SCHEDULE_AFTER", ["wallet", "pallet", "after", "maybe_periodic", "priority", "call"])  # args: [after: BlockNumberFor<T>, maybe_periodic: Option<schedule::Period<BlockNumberFor<T>>>, priority: schedule::Priority, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Scheduler
+SCHEDULE_GRANDPA_CHANGE = namedtuple("SCHEDULE_GRANDPA_CHANGE", ["wallet", "pallet", "next_authorities", "in_blocks", "forced"])  # args: [next_authorities: AuthorityList, in_blocks: BlockNumberFor<T>, forced: Option<BlockNumberFor<T>>]  | Pallet: AdminUtils
+SCHEDULE_NAMED = namedtuple("SCHEDULE_NAMED", ["wallet", "pallet", "id", "when", "maybe_periodic", "priority", "call"])  # args: [id: TaskName, when: BlockNumberFor<T>, maybe_periodic: Option<schedule::Period<BlockNumberFor<T>>>, priority: schedule::Priority, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Scheduler
+SCHEDULE_NAMED_AFTER = namedtuple("SCHEDULE_NAMED_AFTER", ["wallet", "pallet", "id", "after", "maybe_periodic", "priority", "call"])  # args: [id: TaskName, after: BlockNumberFor<T>, maybe_periodic: Option<schedule::Period<BlockNumberFor<T>>>, priority: schedule::Priority, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Scheduler
+SCHEDULE_SWAP_COLDKEY = namedtuple("SCHEDULE_SWAP_COLDKEY", ["wallet", "pallet", "new_coldkey"])  # args: [new_coldkey: T::AccountId]  | Pallet: SubtensorModule
+SERVE_AXON = namedtuple("SERVE_AXON", ["wallet", "pallet", "netuid", "version", "ip", "port", "ip_type", "protocol", "placeholder1", "placeholder2"])  # args: [netuid: NetUid, version: u32, ip: u128, port: u16, ip_type: u8, protocol: u8, placeholder1: u8, placeholder2: u8]  | Pallet: SubtensorModule
+SERVE_AXON_TLS = namedtuple("SERVE_AXON_TLS", ["wallet", "pallet", "netuid", "version", "ip", "port", "ip_type", "protocol", "placeholder1", "placeholder2", "certificate"])  # args: [netuid: NetUid, version: u32, ip: u128, port: u16, ip_type: u8, protocol: u8, placeholder1: u8, placeholder2: u8, certificate: Vec<u8>]  | Pallet: SubtensorModule
+SERVE_PROMETHEUS = namedtuple("SERVE_PROMETHEUS", ["wallet", "pallet", "netuid", "version", "ip", "port", "ip_type"])  # args: [netuid: NetUid, version: u32, ip: u128, port: u16, ip_type: u8]  | Pallet: SubtensorModule
+SET = namedtuple("SET", ["wallet", "pallet", "now"])  # args: [now: T::Moment]  | Pallet: Timestamp
+SET_BASE_FEE_PER_GAS = namedtuple("SET_BASE_FEE_PER_GAS", ["wallet", "pallet", "fee"])  # args: [fee: U256]  | Pallet: BaseFee
+SET_BEACON_CONFIG = namedtuple("SET_BEACON_CONFIG", ["wallet", "pallet", "config_payload", "signature"])  # args: [config_payload: BeaconConfigurationPayload<T::Public, BlockNumberFor<T>>, signature: Option<T::Signature>]  | Pallet: Drand
+SET_CHILDKEY_TAKE = namedtuple("SET_CHILDKEY_TAKE", ["wallet", "pallet", "hotkey", "netuid", "take"])  # args: [hotkey: T::AccountId, netuid: NetUid, take: u16]  | Pallet: SubtensorModule
+SET_CHILDREN = namedtuple("SET_CHILDREN", ["wallet", "pallet", "hotkey", "netuid", "children"])  # args: [hotkey: T::AccountId, netuid: NetUid, children: Vec<(u64, T::AccountId)>]  | Pallet: SubtensorModule
+SET_CODE = namedtuple("SET_CODE", ["wallet", "pallet", "code"])  # args: [code: Vec<u8>]  | Pallet: System
+SET_CODE = namedtuple("SET_CODE", ["wallet", "pallet", "dest", "code_hash"])  # args: [dest: AccountIdLookupOf<T>, code_hash: CodeHash<T>]  | Pallet: Contracts
+SET_CODE_WITHOUT_CHECKS = namedtuple("SET_CODE_WITHOUT_CHECKS", ["wallet", "pallet", "code"])  # args: [code: Vec<u8>]  | Pallet: System
+SET_COLDKEY_AUTO_STAKE_HOTKEY = namedtuple("SET_COLDKEY_AUTO_STAKE_HOTKEY", ["wallet", "pallet", "netuid", "hotkey"])  # args: [netuid: NetUid, hotkey: T::AccountId]  | Pallet: SubtensorModule
+SET_COMMITMENT = namedtuple("SET_COMMITMENT", ["wallet", "pallet", "netuid", "info"])  # args: [netuid: NetUid, info: Box<CommitmentInfo<T::MaxFields>>]  | Pallet: Commitments
+SET_ELASTICITY = namedtuple("SET_ELASTICITY", ["wallet", "pallet", "elasticity"])  # args: [elasticity: Permill]  | Pallet: BaseFee
+SET_FEE_RATE = namedtuple("SET_FEE_RATE", ["wallet", "pallet", "netuid", "rate"])  # args: [netuid: NetUid, rate: u16]  | Pallet: Swap
+SET_HEAP_PAGES = namedtuple("SET_HEAP_PAGES", ["wallet", "pallet", "pages"])  # args: [pages: u64]  | Pallet: System
+SET_IDENTITY = namedtuple("SET_IDENTITY", ["wallet", "pallet", "identified", "info"])  # args: [identified: T::AccountId, info: Box<IdentityInfo<T::MaxAdditionalFields>>]  | Pallet: Registry
+SET_IDENTITY = namedtuple("SET_IDENTITY", ["wallet", "pallet", "name", "url", "github_repo", "image", "discord", "description", "additional"])  # args: [name: Vec<u8>, url: Vec<u8>, github_repo: Vec<u8>, image: Vec<u8>, discord: Vec<u8>, description: Vec<u8>, additional: Vec<u8>]  | Pallet: SubtensorModule
+SET_KEY = namedtuple("SET_KEY", ["wallet", "pallet", "new"])  # args: [new: AccountIdLookupOf<T>]  | Pallet: Sudo
+SET_MAX_SPACE = namedtuple("SET_MAX_SPACE", ["wallet", "pallet", "new_limit"])  # args: [new_limit: u32]  | Pallet: Commitments
+SET_MECHANISM_WEIGHTS = namedtuple("SET_MECHANISM_WEIGHTS", ["wallet", "pallet", "netuid", "mecid", "dests", "weights", "version_key"])  # args: [netuid: NetUid, mecid: MechId, dests: Vec<u16>, weights: Vec<u16>, version_key: u64]  | Pallet: SubtensorModule
+SET_OLDEST_STORED_ROUND = namedtuple("SET_OLDEST_STORED_ROUND", ["wallet", "pallet", "oldest_round"])  # args: [oldest_round: u64]  | Pallet: Drand
+SET_PENDING_CHILDKEY_COOLDOWN = namedtuple("SET_PENDING_CHILDKEY_COOLDOWN", ["wallet", "pallet", "cooldown"])  # args: [cooldown: u64]  | Pallet: SubtensorModule
+SET_RETRY = namedtuple("SET_RETRY", ["wallet", "pallet", "task", "retries", "period"])  # args: [task: TaskAddress<BlockNumberFor<T>>, retries: u8, period: BlockNumberFor<T>]  | Pallet: Scheduler
+SET_RETRY_NAMED = namedtuple("SET_RETRY_NAMED", ["wallet", "pallet", "id", "retries", "period"])  # args: [id: TaskName, retries: u8, period: BlockNumberFor<T>]  | Pallet: Scheduler
+SET_ROOT_CLAIM_TYPE = namedtuple("SET_ROOT_CLAIM_TYPE", ["wallet", "pallet", "new_root_claim_type"])  # args: [new_root_claim_type: RootClaimTypeEnum]  | Pallet: SubtensorModule
+SET_STORAGE = namedtuple("SET_STORAGE", ["wallet", "pallet", "items"])  # args: [items: Vec<KeyValue>]  | Pallet: System
+SET_SUBNET_IDENTITY = namedtuple("SET_SUBNET_IDENTITY", ["wallet", "pallet", "netuid", "subnet_name", "github_repo", "subnet_contact", "subnet_url", "discord", "description", "logo_url", "additional"])  # args: [netuid: NetUid, subnet_name: Vec<u8>, github_repo: Vec<u8>, subnet_contact: Vec<u8>, subnet_url: Vec<u8>, discord: Vec<u8>, description: Vec<u8>, logo_url: Vec<u8>, additional: Vec<u8>]  | Pallet: SubtensorModule
+SET_WEIGHTS = namedtuple("SET_WEIGHTS", ["wallet", "pallet", "netuid", "dests", "weights", "version_key"])  # args: [netuid: NetUid, dests: Vec<u16>, weights: Vec<u16>, version_key: u64]  | Pallet: SubtensorModule
+SET_WHITELIST = namedtuple("SET_WHITELIST", ["wallet", "pallet", "new"])  # args: [new: Vec<H160>]  | Pallet: EVM
+START_CALL = namedtuple("START_CALL", ["wallet", "pallet", "netuid"])  # args: [netuid: NetUid]  | Pallet: SubtensorModule
+SUBMIT_ENCRYPTED = namedtuple("SUBMIT_ENCRYPTED", ["wallet", "pallet", "commitment", "ciphertext"])  # args: [commitment: T::Hash, ciphertext: BoundedVec<u8, ConstU32<8192>>]  | Pallet: MevShield
+SUBNET_BUYBACK = namedtuple("SUBNET_BUYBACK", ["wallet", "pallet", "hotkey", "netuid", "amount", "limit"])  # args: [hotkey: T::AccountId, netuid: NetUid, amount: TaoCurrency, limit: Option<TaoCurrency>]  | Pallet: SubtensorModule
+SUDO = namedtuple("SUDO", ["wallet", "pallet", "call"])  # args: [call: Box<<T as Config>::RuntimeCall>]  | Pallet: Sudo
+SWAP_AUTHORITIES = namedtuple("SWAP_AUTHORITIES", ["wallet", "pallet", "new_authorities"])  # args: [new_authorities: BoundedVec<<T as Config>::AuthorityId, T::MaxAuthorities>]  | Pallet: AdminUtils
+SWAP_COLDKEY = namedtuple("SWAP_COLDKEY", ["wallet", "pallet", "old_coldkey", "new_coldkey", "swap_cost"])  # args: [old_coldkey: T::AccountId, new_coldkey: T::AccountId, swap_cost: TaoCurrency]  | Pallet: SubtensorModule
+SWAP_COLDKEY_ANNOUNCED = namedtuple("SWAP_COLDKEY_ANNOUNCED", ["wallet", "pallet", "new_coldkey"])  # args: [new_coldkey: T::AccountId]  | Pallet: SubtensorModule
+SWAP_HOTKEY = namedtuple("SWAP_HOTKEY", ["wallet", "pallet", "hotkey", "new_hotkey", "netuid"])  # args: [hotkey: T::AccountId, new_hotkey: T::AccountId, netuid: Option<NetUid>]  | Pallet: SubtensorModule
+SWAP_STAKE = namedtuple("SWAP_STAKE", ["wallet", "pallet", "hotkey", "origin_netuid", "destination_netuid", "alpha_amount"])  # args: [hotkey: T::AccountId, origin_netuid: NetUid, destination_netuid: NetUid, alpha_amount: AlphaCurrency]  | Pallet: SubtensorModule
+SWAP_STAKE_LIMIT = namedtuple("SWAP_STAKE_LIMIT", ["wallet", "pallet", "hotkey", "origin_netuid", "destination_netuid", "alpha_amount", "limit_price", "allow_partial"])  # args: [hotkey: T::AccountId, origin_netuid: NetUid, destination_netuid: NetUid, alpha_amount: AlphaCurrency, limit_price: TaoCurrency, allow_partial: bool]  | Pallet: SubtensorModule
+TERMINATE_LEASE = namedtuple("TERMINATE_LEASE", ["wallet", "pallet", "lease_id", "hotkey"])  # args: [lease_id: LeaseId, hotkey: T::AccountId]  | Pallet: SubtensorModule
+TOGGLE_USER_LIQUIDITY = namedtuple("TOGGLE_USER_LIQUIDITY", ["wallet", "pallet", "netuid", "enable"])  # args: [netuid: NetUid, enable: bool]  | Pallet: Swap
+TRANSACT = namedtuple("TRANSACT", ["wallet", "pallet", "transaction"])  # args: [transaction: Transaction]  | Pallet: Ethereum
+TRANSFER_ALL = namedtuple("TRANSFER_ALL", ["wallet", "pallet", "dest", "keep_alive"])  # args: [dest: AccountIdLookupOf<T>, keep_alive: bool]  | Pallet: Balances
+TRANSFER_ALLOW_DEATH = namedtuple("TRANSFER_ALLOW_DEATH", ["wallet", "pallet", "dest", "value"])  # args: [dest: AccountIdLookupOf<T>, value: T::Balance]  | Pallet: Balances
+TRANSFER_KEEP_ALIVE = namedtuple("TRANSFER_KEEP_ALIVE", ["wallet", "pallet", "dest", "value"])  # args: [dest: AccountIdLookupOf<T>, value: T::Balance]  | Pallet: Balances
+TRANSFER_STAKE = namedtuple("TRANSFER_STAKE", ["wallet", "pallet", "destination_coldkey", "hotkey", "origin_netuid", "destination_netuid", "alpha_amount"])  # args: [destination_coldkey: T::AccountId, hotkey: T::AccountId, origin_netuid: NetUid, destination_netuid: NetUid, alpha_amount: AlphaCurrency]  | Pallet: SubtensorModule
+TRY_ASSOCIATE_HOTKEY = namedtuple("TRY_ASSOCIATE_HOTKEY", ["wallet", "pallet", "hotkey"])  # args: [hotkey: T::AccountId]  | Pallet: SubtensorModule
+UNNOTE_PREIMAGE = namedtuple("UNNOTE_PREIMAGE", ["wallet", "pallet", "hash"])  # args: [hash: T::Hash]  | Pallet: Preimage
+UNREQUEST_PREIMAGE = namedtuple("UNREQUEST_PREIMAGE", ["wallet", "pallet", "hash"])  # args: [hash: T::Hash]  | Pallet: Preimage
+UNSTAKE_ALL = namedtuple("UNSTAKE_ALL", ["wallet", "pallet", "hotkey"])  # args: [hotkey: T::AccountId]  | Pallet: SubtensorModule
+UNSTAKE_ALL_ALPHA = namedtuple("UNSTAKE_ALL_ALPHA", ["wallet", "pallet", "hotkey"])  # args: [hotkey: T::AccountId]  | Pallet: SubtensorModule
+UPDATE_CAP = namedtuple("UPDATE_CAP", ["wallet", "pallet", "crowdloan_id", "new_cap"])  # args: [crowdloan_id: CrowdloanId, new_cap: BalanceOf<T>]  | Pallet: Crowdloan
+UPDATE_END = namedtuple("UPDATE_END", ["wallet", "pallet", "crowdloan_id", "new_end"])  # args: [crowdloan_id: CrowdloanId, new_end: BlockNumberFor<T>]  | Pallet: Crowdloan
+UPDATE_MIN_CONTRIBUTION = namedtuple("UPDATE_MIN_CONTRIBUTION", ["wallet", "pallet", "crowdloan_id", "new_min_contribution"])  # args: [crowdloan_id: CrowdloanId, new_min_contribution: BalanceOf<T>]  | Pallet: Crowdloan
+UPDATE_SYMBOL = namedtuple("UPDATE_SYMBOL", ["wallet", "pallet", "netuid", "symbol"])  # args: [netuid: NetUid, symbol: Vec<u8>]  | Pallet: SubtensorModule
+UPGRADE_ACCOUNTS = namedtuple("UPGRADE_ACCOUNTS", ["wallet", "pallet", "who"])  # args: [who: Vec<T::AccountId>]  | Pallet: Balances
+UPLOAD_CODE = namedtuple("UPLOAD_CODE", ["wallet", "pallet", "code", "storage_deposit_limit", "determinism"])  # args: [code: Vec<u8>, storage_deposit_limit: Option<<BalanceOf<T> as codec::HasCompact>::Type>, determinism: Determinism]  | Pallet: Contracts
+WITHDRAW = namedtuple("WITHDRAW", ["wallet", "pallet", "address", "value"])  # args: [address: H160, value: BalanceOf<T>]  | Pallet: EVM
+WITHDRAW = namedtuple("WITHDRAW", ["wallet", "pallet", "crowdloan_id"])  # args: [crowdloan_id: CrowdloanId]  | Pallet: Crowdloan
+WITH_WEIGHT = namedtuple("WITH_WEIGHT", ["wallet", "pallet", "call", "weight"])  # args: [call: Box<<T as Config>::RuntimeCall>, weight: Weight]  | Pallet: Utility
+WRITE_PULSE = namedtuple("WRITE_PULSE", ["wallet", "pallet", "pulses_payload", "signature"])  # args: [pulses_payload: PulsesPayload<T::Public, BlockNumberFor<T>>, signature: Option<T::Signature>]  | Pallet: Drand

--- a/bittensor/extras/dev_framework/calls/non_sudo_calls.py
+++ b/bittensor/extras/dev_framework/calls/non_sudo_calls.py
@@ -17,185 +17,849 @@ Note:
 from collections import namedtuple
 
 
-ADD_LIQUIDITY = namedtuple("ADD_LIQUIDITY", ["wallet", "pallet", "hotkey", "netuid", "tick_low", "tick_high", "liquidity"])  # args: [hotkey: T::AccountId, netuid: NetUid, tick_low: TickIndex, tick_high: TickIndex, liquidity: u64]  | Pallet: Swap
-ADD_PROXY = namedtuple("ADD_PROXY", ["wallet", "pallet", "delegate", "proxy_type", "delay"])  # args: [delegate: AccountIdLookupOf<T>, proxy_type: T::ProxyType, delay: BlockNumberFor<T>]  | Pallet: Proxy
-ADD_STAKE = namedtuple("ADD_STAKE", ["wallet", "pallet", "hotkey", "netuid", "amount_staked"])  # args: [hotkey: T::AccountId, netuid: NetUid, amount_staked: TaoCurrency]  | Pallet: SubtensorModule
-ADD_STAKE_LIMIT = namedtuple("ADD_STAKE_LIMIT", ["wallet", "pallet", "hotkey", "netuid", "amount_staked", "limit_price", "allow_partial"])  # args: [hotkey: T::AccountId, netuid: NetUid, amount_staked: TaoCurrency, limit_price: TaoCurrency, allow_partial: bool]  | Pallet: SubtensorModule
-ANNOUNCE = namedtuple("ANNOUNCE", ["wallet", "pallet", "real", "call_hash"])  # args: [real: AccountIdLookupOf<T>, call_hash: CallHashOf<T>]  | Pallet: Proxy
-ANNOUNCE_COLDKEY_SWAP = namedtuple("ANNOUNCE_COLDKEY_SWAP", ["wallet", "pallet", "new_coldkey_hash"])  # args: [new_coldkey_hash: T::Hash]  | Pallet: SubtensorModule
-ANNOUNCE_NEXT_KEY = namedtuple("ANNOUNCE_NEXT_KEY", ["wallet", "pallet", "public_key"])  # args: [public_key: BoundedVec<u8, ConstU32<2048>>]  | Pallet: MevShield
-APPLY_AUTHORIZED_UPGRADE = namedtuple("APPLY_AUTHORIZED_UPGRADE", ["wallet", "pallet", "code"])  # args: [code: Vec<u8>]  | Pallet: System
-APPROVE_AS_MULTI = namedtuple("APPROVE_AS_MULTI", ["wallet", "pallet", "threshold", "other_signatories", "maybe_timepoint", "call_hash", "max_weight"])  # args: [threshold: u16, other_signatories: Vec<T::AccountId>, maybe_timepoint: Option<Timepoint<BlockNumberFor<T>>>, call_hash: [u8; 32], max_weight: Weight]  | Pallet: Multisig
-ASSOCIATE_EVM_KEY = namedtuple("ASSOCIATE_EVM_KEY", ["wallet", "pallet", "netuid", "evm_key", "block_number", "signature"])  # args: [netuid: NetUid, evm_key: H160, block_number: u64, signature: Signature]  | Pallet: SubtensorModule
-AS_DERIVATIVE = namedtuple("AS_DERIVATIVE", ["wallet", "pallet", "index", "call"])  # args: [index: u16, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Utility
-AS_MULTI = namedtuple("AS_MULTI", ["wallet", "pallet", "threshold", "other_signatories", "maybe_timepoint", "call", "max_weight"])  # args: [threshold: u16, other_signatories: Vec<T::AccountId>, maybe_timepoint: Option<Timepoint<BlockNumberFor<T>>>, call: Box<<T as Config>::RuntimeCall>, max_weight: Weight]  | Pallet: Multisig
-AS_MULTI_THRESHOLD_1 = namedtuple("AS_MULTI_THRESHOLD_1", ["wallet", "pallet", "other_signatories", "call"])  # args: [other_signatories: Vec<T::AccountId>, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Multisig
-AUTHORIZE_UPGRADE = namedtuple("AUTHORIZE_UPGRADE", ["wallet", "pallet", "code_hash"])  # args: [code_hash: T::Hash]  | Pallet: System
-AUTHORIZE_UPGRADE_WITHOUT_CHECKS = namedtuple("AUTHORIZE_UPGRADE_WITHOUT_CHECKS", ["wallet", "pallet", "code_hash"])  # args: [code_hash: T::Hash]  | Pallet: System
-BATCH = namedtuple("BATCH", ["wallet", "pallet", "calls"])  # args: [calls: Vec<<T as Config>::RuntimeCall>]  | Pallet: Utility
-BATCH_ALL = namedtuple("BATCH_ALL", ["wallet", "pallet", "calls"])  # args: [calls: Vec<<T as Config>::RuntimeCall>]  | Pallet: Utility
-BATCH_COMMIT_WEIGHTS = namedtuple("BATCH_COMMIT_WEIGHTS", ["wallet", "pallet", "netuids", "commit_hashes"])  # args: [netuids: Vec<Compact<NetUid>>, commit_hashes: Vec<H256>]  | Pallet: SubtensorModule
-BATCH_REVEAL_WEIGHTS = namedtuple("BATCH_REVEAL_WEIGHTS", ["wallet", "pallet", "netuid", "uids_list", "values_list", "salts_list", "version_keys"])  # args: [netuid: NetUid, uids_list: Vec<Vec<u16>>, values_list: Vec<Vec<u16>>, salts_list: Vec<Vec<u16>>, version_keys: Vec<u64>]  | Pallet: SubtensorModule
-BATCH_SET_WEIGHTS = namedtuple("BATCH_SET_WEIGHTS", ["wallet", "pallet", "netuids", "weights", "version_keys"])  # args: [netuids: Vec<Compact<NetUid>>, weights: Vec<Vec<(Compact<u16>, Compact<u16>)>>, version_keys: Vec<Compact<u64>>]  | Pallet: SubtensorModule
-BURN = namedtuple("BURN", ["wallet", "pallet", "value", "keep_alive"])  # args: [value: T::Balance, keep_alive: bool]  | Pallet: Balances
-BURNED_REGISTER = namedtuple("BURNED_REGISTER", ["wallet", "pallet", "netuid", "hotkey"])  # args: [netuid: NetUid, hotkey: T::AccountId]  | Pallet: SubtensorModule
-BURN_ALPHA = namedtuple("BURN_ALPHA", ["wallet", "pallet", "hotkey", "amount", "netuid"])  # args: [hotkey: T::AccountId, amount: AlphaCurrency, netuid: NetUid]  | Pallet: SubtensorModule
-CALL = namedtuple("CALL", ["wallet", "pallet", "dest", "value", "gas_limit", "storage_deposit_limit", "data"])  # args: [dest: AccountIdLookupOf<T>, value: BalanceOf<T>, gas_limit: Weight, storage_deposit_limit: Option<<BalanceOf<T> as codec::HasCompact>::Type>, data: Vec<u8>]  | Pallet: Contracts
-CALL = namedtuple("CALL", ["wallet", "pallet", "source", "target", "input", "value", "gas_limit", "max_fee_per_gas", "max_priority_fee_per_gas", "nonce", "access_list", "authorization_list"])  # args: [source: H160, target: H160, input: Vec<u8>, value: U256, gas_limit: u64, max_fee_per_gas: U256, max_priority_fee_per_gas: Option<U256>, nonce: Option<U256>, access_list: Vec<(H160, Vec<H256>)>, authorization_list: AuthorizationList]  | Pallet: EVM
-CALL_OLD_WEIGHT = namedtuple("CALL_OLD_WEIGHT", ["wallet", "pallet", "dest", "value", "gas_limit", "storage_deposit_limit", "data"])  # args: [dest: AccountIdLookupOf<T>, value: BalanceOf<T>, gas_limit: OldWeight, storage_deposit_limit: Option<<BalanceOf<T> as codec::HasCompact>::Type>, data: Vec<u8>]  | Pallet: Contracts
-CANCEL = namedtuple("CANCEL", ["wallet", "pallet", "when", "index"])  # args: [when: BlockNumberFor<T>, index: u32]  | Pallet: Scheduler
-CANCEL_AS_MULTI = namedtuple("CANCEL_AS_MULTI", ["wallet", "pallet", "threshold", "other_signatories", "timepoint", "call_hash"])  # args: [threshold: u16, other_signatories: Vec<T::AccountId>, timepoint: Timepoint<BlockNumberFor<T>>, call_hash: [u8; 32]]  | Pallet: Multisig
-CANCEL_NAMED = namedtuple("CANCEL_NAMED", ["wallet", "pallet", "id"])  # args: [id: TaskName]  | Pallet: Scheduler
-CANCEL_RETRY = namedtuple("CANCEL_RETRY", ["wallet", "pallet", "task"])  # args: [task: TaskAddress<BlockNumberFor<T>>]  | Pallet: Scheduler
-CANCEL_RETRY_NAMED = namedtuple("CANCEL_RETRY_NAMED", ["wallet", "pallet", "id"])  # args: [id: TaskName]  | Pallet: Scheduler
-CLAIM_ROOT = namedtuple("CLAIM_ROOT", ["wallet", "pallet", "subnets"])  # args: [subnets: BTreeSet<NetUid>]  | Pallet: SubtensorModule
-CLEAR_IDENTITY = namedtuple("CLEAR_IDENTITY", ["wallet", "pallet", "identified"])  # args: [identified: T::AccountId]  | Pallet: Registry
-COMMIT_CRV3_MECHANISM_WEIGHTS = namedtuple("COMMIT_CRV3_MECHANISM_WEIGHTS", ["wallet", "pallet", "netuid", "mecid", "commit", "reveal_round"])  # args: [netuid: NetUid, mecid: MechId, commit: BoundedVec<u8, ConstU32<MAX_CRV3_COMMIT_SIZE_BYTES>>, reveal_round: u64]  | Pallet: SubtensorModule
-COMMIT_MECHANISM_WEIGHTS = namedtuple("COMMIT_MECHANISM_WEIGHTS", ["wallet", "pallet", "netuid", "mecid", "commit_hash"])  # args: [netuid: NetUid, mecid: MechId, commit_hash: H256]  | Pallet: SubtensorModule
-COMMIT_TIMELOCKED_MECHANISM_WEIGHTS = namedtuple("COMMIT_TIMELOCKED_MECHANISM_WEIGHTS", ["wallet", "pallet", "netuid", "mecid", "commit", "reveal_round", "commit_reveal_version"])  # args: [netuid: NetUid, mecid: MechId, commit: BoundedVec<u8, ConstU32<MAX_CRV3_COMMIT_SIZE_BYTES>>, reveal_round: u64, commit_reveal_version: u16]  | Pallet: SubtensorModule
-COMMIT_TIMELOCKED_WEIGHTS = namedtuple("COMMIT_TIMELOCKED_WEIGHTS", ["wallet", "pallet", "netuid", "commit", "reveal_round", "commit_reveal_version"])  # args: [netuid: NetUid, commit: BoundedVec<u8, ConstU32<MAX_CRV3_COMMIT_SIZE_BYTES>>, reveal_round: u64, commit_reveal_version: u16]  | Pallet: SubtensorModule
-COMMIT_WEIGHTS = namedtuple("COMMIT_WEIGHTS", ["wallet", "pallet", "netuid", "commit_hash"])  # args: [netuid: NetUid, commit_hash: H256]  | Pallet: SubtensorModule
-CONTRIBUTE = namedtuple("CONTRIBUTE", ["wallet", "pallet", "crowdloan_id", "amount"])  # args: [crowdloan_id: CrowdloanId, amount: BalanceOf<T>]  | Pallet: Crowdloan
-CREATE = namedtuple("CREATE", ["wallet", "pallet", "deposit", "min_contribution", "cap", "end", "call", "target_address"])  # args: [deposit: BalanceOf<T>, min_contribution: BalanceOf<T>, cap: BalanceOf<T>, end: BlockNumberFor<T>, call: Option<Box<<T as Config>::RuntimeCall>>, target_address: Option<T::AccountId>]  | Pallet: Crowdloan
-CREATE = namedtuple("CREATE", ["wallet", "pallet", "source", "init", "value", "gas_limit", "max_fee_per_gas", "max_priority_fee_per_gas", "nonce", "access_list", "authorization_list"])  # args: [source: H160, init: Vec<u8>, value: U256, gas_limit: u64, max_fee_per_gas: U256, max_priority_fee_per_gas: Option<U256>, nonce: Option<U256>, access_list: Vec<(H160, Vec<H256>)>, authorization_list: AuthorizationList]  | Pallet: EVM
-CREATE2 = namedtuple("CREATE2", ["wallet", "pallet", "source", "init", "salt", "value", "gas_limit", "max_fee_per_gas", "max_priority_fee_per_gas", "nonce", "access_list", "authorization_list"])  # args: [source: H160, init: Vec<u8>, salt: H256, value: U256, gas_limit: u64, max_fee_per_gas: U256, max_priority_fee_per_gas: Option<U256>, nonce: Option<U256>, access_list: Vec<(H160, Vec<H256>)>, authorization_list: AuthorizationList]  | Pallet: EVM
-CREATE_PURE = namedtuple("CREATE_PURE", ["wallet", "pallet", "proxy_type", "delay", "index"])  # args: [proxy_type: T::ProxyType, delay: BlockNumberFor<T>, index: u16]  | Pallet: Proxy
-DECREASE_TAKE = namedtuple("DECREASE_TAKE", ["wallet", "pallet", "hotkey", "take"])  # args: [hotkey: T::AccountId, take: u16]  | Pallet: SubtensorModule
-DISABLE_LP = namedtuple("DISABLE_LP", ["wallet", "pallet", ])  # args: []  | Pallet: Swap
-DISABLE_VOTING_POWER_TRACKING = namedtuple("DISABLE_VOTING_POWER_TRACKING", ["wallet", "pallet", "netuid"])  # args: [netuid: NetUid]  | Pallet: SubtensorModule
-DISABLE_WHITELIST = namedtuple("DISABLE_WHITELIST", ["wallet", "pallet", "disabled"])  # args: [disabled: bool]  | Pallet: EVM
-DISPATCH_AS = namedtuple("DISPATCH_AS", ["wallet", "pallet", "as_origin", "call"])  # args: [as_origin: Box<T::PalletsOrigin>, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Utility
-DISPATCH_AS_FALLIBLE = namedtuple("DISPATCH_AS_FALLIBLE", ["wallet", "pallet", "as_origin", "call"])  # args: [as_origin: Box<T::PalletsOrigin>, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Utility
-DISPUTE_COLDKEY_SWAP = namedtuple("DISPUTE_COLDKEY_SWAP", ["wallet", "pallet", ])  # args: []  | Pallet: SubtensorModule
-DISSOLVE = namedtuple("DISSOLVE", ["wallet", "pallet", "crowdloan_id"])  # args: [crowdloan_id: CrowdloanId]  | Pallet: Crowdloan
-DISSOLVE_NETWORK = namedtuple("DISSOLVE_NETWORK", ["wallet", "pallet", "coldkey", "netuid"])  # args: [coldkey: T::AccountId, netuid: NetUid]  | Pallet: SubtensorModule
-ENABLE_VOTING_POWER_TRACKING = namedtuple("ENABLE_VOTING_POWER_TRACKING", ["wallet", "pallet", "netuid"])  # args: [netuid: NetUid]  | Pallet: SubtensorModule
-ENSURE_UPDATED = namedtuple("ENSURE_UPDATED", ["wallet", "pallet", "hashes"])  # args: [hashes: Vec<T::Hash>]  | Pallet: Preimage
-ENTER = namedtuple("ENTER", ["wallet", "pallet", ])  # args: []  | Pallet: SafeMode
-EXTEND = namedtuple("EXTEND", ["wallet", "pallet", ])  # args: []  | Pallet: SafeMode
-FAUCET = namedtuple("FAUCET", ["wallet", "pallet", "block_number", "nonce", "work"])  # args: [block_number: u64, nonce: u64, work: Vec<u8>]  | Pallet: SubtensorModule
-FINALIZE = namedtuple("FINALIZE", ["wallet", "pallet", "crowdloan_id"])  # args: [crowdloan_id: CrowdloanId]  | Pallet: Crowdloan
-FORCE_ADJUST_TOTAL_ISSUANCE = namedtuple("FORCE_ADJUST_TOTAL_ISSUANCE", ["wallet", "pallet", "direction", "delta"])  # args: [direction: AdjustmentDirection, delta: T::Balance]  | Pallet: Balances
-FORCE_BATCH = namedtuple("FORCE_BATCH", ["wallet", "pallet", "calls"])  # args: [calls: Vec<<T as Config>::RuntimeCall>]  | Pallet: Utility
-FORCE_ENTER = namedtuple("FORCE_ENTER", ["wallet", "pallet", ])  # args: []  | Pallet: SafeMode
-FORCE_EXIT = namedtuple("FORCE_EXIT", ["wallet", "pallet", ])  # args: []  | Pallet: SafeMode
-FORCE_EXTEND = namedtuple("FORCE_EXTEND", ["wallet", "pallet", ])  # args: []  | Pallet: SafeMode
-FORCE_RELEASE_DEPOSIT = namedtuple("FORCE_RELEASE_DEPOSIT", ["wallet", "pallet", "account", "block"])  # args: [account: T::AccountId, block: BlockNumberFor<T>]  | Pallet: SafeMode
-FORCE_SET_BALANCE = namedtuple("FORCE_SET_BALANCE", ["wallet", "pallet", "who", "new_free"])  # args: [who: AccountIdLookupOf<T>, new_free: T::Balance]  | Pallet: Balances
-FORCE_SLASH_DEPOSIT = namedtuple("FORCE_SLASH_DEPOSIT", ["wallet", "pallet", "account", "block"])  # args: [account: T::AccountId, block: BlockNumberFor<T>]  | Pallet: SafeMode
-FORCE_TRANSFER = namedtuple("FORCE_TRANSFER", ["wallet", "pallet", "source", "dest", "value"])  # args: [source: AccountIdLookupOf<T>, dest: AccountIdLookupOf<T>, value: T::Balance]  | Pallet: Balances
-FORCE_UNRESERVE = namedtuple("FORCE_UNRESERVE", ["wallet", "pallet", "who", "amount"])  # args: [who: AccountIdLookupOf<T>, amount: T::Balance]  | Pallet: Balances
-IF_ELSE = namedtuple("IF_ELSE", ["wallet", "pallet", "main", "fallback"])  # args: [main: Box<<T as Config>::RuntimeCall>, fallback: Box<<T as Config>::RuntimeCall>]  | Pallet: Utility
-INCREASE_TAKE = namedtuple("INCREASE_TAKE", ["wallet", "pallet", "hotkey", "take"])  # args: [hotkey: T::AccountId, take: u16]  | Pallet: SubtensorModule
-INSTANTIATE = namedtuple("INSTANTIATE", ["wallet", "pallet", "value", "gas_limit", "storage_deposit_limit", "code_hash", "data", "salt"])  # args: [value: BalanceOf<T>, gas_limit: Weight, storage_deposit_limit: Option<<BalanceOf<T> as codec::HasCompact>::Type>, code_hash: CodeHash<T>, data: Vec<u8>, salt: Vec<u8>]  | Pallet: Contracts
-INSTANTIATE_OLD_WEIGHT = namedtuple("INSTANTIATE_OLD_WEIGHT", ["wallet", "pallet", "value", "gas_limit", "storage_deposit_limit", "code_hash", "data", "salt"])  # args: [value: BalanceOf<T>, gas_limit: OldWeight, storage_deposit_limit: Option<<BalanceOf<T> as codec::HasCompact>::Type>, code_hash: CodeHash<T>, data: Vec<u8>, salt: Vec<u8>]  | Pallet: Contracts
-INSTANTIATE_WITH_CODE = namedtuple("INSTANTIATE_WITH_CODE", ["wallet", "pallet", "value", "gas_limit", "storage_deposit_limit", "code", "data", "salt"])  # args: [value: BalanceOf<T>, gas_limit: Weight, storage_deposit_limit: Option<<BalanceOf<T> as codec::HasCompact>::Type>, code: Vec<u8>, data: Vec<u8>, salt: Vec<u8>]  | Pallet: Contracts
-INSTANTIATE_WITH_CODE_OLD_WEIGHT = namedtuple("INSTANTIATE_WITH_CODE_OLD_WEIGHT", ["wallet", "pallet", "value", "gas_limit", "storage_deposit_limit", "code", "data", "salt"])  # args: [value: BalanceOf<T>, gas_limit: OldWeight, storage_deposit_limit: Option<<BalanceOf<T> as codec::HasCompact>::Type>, code: Vec<u8>, data: Vec<u8>, salt: Vec<u8>]  | Pallet: Contracts
-KILL_PREFIX = namedtuple("KILL_PREFIX", ["wallet", "pallet", "prefix", "subkeys"])  # args: [prefix: Key, subkeys: u32]  | Pallet: System
-KILL_PURE = namedtuple("KILL_PURE", ["wallet", "pallet", "spawner", "proxy_type", "index", "height", "ext_index"])  # args: [spawner: AccountIdLookupOf<T>, proxy_type: T::ProxyType, index: u16, height: BlockNumberFor<T>, ext_index: u32]  | Pallet: Proxy
-KILL_STORAGE = namedtuple("KILL_STORAGE", ["wallet", "pallet", "keys"])  # args: [keys: Vec<Key>]  | Pallet: System
-MARK_DECRYPTION_FAILED = namedtuple("MARK_DECRYPTION_FAILED", ["wallet", "pallet", "id", "reason"])  # args: [id: T::Hash, reason: BoundedVec<u8, ConstU32<256>>]  | Pallet: MevShield
-MIGRATE = namedtuple("MIGRATE", ["wallet", "pallet", "weight_limit"])  # args: [weight_limit: Weight]  | Pallet: Contracts
-MODIFY_POSITION = namedtuple("MODIFY_POSITION", ["wallet", "pallet", "hotkey", "netuid", "position_id", "liquidity_delta"])  # args: [hotkey: T::AccountId, netuid: NetUid, position_id: PositionId, liquidity_delta: i64]  | Pallet: Swap
-MOVE_STAKE = namedtuple("MOVE_STAKE", ["wallet", "pallet", "origin_hotkey", "destination_hotkey", "origin_netuid", "destination_netuid", "alpha_amount"])  # args: [origin_hotkey: T::AccountId, destination_hotkey: T::AccountId, origin_netuid: NetUid, destination_netuid: NetUid, alpha_amount: AlphaCurrency]  | Pallet: SubtensorModule
-NOTE_PREIMAGE = namedtuple("NOTE_PREIMAGE", ["wallet", "pallet", "bytes"])  # args: [bytes: Vec<u8>]  | Pallet: Preimage
-NOTE_STALLED = namedtuple("NOTE_STALLED", ["wallet", "pallet", "delay", "best_finalized_block_number"])  # args: [delay: BlockNumberFor<T>, best_finalized_block_number: BlockNumberFor<T>]  | Pallet: Grandpa
-POKE_DEPOSIT = namedtuple("POKE_DEPOSIT", ["wallet", "pallet", "threshold", "other_signatories", "call_hash"])  # args: [threshold: u16, other_signatories: Vec<T::AccountId>, call_hash: [u8; 32]]  | Pallet: Multisig
-POKE_DEPOSIT = namedtuple("POKE_DEPOSIT", ["wallet", "pallet", ])  # args: []  | Pallet: Proxy
-PROXY = namedtuple("PROXY", ["wallet", "pallet", "real", "force_proxy_type", "call"])  # args: [real: AccountIdLookupOf<T>, force_proxy_type: Option<T::ProxyType>, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Proxy
-PROXY_ANNOUNCED = namedtuple("PROXY_ANNOUNCED", ["wallet", "pallet", "delegate", "real", "force_proxy_type", "call"])  # args: [delegate: AccountIdLookupOf<T>, real: AccountIdLookupOf<T>, force_proxy_type: Option<T::ProxyType>, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Proxy
-RECYCLE_ALPHA = namedtuple("RECYCLE_ALPHA", ["wallet", "pallet", "hotkey", "amount", "netuid"])  # args: [hotkey: T::AccountId, amount: AlphaCurrency, netuid: NetUid]  | Pallet: SubtensorModule
-REFUND = namedtuple("REFUND", ["wallet", "pallet", "crowdloan_id"])  # args: [crowdloan_id: CrowdloanId]  | Pallet: Crowdloan
-REGISTER = namedtuple("REGISTER", ["wallet", "pallet", "netuid", "block_number", "nonce", "work", "hotkey", "coldkey"])  # args: [netuid: NetUid, block_number: u64, nonce: u64, work: Vec<u8>, hotkey: T::AccountId, coldkey: T::AccountId]  | Pallet: SubtensorModule
-REGISTER_LEASED_NETWORK = namedtuple("REGISTER_LEASED_NETWORK", ["wallet", "pallet", "emissions_share", "end_block"])  # args: [emissions_share: Percent, end_block: Option<BlockNumberFor<T>>]  | Pallet: SubtensorModule
-REGISTER_NETWORK = namedtuple("REGISTER_NETWORK", ["wallet", "pallet", "hotkey"])  # args: [hotkey: T::AccountId]  | Pallet: SubtensorModule
-REGISTER_NETWORK_WITH_IDENTITY = namedtuple("REGISTER_NETWORK_WITH_IDENTITY", ["wallet", "pallet", "hotkey", "identity"])  # args: [hotkey: T::AccountId, identity: Option<SubnetIdentityOfV3>]  | Pallet: SubtensorModule
-REJECT_ANNOUNCEMENT = namedtuple("REJECT_ANNOUNCEMENT", ["wallet", "pallet", "delegate", "call_hash"])  # args: [delegate: AccountIdLookupOf<T>, call_hash: CallHashOf<T>]  | Pallet: Proxy
-RELEASE_DEPOSIT = namedtuple("RELEASE_DEPOSIT", ["wallet", "pallet", "account", "block"])  # args: [account: T::AccountId, block: BlockNumberFor<T>]  | Pallet: SafeMode
-REMARK = namedtuple("REMARK", ["wallet", "pallet", "remark"])  # args: [remark: Vec<u8>]  | Pallet: System
-REMARK_WITH_EVENT = namedtuple("REMARK_WITH_EVENT", ["wallet", "pallet", "remark"])  # args: [remark: Vec<u8>]  | Pallet: System
-REMOVE_ANNOUNCEMENT = namedtuple("REMOVE_ANNOUNCEMENT", ["wallet", "pallet", "real", "call_hash"])  # args: [real: AccountIdLookupOf<T>, call_hash: CallHashOf<T>]  | Pallet: Proxy
-REMOVE_CODE = namedtuple("REMOVE_CODE", ["wallet", "pallet", "code_hash"])  # args: [code_hash: CodeHash<T>]  | Pallet: Contracts
-REMOVE_KEY = namedtuple("REMOVE_KEY", ["wallet", "pallet", ])  # args: []  | Pallet: Sudo
-REMOVE_LIQUIDITY = namedtuple("REMOVE_LIQUIDITY", ["wallet", "pallet", "hotkey", "netuid", "position_id"])  # args: [hotkey: T::AccountId, netuid: NetUid, position_id: PositionId]  | Pallet: Swap
-REMOVE_PROXIES = namedtuple("REMOVE_PROXIES", ["wallet", "pallet", ])  # args: []  | Pallet: Proxy
-REMOVE_PROXY = namedtuple("REMOVE_PROXY", ["wallet", "pallet", "delegate", "proxy_type", "delay"])  # args: [delegate: AccountIdLookupOf<T>, proxy_type: T::ProxyType, delay: BlockNumberFor<T>]  | Pallet: Proxy
-REMOVE_STAKE = namedtuple("REMOVE_STAKE", ["wallet", "pallet", "hotkey", "netuid", "amount_unstaked"])  # args: [hotkey: T::AccountId, netuid: NetUid, amount_unstaked: AlphaCurrency]  | Pallet: SubtensorModule
-REMOVE_STAKE_FULL_LIMIT = namedtuple("REMOVE_STAKE_FULL_LIMIT", ["wallet", "pallet", "hotkey", "netuid", "limit_price"])  # args: [hotkey: T::AccountId, netuid: NetUid, limit_price: Option<TaoCurrency>]  | Pallet: SubtensorModule
-REMOVE_STAKE_LIMIT = namedtuple("REMOVE_STAKE_LIMIT", ["wallet", "pallet", "hotkey", "netuid", "amount_unstaked", "limit_price", "allow_partial"])  # args: [hotkey: T::AccountId, netuid: NetUid, amount_unstaked: AlphaCurrency, limit_price: TaoCurrency, allow_partial: bool]  | Pallet: SubtensorModule
-REPORT_EQUIVOCATION = namedtuple("REPORT_EQUIVOCATION", ["wallet", "pallet", "equivocation_proof", "key_owner_proof"])  # args: [equivocation_proof: Box<EquivocationProof<T::Hash, BlockNumberFor<T>>>, key_owner_proof: T::KeyOwnerProof]  | Pallet: Grandpa
-REPORT_EQUIVOCATION_UNSIGNED = namedtuple("REPORT_EQUIVOCATION_UNSIGNED", ["wallet", "pallet", "equivocation_proof", "key_owner_proof"])  # args: [equivocation_proof: Box<EquivocationProof<T::Hash, BlockNumberFor<T>>>, key_owner_proof: T::KeyOwnerProof]  | Pallet: Grandpa
-REQUEST_PREIMAGE = namedtuple("REQUEST_PREIMAGE", ["wallet", "pallet", "hash"])  # args: [hash: T::Hash]  | Pallet: Preimage
-RESET_COLDKEY_SWAP = namedtuple("RESET_COLDKEY_SWAP", ["wallet", "pallet", "coldkey"])  # args: [coldkey: T::AccountId]  | Pallet: SubtensorModule
-REVEAL_MECHANISM_WEIGHTS = namedtuple("REVEAL_MECHANISM_WEIGHTS", ["wallet", "pallet", "netuid", "mecid", "uids", "values", "salt", "version_key"])  # args: [netuid: NetUid, mecid: MechId, uids: Vec<u16>, values: Vec<u16>, salt: Vec<u16>, version_key: u64]  | Pallet: SubtensorModule
-REVEAL_WEIGHTS = namedtuple("REVEAL_WEIGHTS", ["wallet", "pallet", "netuid", "uids", "values", "salt", "version_key"])  # args: [netuid: NetUid, uids: Vec<u16>, values: Vec<u16>, salt: Vec<u16>, version_key: u64]  | Pallet: SubtensorModule
-ROOT_DISSOLVE_NETWORK = namedtuple("ROOT_DISSOLVE_NETWORK", ["wallet", "pallet", "netuid"])  # args: [netuid: NetUid]  | Pallet: SubtensorModule
-ROOT_REGISTER = namedtuple("ROOT_REGISTER", ["wallet", "pallet", "hotkey"])  # args: [hotkey: T::AccountId]  | Pallet: SubtensorModule
-SCHEDULE = namedtuple("SCHEDULE", ["wallet", "pallet", "when", "maybe_periodic", "priority", "call"])  # args: [when: BlockNumberFor<T>, maybe_periodic: Option<schedule::Period<BlockNumberFor<T>>>, priority: schedule::Priority, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Scheduler
-SCHEDULE_AFTER = namedtuple("SCHEDULE_AFTER", ["wallet", "pallet", "after", "maybe_periodic", "priority", "call"])  # args: [after: BlockNumberFor<T>, maybe_periodic: Option<schedule::Period<BlockNumberFor<T>>>, priority: schedule::Priority, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Scheduler
-SCHEDULE_GRANDPA_CHANGE = namedtuple("SCHEDULE_GRANDPA_CHANGE", ["wallet", "pallet", "next_authorities", "in_blocks", "forced"])  # args: [next_authorities: AuthorityList, in_blocks: BlockNumberFor<T>, forced: Option<BlockNumberFor<T>>]  | Pallet: AdminUtils
-SCHEDULE_NAMED = namedtuple("SCHEDULE_NAMED", ["wallet", "pallet", "id", "when", "maybe_periodic", "priority", "call"])  # args: [id: TaskName, when: BlockNumberFor<T>, maybe_periodic: Option<schedule::Period<BlockNumberFor<T>>>, priority: schedule::Priority, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Scheduler
-SCHEDULE_NAMED_AFTER = namedtuple("SCHEDULE_NAMED_AFTER", ["wallet", "pallet", "id", "after", "maybe_periodic", "priority", "call"])  # args: [id: TaskName, after: BlockNumberFor<T>, maybe_periodic: Option<schedule::Period<BlockNumberFor<T>>>, priority: schedule::Priority, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Scheduler
-SCHEDULE_SWAP_COLDKEY = namedtuple("SCHEDULE_SWAP_COLDKEY", ["wallet", "pallet", "new_coldkey"])  # args: [new_coldkey: T::AccountId]  | Pallet: SubtensorModule
-SERVE_AXON = namedtuple("SERVE_AXON", ["wallet", "pallet", "netuid", "version", "ip", "port", "ip_type", "protocol", "placeholder1", "placeholder2"])  # args: [netuid: NetUid, version: u32, ip: u128, port: u16, ip_type: u8, protocol: u8, placeholder1: u8, placeholder2: u8]  | Pallet: SubtensorModule
-SERVE_AXON_TLS = namedtuple("SERVE_AXON_TLS", ["wallet", "pallet", "netuid", "version", "ip", "port", "ip_type", "protocol", "placeholder1", "placeholder2", "certificate"])  # args: [netuid: NetUid, version: u32, ip: u128, port: u16, ip_type: u8, protocol: u8, placeholder1: u8, placeholder2: u8, certificate: Vec<u8>]  | Pallet: SubtensorModule
-SERVE_PROMETHEUS = namedtuple("SERVE_PROMETHEUS", ["wallet", "pallet", "netuid", "version", "ip", "port", "ip_type"])  # args: [netuid: NetUid, version: u32, ip: u128, port: u16, ip_type: u8]  | Pallet: SubtensorModule
-SET = namedtuple("SET", ["wallet", "pallet", "now"])  # args: [now: T::Moment]  | Pallet: Timestamp
-SET_BASE_FEE_PER_GAS = namedtuple("SET_BASE_FEE_PER_GAS", ["wallet", "pallet", "fee"])  # args: [fee: U256]  | Pallet: BaseFee
-SET_BEACON_CONFIG = namedtuple("SET_BEACON_CONFIG", ["wallet", "pallet", "config_payload", "signature"])  # args: [config_payload: BeaconConfigurationPayload<T::Public, BlockNumberFor<T>>, signature: Option<T::Signature>]  | Pallet: Drand
-SET_CHILDKEY_TAKE = namedtuple("SET_CHILDKEY_TAKE", ["wallet", "pallet", "hotkey", "netuid", "take"])  # args: [hotkey: T::AccountId, netuid: NetUid, take: u16]  | Pallet: SubtensorModule
-SET_CHILDREN = namedtuple("SET_CHILDREN", ["wallet", "pallet", "hotkey", "netuid", "children"])  # args: [hotkey: T::AccountId, netuid: NetUid, children: Vec<(u64, T::AccountId)>]  | Pallet: SubtensorModule
-SET_CODE = namedtuple("SET_CODE", ["wallet", "pallet", "code"])  # args: [code: Vec<u8>]  | Pallet: System
-SET_CODE = namedtuple("SET_CODE", ["wallet", "pallet", "dest", "code_hash"])  # args: [dest: AccountIdLookupOf<T>, code_hash: CodeHash<T>]  | Pallet: Contracts
-SET_CODE_WITHOUT_CHECKS = namedtuple("SET_CODE_WITHOUT_CHECKS", ["wallet", "pallet", "code"])  # args: [code: Vec<u8>]  | Pallet: System
-SET_COLDKEY_AUTO_STAKE_HOTKEY = namedtuple("SET_COLDKEY_AUTO_STAKE_HOTKEY", ["wallet", "pallet", "netuid", "hotkey"])  # args: [netuid: NetUid, hotkey: T::AccountId]  | Pallet: SubtensorModule
-SET_COMMITMENT = namedtuple("SET_COMMITMENT", ["wallet", "pallet", "netuid", "info"])  # args: [netuid: NetUid, info: Box<CommitmentInfo<T::MaxFields>>]  | Pallet: Commitments
-SET_ELASTICITY = namedtuple("SET_ELASTICITY", ["wallet", "pallet", "elasticity"])  # args: [elasticity: Permill]  | Pallet: BaseFee
-SET_FEE_RATE = namedtuple("SET_FEE_RATE", ["wallet", "pallet", "netuid", "rate"])  # args: [netuid: NetUid, rate: u16]  | Pallet: Swap
-SET_HEAP_PAGES = namedtuple("SET_HEAP_PAGES", ["wallet", "pallet", "pages"])  # args: [pages: u64]  | Pallet: System
-SET_IDENTITY = namedtuple("SET_IDENTITY", ["wallet", "pallet", "identified", "info"])  # args: [identified: T::AccountId, info: Box<IdentityInfo<T::MaxAdditionalFields>>]  | Pallet: Registry
-SET_IDENTITY = namedtuple("SET_IDENTITY", ["wallet", "pallet", "name", "url", "github_repo", "image", "discord", "description", "additional"])  # args: [name: Vec<u8>, url: Vec<u8>, github_repo: Vec<u8>, image: Vec<u8>, discord: Vec<u8>, description: Vec<u8>, additional: Vec<u8>]  | Pallet: SubtensorModule
-SET_KEY = namedtuple("SET_KEY", ["wallet", "pallet", "new"])  # args: [new: AccountIdLookupOf<T>]  | Pallet: Sudo
-SET_MAX_SPACE = namedtuple("SET_MAX_SPACE", ["wallet", "pallet", "new_limit"])  # args: [new_limit: u32]  | Pallet: Commitments
-SET_MECHANISM_WEIGHTS = namedtuple("SET_MECHANISM_WEIGHTS", ["wallet", "pallet", "netuid", "mecid", "dests", "weights", "version_key"])  # args: [netuid: NetUid, mecid: MechId, dests: Vec<u16>, weights: Vec<u16>, version_key: u64]  | Pallet: SubtensorModule
-SET_OLDEST_STORED_ROUND = namedtuple("SET_OLDEST_STORED_ROUND", ["wallet", "pallet", "oldest_round"])  # args: [oldest_round: u64]  | Pallet: Drand
-SET_PENDING_CHILDKEY_COOLDOWN = namedtuple("SET_PENDING_CHILDKEY_COOLDOWN", ["wallet", "pallet", "cooldown"])  # args: [cooldown: u64]  | Pallet: SubtensorModule
-SET_RETRY = namedtuple("SET_RETRY", ["wallet", "pallet", "task", "retries", "period"])  # args: [task: TaskAddress<BlockNumberFor<T>>, retries: u8, period: BlockNumberFor<T>]  | Pallet: Scheduler
-SET_RETRY_NAMED = namedtuple("SET_RETRY_NAMED", ["wallet", "pallet", "id", "retries", "period"])  # args: [id: TaskName, retries: u8, period: BlockNumberFor<T>]  | Pallet: Scheduler
-SET_ROOT_CLAIM_TYPE = namedtuple("SET_ROOT_CLAIM_TYPE", ["wallet", "pallet", "new_root_claim_type"])  # args: [new_root_claim_type: RootClaimTypeEnum]  | Pallet: SubtensorModule
-SET_STORAGE = namedtuple("SET_STORAGE", ["wallet", "pallet", "items"])  # args: [items: Vec<KeyValue>]  | Pallet: System
-SET_SUBNET_IDENTITY = namedtuple("SET_SUBNET_IDENTITY", ["wallet", "pallet", "netuid", "subnet_name", "github_repo", "subnet_contact", "subnet_url", "discord", "description", "logo_url", "additional"])  # args: [netuid: NetUid, subnet_name: Vec<u8>, github_repo: Vec<u8>, subnet_contact: Vec<u8>, subnet_url: Vec<u8>, discord: Vec<u8>, description: Vec<u8>, logo_url: Vec<u8>, additional: Vec<u8>]  | Pallet: SubtensorModule
-SET_WEIGHTS = namedtuple("SET_WEIGHTS", ["wallet", "pallet", "netuid", "dests", "weights", "version_key"])  # args: [netuid: NetUid, dests: Vec<u16>, weights: Vec<u16>, version_key: u64]  | Pallet: SubtensorModule
-SET_WHITELIST = namedtuple("SET_WHITELIST", ["wallet", "pallet", "new"])  # args: [new: Vec<H160>]  | Pallet: EVM
-START_CALL = namedtuple("START_CALL", ["wallet", "pallet", "netuid"])  # args: [netuid: NetUid]  | Pallet: SubtensorModule
-SUBMIT_ENCRYPTED = namedtuple("SUBMIT_ENCRYPTED", ["wallet", "pallet", "commitment", "ciphertext"])  # args: [commitment: T::Hash, ciphertext: BoundedVec<u8, ConstU32<8192>>]  | Pallet: MevShield
-SUBNET_BUYBACK = namedtuple("SUBNET_BUYBACK", ["wallet", "pallet", "hotkey", "netuid", "amount", "limit"])  # args: [hotkey: T::AccountId, netuid: NetUid, amount: TaoCurrency, limit: Option<TaoCurrency>]  | Pallet: SubtensorModule
-SUDO = namedtuple("SUDO", ["wallet", "pallet", "call"])  # args: [call: Box<<T as Config>::RuntimeCall>]  | Pallet: Sudo
-SWAP_AUTHORITIES = namedtuple("SWAP_AUTHORITIES", ["wallet", "pallet", "new_authorities"])  # args: [new_authorities: BoundedVec<<T as Config>::AuthorityId, T::MaxAuthorities>]  | Pallet: AdminUtils
-SWAP_COLDKEY = namedtuple("SWAP_COLDKEY", ["wallet", "pallet", "old_coldkey", "new_coldkey", "swap_cost"])  # args: [old_coldkey: T::AccountId, new_coldkey: T::AccountId, swap_cost: TaoCurrency]  | Pallet: SubtensorModule
-SWAP_COLDKEY_ANNOUNCED = namedtuple("SWAP_COLDKEY_ANNOUNCED", ["wallet", "pallet", "new_coldkey"])  # args: [new_coldkey: T::AccountId]  | Pallet: SubtensorModule
-SWAP_HOTKEY = namedtuple("SWAP_HOTKEY", ["wallet", "pallet", "hotkey", "new_hotkey", "netuid"])  # args: [hotkey: T::AccountId, new_hotkey: T::AccountId, netuid: Option<NetUid>]  | Pallet: SubtensorModule
-SWAP_STAKE = namedtuple("SWAP_STAKE", ["wallet", "pallet", "hotkey", "origin_netuid", "destination_netuid", "alpha_amount"])  # args: [hotkey: T::AccountId, origin_netuid: NetUid, destination_netuid: NetUid, alpha_amount: AlphaCurrency]  | Pallet: SubtensorModule
-SWAP_STAKE_LIMIT = namedtuple("SWAP_STAKE_LIMIT", ["wallet", "pallet", "hotkey", "origin_netuid", "destination_netuid", "alpha_amount", "limit_price", "allow_partial"])  # args: [hotkey: T::AccountId, origin_netuid: NetUid, destination_netuid: NetUid, alpha_amount: AlphaCurrency, limit_price: TaoCurrency, allow_partial: bool]  | Pallet: SubtensorModule
-TERMINATE_LEASE = namedtuple("TERMINATE_LEASE", ["wallet", "pallet", "lease_id", "hotkey"])  # args: [lease_id: LeaseId, hotkey: T::AccountId]  | Pallet: SubtensorModule
-TOGGLE_USER_LIQUIDITY = namedtuple("TOGGLE_USER_LIQUIDITY", ["wallet", "pallet", "netuid", "enable"])  # args: [netuid: NetUid, enable: bool]  | Pallet: Swap
-TRANSACT = namedtuple("TRANSACT", ["wallet", "pallet", "transaction"])  # args: [transaction: Transaction]  | Pallet: Ethereum
-TRANSFER_ALL = namedtuple("TRANSFER_ALL", ["wallet", "pallet", "dest", "keep_alive"])  # args: [dest: AccountIdLookupOf<T>, keep_alive: bool]  | Pallet: Balances
-TRANSFER_ALLOW_DEATH = namedtuple("TRANSFER_ALLOW_DEATH", ["wallet", "pallet", "dest", "value"])  # args: [dest: AccountIdLookupOf<T>, value: T::Balance]  | Pallet: Balances
-TRANSFER_KEEP_ALIVE = namedtuple("TRANSFER_KEEP_ALIVE", ["wallet", "pallet", "dest", "value"])  # args: [dest: AccountIdLookupOf<T>, value: T::Balance]  | Pallet: Balances
-TRANSFER_STAKE = namedtuple("TRANSFER_STAKE", ["wallet", "pallet", "destination_coldkey", "hotkey", "origin_netuid", "destination_netuid", "alpha_amount"])  # args: [destination_coldkey: T::AccountId, hotkey: T::AccountId, origin_netuid: NetUid, destination_netuid: NetUid, alpha_amount: AlphaCurrency]  | Pallet: SubtensorModule
-TRY_ASSOCIATE_HOTKEY = namedtuple("TRY_ASSOCIATE_HOTKEY", ["wallet", "pallet", "hotkey"])  # args: [hotkey: T::AccountId]  | Pallet: SubtensorModule
-UNNOTE_PREIMAGE = namedtuple("UNNOTE_PREIMAGE", ["wallet", "pallet", "hash"])  # args: [hash: T::Hash]  | Pallet: Preimage
-UNREQUEST_PREIMAGE = namedtuple("UNREQUEST_PREIMAGE", ["wallet", "pallet", "hash"])  # args: [hash: T::Hash]  | Pallet: Preimage
-UNSTAKE_ALL = namedtuple("UNSTAKE_ALL", ["wallet", "pallet", "hotkey"])  # args: [hotkey: T::AccountId]  | Pallet: SubtensorModule
-UNSTAKE_ALL_ALPHA = namedtuple("UNSTAKE_ALL_ALPHA", ["wallet", "pallet", "hotkey"])  # args: [hotkey: T::AccountId]  | Pallet: SubtensorModule
-UPDATE_CAP = namedtuple("UPDATE_CAP", ["wallet", "pallet", "crowdloan_id", "new_cap"])  # args: [crowdloan_id: CrowdloanId, new_cap: BalanceOf<T>]  | Pallet: Crowdloan
-UPDATE_END = namedtuple("UPDATE_END", ["wallet", "pallet", "crowdloan_id", "new_end"])  # args: [crowdloan_id: CrowdloanId, new_end: BlockNumberFor<T>]  | Pallet: Crowdloan
-UPDATE_MIN_CONTRIBUTION = namedtuple("UPDATE_MIN_CONTRIBUTION", ["wallet", "pallet", "crowdloan_id", "new_min_contribution"])  # args: [crowdloan_id: CrowdloanId, new_min_contribution: BalanceOf<T>]  | Pallet: Crowdloan
-UPDATE_SYMBOL = namedtuple("UPDATE_SYMBOL", ["wallet", "pallet", "netuid", "symbol"])  # args: [netuid: NetUid, symbol: Vec<u8>]  | Pallet: SubtensorModule
-UPGRADE_ACCOUNTS = namedtuple("UPGRADE_ACCOUNTS", ["wallet", "pallet", "who"])  # args: [who: Vec<T::AccountId>]  | Pallet: Balances
-UPLOAD_CODE = namedtuple("UPLOAD_CODE", ["wallet", "pallet", "code", "storage_deposit_limit", "determinism"])  # args: [code: Vec<u8>, storage_deposit_limit: Option<<BalanceOf<T> as codec::HasCompact>::Type>, determinism: Determinism]  | Pallet: Contracts
-WITHDRAW = namedtuple("WITHDRAW", ["wallet", "pallet", "address", "value"])  # args: [address: H160, value: BalanceOf<T>]  | Pallet: EVM
-WITHDRAW = namedtuple("WITHDRAW", ["wallet", "pallet", "crowdloan_id"])  # args: [crowdloan_id: CrowdloanId]  | Pallet: Crowdloan
-WITH_WEIGHT = namedtuple("WITH_WEIGHT", ["wallet", "pallet", "call", "weight"])  # args: [call: Box<<T as Config>::RuntimeCall>, weight: Weight]  | Pallet: Utility
-WRITE_PULSE = namedtuple("WRITE_PULSE", ["wallet", "pallet", "pulses_payload", "signature"])  # args: [pulses_payload: PulsesPayload<T::Public, BlockNumberFor<T>>, signature: Option<T::Signature>]  | Pallet: Drand
+ADD_LIQUIDITY = namedtuple(
+    "ADD_LIQUIDITY",
+    ["wallet", "pallet", "hotkey", "netuid", "tick_low", "tick_high", "liquidity"],
+)  # args: [hotkey: T::AccountId, netuid: NetUid, tick_low: TickIndex, tick_high: TickIndex, liquidity: u64]  | Pallet: Swap
+ADD_PROXY = namedtuple(
+    "ADD_PROXY", ["wallet", "pallet", "delegate", "proxy_type", "delay"]
+)  # args: [delegate: AccountIdLookupOf<T>, proxy_type: T::ProxyType, delay: BlockNumberFor<T>]  | Pallet: Proxy
+ADD_STAKE = namedtuple(
+    "ADD_STAKE", ["wallet", "pallet", "hotkey", "netuid", "amount_staked"]
+)  # args: [hotkey: T::AccountId, netuid: NetUid, amount_staked: TaoCurrency]  | Pallet: SubtensorModule
+ADD_STAKE_LIMIT = namedtuple(
+    "ADD_STAKE_LIMIT",
+    [
+        "wallet",
+        "pallet",
+        "hotkey",
+        "netuid",
+        "amount_staked",
+        "limit_price",
+        "allow_partial",
+    ],
+)  # args: [hotkey: T::AccountId, netuid: NetUid, amount_staked: TaoCurrency, limit_price: TaoCurrency, allow_partial: bool]  | Pallet: SubtensorModule
+ANNOUNCE = namedtuple(
+    "ANNOUNCE", ["wallet", "pallet", "real", "call_hash"]
+)  # args: [real: AccountIdLookupOf<T>, call_hash: CallHashOf<T>]  | Pallet: Proxy
+ANNOUNCE_COLDKEY_SWAP = namedtuple(
+    "ANNOUNCE_COLDKEY_SWAP", ["wallet", "pallet", "new_coldkey_hash"]
+)  # args: [new_coldkey_hash: T::Hash]  | Pallet: SubtensorModule
+ANNOUNCE_NEXT_KEY = namedtuple(
+    "ANNOUNCE_NEXT_KEY", ["wallet", "pallet", "public_key"]
+)  # args: [public_key: BoundedVec<u8, ConstU32<2048>>]  | Pallet: MevShield
+APPLY_AUTHORIZED_UPGRADE = namedtuple(
+    "APPLY_AUTHORIZED_UPGRADE", ["wallet", "pallet", "code"]
+)  # args: [code: Vec<u8>]  | Pallet: System
+APPROVE_AS_MULTI = namedtuple(
+    "APPROVE_AS_MULTI",
+    [
+        "wallet",
+        "pallet",
+        "threshold",
+        "other_signatories",
+        "maybe_timepoint",
+        "call_hash",
+        "max_weight",
+    ],
+)  # args: [threshold: u16, other_signatories: Vec<T::AccountId>, maybe_timepoint: Option<Timepoint<BlockNumberFor<T>>>, call_hash: [u8; 32], max_weight: Weight]  | Pallet: Multisig
+ASSOCIATE_EVM_KEY = namedtuple(
+    "ASSOCIATE_EVM_KEY",
+    ["wallet", "pallet", "netuid", "evm_key", "block_number", "signature"],
+)  # args: [netuid: NetUid, evm_key: H160, block_number: u64, signature: Signature]  | Pallet: SubtensorModule
+AS_DERIVATIVE = namedtuple(
+    "AS_DERIVATIVE", ["wallet", "pallet", "index", "call"]
+)  # args: [index: u16, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Utility
+AS_MULTI = namedtuple(
+    "AS_MULTI",
+    [
+        "wallet",
+        "pallet",
+        "threshold",
+        "other_signatories",
+        "maybe_timepoint",
+        "call",
+        "max_weight",
+    ],
+)  # args: [threshold: u16, other_signatories: Vec<T::AccountId>, maybe_timepoint: Option<Timepoint<BlockNumberFor<T>>>, call: Box<<T as Config>::RuntimeCall>, max_weight: Weight]  | Pallet: Multisig
+AS_MULTI_THRESHOLD_1 = namedtuple(
+    "AS_MULTI_THRESHOLD_1", ["wallet", "pallet", "other_signatories", "call"]
+)  # args: [other_signatories: Vec<T::AccountId>, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Multisig
+AUTHORIZE_UPGRADE = namedtuple(
+    "AUTHORIZE_UPGRADE", ["wallet", "pallet", "code_hash"]
+)  # args: [code_hash: T::Hash]  | Pallet: System
+AUTHORIZE_UPGRADE_WITHOUT_CHECKS = namedtuple(
+    "AUTHORIZE_UPGRADE_WITHOUT_CHECKS", ["wallet", "pallet", "code_hash"]
+)  # args: [code_hash: T::Hash]  | Pallet: System
+BATCH = namedtuple(
+    "BATCH", ["wallet", "pallet", "calls"]
+)  # args: [calls: Vec<<T as Config>::RuntimeCall>]  | Pallet: Utility
+BATCH_ALL = namedtuple(
+    "BATCH_ALL", ["wallet", "pallet", "calls"]
+)  # args: [calls: Vec<<T as Config>::RuntimeCall>]  | Pallet: Utility
+BATCH_COMMIT_WEIGHTS = namedtuple(
+    "BATCH_COMMIT_WEIGHTS", ["wallet", "pallet", "netuids", "commit_hashes"]
+)  # args: [netuids: Vec<Compact<NetUid>>, commit_hashes: Vec<H256>]  | Pallet: SubtensorModule
+BATCH_REVEAL_WEIGHTS = namedtuple(
+    "BATCH_REVEAL_WEIGHTS",
+    [
+        "wallet",
+        "pallet",
+        "netuid",
+        "uids_list",
+        "values_list",
+        "salts_list",
+        "version_keys",
+    ],
+)  # args: [netuid: NetUid, uids_list: Vec<Vec<u16>>, values_list: Vec<Vec<u16>>, salts_list: Vec<Vec<u16>>, version_keys: Vec<u64>]  | Pallet: SubtensorModule
+BATCH_SET_WEIGHTS = namedtuple(
+    "BATCH_SET_WEIGHTS", ["wallet", "pallet", "netuids", "weights", "version_keys"]
+)  # args: [netuids: Vec<Compact<NetUid>>, weights: Vec<Vec<(Compact<u16>, Compact<u16>)>>, version_keys: Vec<Compact<u64>>]  | Pallet: SubtensorModule
+BURN = namedtuple(
+    "BURN", ["wallet", "pallet", "value", "keep_alive"]
+)  # args: [value: T::Balance, keep_alive: bool]  | Pallet: Balances
+BURNED_REGISTER = namedtuple(
+    "BURNED_REGISTER", ["wallet", "pallet", "netuid", "hotkey"]
+)  # args: [netuid: NetUid, hotkey: T::AccountId]  | Pallet: SubtensorModule
+BURN_ALPHA = namedtuple(
+    "BURN_ALPHA", ["wallet", "pallet", "hotkey", "amount", "netuid"]
+)  # args: [hotkey: T::AccountId, amount: AlphaCurrency, netuid: NetUid]  | Pallet: SubtensorModule
+CALL = namedtuple(
+    "CALL",
+    ["wallet", "pallet", "dest", "value", "gas_limit", "storage_deposit_limit", "data"],
+)  # args: [dest: AccountIdLookupOf<T>, value: BalanceOf<T>, gas_limit: Weight, storage_deposit_limit: Option<<BalanceOf<T> as codec::HasCompact>::Type>, data: Vec<u8>]  | Pallet: Contracts
+CALL = namedtuple(
+    "CALL",
+    [
+        "wallet",
+        "pallet",
+        "source",
+        "target",
+        "input",
+        "value",
+        "gas_limit",
+        "max_fee_per_gas",
+        "max_priority_fee_per_gas",
+        "nonce",
+        "access_list",
+        "authorization_list",
+    ],
+)  # args: [source: H160, target: H160, input: Vec<u8>, value: U256, gas_limit: u64, max_fee_per_gas: U256, max_priority_fee_per_gas: Option<U256>, nonce: Option<U256>, access_list: Vec<(H160, Vec<H256>)>, authorization_list: AuthorizationList]  | Pallet: EVM
+CALL_OLD_WEIGHT = namedtuple(
+    "CALL_OLD_WEIGHT",
+    ["wallet", "pallet", "dest", "value", "gas_limit", "storage_deposit_limit", "data"],
+)  # args: [dest: AccountIdLookupOf<T>, value: BalanceOf<T>, gas_limit: OldWeight, storage_deposit_limit: Option<<BalanceOf<T> as codec::HasCompact>::Type>, data: Vec<u8>]  | Pallet: Contracts
+CANCEL = namedtuple(
+    "CANCEL", ["wallet", "pallet", "when", "index"]
+)  # args: [when: BlockNumberFor<T>, index: u32]  | Pallet: Scheduler
+CANCEL_AS_MULTI = namedtuple(
+    "CANCEL_AS_MULTI",
+    ["wallet", "pallet", "threshold", "other_signatories", "timepoint", "call_hash"],
+)  # args: [threshold: u16, other_signatories: Vec<T::AccountId>, timepoint: Timepoint<BlockNumberFor<T>>, call_hash: [u8; 32]]  | Pallet: Multisig
+CANCEL_NAMED = namedtuple(
+    "CANCEL_NAMED", ["wallet", "pallet", "id"]
+)  # args: [id: TaskName]  | Pallet: Scheduler
+CANCEL_RETRY = namedtuple(
+    "CANCEL_RETRY", ["wallet", "pallet", "task"]
+)  # args: [task: TaskAddress<BlockNumberFor<T>>]  | Pallet: Scheduler
+CANCEL_RETRY_NAMED = namedtuple(
+    "CANCEL_RETRY_NAMED", ["wallet", "pallet", "id"]
+)  # args: [id: TaskName]  | Pallet: Scheduler
+CLAIM_ROOT = namedtuple(
+    "CLAIM_ROOT", ["wallet", "pallet", "subnets"]
+)  # args: [subnets: BTreeSet<NetUid>]  | Pallet: SubtensorModule
+CLEAR_IDENTITY = namedtuple(
+    "CLEAR_IDENTITY", ["wallet", "pallet", "identified"]
+)  # args: [identified: T::AccountId]  | Pallet: Registry
+COMMIT_CRV3_MECHANISM_WEIGHTS = namedtuple(
+    "COMMIT_CRV3_MECHANISM_WEIGHTS",
+    ["wallet", "pallet", "netuid", "mecid", "commit", "reveal_round"],
+)  # args: [netuid: NetUid, mecid: MechId, commit: BoundedVec<u8, ConstU32<MAX_CRV3_COMMIT_SIZE_BYTES>>, reveal_round: u64]  | Pallet: SubtensorModule
+COMMIT_MECHANISM_WEIGHTS = namedtuple(
+    "COMMIT_MECHANISM_WEIGHTS", ["wallet", "pallet", "netuid", "mecid", "commit_hash"]
+)  # args: [netuid: NetUid, mecid: MechId, commit_hash: H256]  | Pallet: SubtensorModule
+COMMIT_TIMELOCKED_MECHANISM_WEIGHTS = namedtuple(
+    "COMMIT_TIMELOCKED_MECHANISM_WEIGHTS",
+    [
+        "wallet",
+        "pallet",
+        "netuid",
+        "mecid",
+        "commit",
+        "reveal_round",
+        "commit_reveal_version",
+    ],
+)  # args: [netuid: NetUid, mecid: MechId, commit: BoundedVec<u8, ConstU32<MAX_CRV3_COMMIT_SIZE_BYTES>>, reveal_round: u64, commit_reveal_version: u16]  | Pallet: SubtensorModule
+COMMIT_TIMELOCKED_WEIGHTS = namedtuple(
+    "COMMIT_TIMELOCKED_WEIGHTS",
+    ["wallet", "pallet", "netuid", "commit", "reveal_round", "commit_reveal_version"],
+)  # args: [netuid: NetUid, commit: BoundedVec<u8, ConstU32<MAX_CRV3_COMMIT_SIZE_BYTES>>, reveal_round: u64, commit_reveal_version: u16]  | Pallet: SubtensorModule
+COMMIT_WEIGHTS = namedtuple(
+    "COMMIT_WEIGHTS", ["wallet", "pallet", "netuid", "commit_hash"]
+)  # args: [netuid: NetUid, commit_hash: H256]  | Pallet: SubtensorModule
+CONTRIBUTE = namedtuple(
+    "CONTRIBUTE", ["wallet", "pallet", "crowdloan_id", "amount"]
+)  # args: [crowdloan_id: CrowdloanId, amount: BalanceOf<T>]  | Pallet: Crowdloan
+CREATE = namedtuple(
+    "CREATE",
+    [
+        "wallet",
+        "pallet",
+        "deposit",
+        "min_contribution",
+        "cap",
+        "end",
+        "call",
+        "target_address",
+    ],
+)  # args: [deposit: BalanceOf<T>, min_contribution: BalanceOf<T>, cap: BalanceOf<T>, end: BlockNumberFor<T>, call: Option<Box<<T as Config>::RuntimeCall>>, target_address: Option<T::AccountId>]  | Pallet: Crowdloan
+CREATE = namedtuple(
+    "CREATE",
+    [
+        "wallet",
+        "pallet",
+        "source",
+        "init",
+        "value",
+        "gas_limit",
+        "max_fee_per_gas",
+        "max_priority_fee_per_gas",
+        "nonce",
+        "access_list",
+        "authorization_list",
+    ],
+)  # args: [source: H160, init: Vec<u8>, value: U256, gas_limit: u64, max_fee_per_gas: U256, max_priority_fee_per_gas: Option<U256>, nonce: Option<U256>, access_list: Vec<(H160, Vec<H256>)>, authorization_list: AuthorizationList]  | Pallet: EVM
+CREATE2 = namedtuple(
+    "CREATE2",
+    [
+        "wallet",
+        "pallet",
+        "source",
+        "init",
+        "salt",
+        "value",
+        "gas_limit",
+        "max_fee_per_gas",
+        "max_priority_fee_per_gas",
+        "nonce",
+        "access_list",
+        "authorization_list",
+    ],
+)  # args: [source: H160, init: Vec<u8>, salt: H256, value: U256, gas_limit: u64, max_fee_per_gas: U256, max_priority_fee_per_gas: Option<U256>, nonce: Option<U256>, access_list: Vec<(H160, Vec<H256>)>, authorization_list: AuthorizationList]  | Pallet: EVM
+CREATE_PURE = namedtuple(
+    "CREATE_PURE", ["wallet", "pallet", "proxy_type", "delay", "index"]
+)  # args: [proxy_type: T::ProxyType, delay: BlockNumberFor<T>, index: u16]  | Pallet: Proxy
+DECREASE_TAKE = namedtuple(
+    "DECREASE_TAKE", ["wallet", "pallet", "hotkey", "take"]
+)  # args: [hotkey: T::AccountId, take: u16]  | Pallet: SubtensorModule
+DISABLE_LP = namedtuple(
+    "DISABLE_LP",
+    [
+        "wallet",
+        "pallet",
+    ],
+)  # args: []  | Pallet: Swap
+DISABLE_VOTING_POWER_TRACKING = namedtuple(
+    "DISABLE_VOTING_POWER_TRACKING", ["wallet", "pallet", "netuid"]
+)  # args: [netuid: NetUid]  | Pallet: SubtensorModule
+DISABLE_WHITELIST = namedtuple(
+    "DISABLE_WHITELIST", ["wallet", "pallet", "disabled"]
+)  # args: [disabled: bool]  | Pallet: EVM
+DISPATCH_AS = namedtuple(
+    "DISPATCH_AS", ["wallet", "pallet", "as_origin", "call"]
+)  # args: [as_origin: Box<T::PalletsOrigin>, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Utility
+DISPATCH_AS_FALLIBLE = namedtuple(
+    "DISPATCH_AS_FALLIBLE", ["wallet", "pallet", "as_origin", "call"]
+)  # args: [as_origin: Box<T::PalletsOrigin>, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Utility
+DISPUTE_COLDKEY_SWAP = namedtuple(
+    "DISPUTE_COLDKEY_SWAP",
+    [
+        "wallet",
+        "pallet",
+    ],
+)  # args: []  | Pallet: SubtensorModule
+DISSOLVE = namedtuple(
+    "DISSOLVE", ["wallet", "pallet", "crowdloan_id"]
+)  # args: [crowdloan_id: CrowdloanId]  | Pallet: Crowdloan
+DISSOLVE_NETWORK = namedtuple(
+    "DISSOLVE_NETWORK", ["wallet", "pallet", "coldkey", "netuid"]
+)  # args: [coldkey: T::AccountId, netuid: NetUid]  | Pallet: SubtensorModule
+ENABLE_VOTING_POWER_TRACKING = namedtuple(
+    "ENABLE_VOTING_POWER_TRACKING", ["wallet", "pallet", "netuid"]
+)  # args: [netuid: NetUid]  | Pallet: SubtensorModule
+ENSURE_UPDATED = namedtuple(
+    "ENSURE_UPDATED", ["wallet", "pallet", "hashes"]
+)  # args: [hashes: Vec<T::Hash>]  | Pallet: Preimage
+ENTER = namedtuple(
+    "ENTER",
+    [
+        "wallet",
+        "pallet",
+    ],
+)  # args: []  | Pallet: SafeMode
+EXTEND = namedtuple(
+    "EXTEND",
+    [
+        "wallet",
+        "pallet",
+    ],
+)  # args: []  | Pallet: SafeMode
+FAUCET = namedtuple(
+    "FAUCET", ["wallet", "pallet", "block_number", "nonce", "work"]
+)  # args: [block_number: u64, nonce: u64, work: Vec<u8>]  | Pallet: SubtensorModule
+FINALIZE = namedtuple(
+    "FINALIZE", ["wallet", "pallet", "crowdloan_id"]
+)  # args: [crowdloan_id: CrowdloanId]  | Pallet: Crowdloan
+FORCE_ADJUST_TOTAL_ISSUANCE = namedtuple(
+    "FORCE_ADJUST_TOTAL_ISSUANCE", ["wallet", "pallet", "direction", "delta"]
+)  # args: [direction: AdjustmentDirection, delta: T::Balance]  | Pallet: Balances
+FORCE_BATCH = namedtuple(
+    "FORCE_BATCH", ["wallet", "pallet", "calls"]
+)  # args: [calls: Vec<<T as Config>::RuntimeCall>]  | Pallet: Utility
+FORCE_ENTER = namedtuple(
+    "FORCE_ENTER",
+    [
+        "wallet",
+        "pallet",
+    ],
+)  # args: []  | Pallet: SafeMode
+FORCE_EXIT = namedtuple(
+    "FORCE_EXIT",
+    [
+        "wallet",
+        "pallet",
+    ],
+)  # args: []  | Pallet: SafeMode
+FORCE_EXTEND = namedtuple(
+    "FORCE_EXTEND",
+    [
+        "wallet",
+        "pallet",
+    ],
+)  # args: []  | Pallet: SafeMode
+FORCE_RELEASE_DEPOSIT = namedtuple(
+    "FORCE_RELEASE_DEPOSIT", ["wallet", "pallet", "account", "block"]
+)  # args: [account: T::AccountId, block: BlockNumberFor<T>]  | Pallet: SafeMode
+FORCE_SET_BALANCE = namedtuple(
+    "FORCE_SET_BALANCE", ["wallet", "pallet", "who", "new_free"]
+)  # args: [who: AccountIdLookupOf<T>, new_free: T::Balance]  | Pallet: Balances
+FORCE_SLASH_DEPOSIT = namedtuple(
+    "FORCE_SLASH_DEPOSIT", ["wallet", "pallet", "account", "block"]
+)  # args: [account: T::AccountId, block: BlockNumberFor<T>]  | Pallet: SafeMode
+FORCE_TRANSFER = namedtuple(
+    "FORCE_TRANSFER", ["wallet", "pallet", "source", "dest", "value"]
+)  # args: [source: AccountIdLookupOf<T>, dest: AccountIdLookupOf<T>, value: T::Balance]  | Pallet: Balances
+FORCE_UNRESERVE = namedtuple(
+    "FORCE_UNRESERVE", ["wallet", "pallet", "who", "amount"]
+)  # args: [who: AccountIdLookupOf<T>, amount: T::Balance]  | Pallet: Balances
+IF_ELSE = namedtuple(
+    "IF_ELSE", ["wallet", "pallet", "main", "fallback"]
+)  # args: [main: Box<<T as Config>::RuntimeCall>, fallback: Box<<T as Config>::RuntimeCall>]  | Pallet: Utility
+INCREASE_TAKE = namedtuple(
+    "INCREASE_TAKE", ["wallet", "pallet", "hotkey", "take"]
+)  # args: [hotkey: T::AccountId, take: u16]  | Pallet: SubtensorModule
+INSTANTIATE = namedtuple(
+    "INSTANTIATE",
+    [
+        "wallet",
+        "pallet",
+        "value",
+        "gas_limit",
+        "storage_deposit_limit",
+        "code_hash",
+        "data",
+        "salt",
+    ],
+)  # args: [value: BalanceOf<T>, gas_limit: Weight, storage_deposit_limit: Option<<BalanceOf<T> as codec::HasCompact>::Type>, code_hash: CodeHash<T>, data: Vec<u8>, salt: Vec<u8>]  | Pallet: Contracts
+INSTANTIATE_OLD_WEIGHT = namedtuple(
+    "INSTANTIATE_OLD_WEIGHT",
+    [
+        "wallet",
+        "pallet",
+        "value",
+        "gas_limit",
+        "storage_deposit_limit",
+        "code_hash",
+        "data",
+        "salt",
+    ],
+)  # args: [value: BalanceOf<T>, gas_limit: OldWeight, storage_deposit_limit: Option<<BalanceOf<T> as codec::HasCompact>::Type>, code_hash: CodeHash<T>, data: Vec<u8>, salt: Vec<u8>]  | Pallet: Contracts
+INSTANTIATE_WITH_CODE = namedtuple(
+    "INSTANTIATE_WITH_CODE",
+    [
+        "wallet",
+        "pallet",
+        "value",
+        "gas_limit",
+        "storage_deposit_limit",
+        "code",
+        "data",
+        "salt",
+    ],
+)  # args: [value: BalanceOf<T>, gas_limit: Weight, storage_deposit_limit: Option<<BalanceOf<T> as codec::HasCompact>::Type>, code: Vec<u8>, data: Vec<u8>, salt: Vec<u8>]  | Pallet: Contracts
+INSTANTIATE_WITH_CODE_OLD_WEIGHT = namedtuple(
+    "INSTANTIATE_WITH_CODE_OLD_WEIGHT",
+    [
+        "wallet",
+        "pallet",
+        "value",
+        "gas_limit",
+        "storage_deposit_limit",
+        "code",
+        "data",
+        "salt",
+    ],
+)  # args: [value: BalanceOf<T>, gas_limit: OldWeight, storage_deposit_limit: Option<<BalanceOf<T> as codec::HasCompact>::Type>, code: Vec<u8>, data: Vec<u8>, salt: Vec<u8>]  | Pallet: Contracts
+KILL_PREFIX = namedtuple(
+    "KILL_PREFIX", ["wallet", "pallet", "prefix", "subkeys"]
+)  # args: [prefix: Key, subkeys: u32]  | Pallet: System
+KILL_PURE = namedtuple(
+    "KILL_PURE",
+    ["wallet", "pallet", "spawner", "proxy_type", "index", "height", "ext_index"],
+)  # args: [spawner: AccountIdLookupOf<T>, proxy_type: T::ProxyType, index: u16, height: BlockNumberFor<T>, ext_index: u32]  | Pallet: Proxy
+KILL_STORAGE = namedtuple(
+    "KILL_STORAGE", ["wallet", "pallet", "keys"]
+)  # args: [keys: Vec<Key>]  | Pallet: System
+MARK_DECRYPTION_FAILED = namedtuple(
+    "MARK_DECRYPTION_FAILED", ["wallet", "pallet", "id", "reason"]
+)  # args: [id: T::Hash, reason: BoundedVec<u8, ConstU32<256>>]  | Pallet: MevShield
+MIGRATE = namedtuple(
+    "MIGRATE", ["wallet", "pallet", "weight_limit"]
+)  # args: [weight_limit: Weight]  | Pallet: Contracts
+MODIFY_POSITION = namedtuple(
+    "MODIFY_POSITION",
+    ["wallet", "pallet", "hotkey", "netuid", "position_id", "liquidity_delta"],
+)  # args: [hotkey: T::AccountId, netuid: NetUid, position_id: PositionId, liquidity_delta: i64]  | Pallet: Swap
+MOVE_STAKE = namedtuple(
+    "MOVE_STAKE",
+    [
+        "wallet",
+        "pallet",
+        "origin_hotkey",
+        "destination_hotkey",
+        "origin_netuid",
+        "destination_netuid",
+        "alpha_amount",
+    ],
+)  # args: [origin_hotkey: T::AccountId, destination_hotkey: T::AccountId, origin_netuid: NetUid, destination_netuid: NetUid, alpha_amount: AlphaCurrency]  | Pallet: SubtensorModule
+NOTE_PREIMAGE = namedtuple(
+    "NOTE_PREIMAGE", ["wallet", "pallet", "bytes"]
+)  # args: [bytes: Vec<u8>]  | Pallet: Preimage
+NOTE_STALLED = namedtuple(
+    "NOTE_STALLED", ["wallet", "pallet", "delay", "best_finalized_block_number"]
+)  # args: [delay: BlockNumberFor<T>, best_finalized_block_number: BlockNumberFor<T>]  | Pallet: Grandpa
+POKE_DEPOSIT = namedtuple(
+    "POKE_DEPOSIT", ["wallet", "pallet", "threshold", "other_signatories", "call_hash"]
+)  # args: [threshold: u16, other_signatories: Vec<T::AccountId>, call_hash: [u8; 32]]  | Pallet: Multisig
+POKE_DEPOSIT = namedtuple(
+    "POKE_DEPOSIT",
+    [
+        "wallet",
+        "pallet",
+    ],
+)  # args: []  | Pallet: Proxy
+PROXY = namedtuple(
+    "PROXY", ["wallet", "pallet", "real", "force_proxy_type", "call"]
+)  # args: [real: AccountIdLookupOf<T>, force_proxy_type: Option<T::ProxyType>, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Proxy
+PROXY_ANNOUNCED = namedtuple(
+    "PROXY_ANNOUNCED",
+    ["wallet", "pallet", "delegate", "real", "force_proxy_type", "call"],
+)  # args: [delegate: AccountIdLookupOf<T>, real: AccountIdLookupOf<T>, force_proxy_type: Option<T::ProxyType>, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Proxy
+RECYCLE_ALPHA = namedtuple(
+    "RECYCLE_ALPHA", ["wallet", "pallet", "hotkey", "amount", "netuid"]
+)  # args: [hotkey: T::AccountId, amount: AlphaCurrency, netuid: NetUid]  | Pallet: SubtensorModule
+REFUND = namedtuple(
+    "REFUND", ["wallet", "pallet", "crowdloan_id"]
+)  # args: [crowdloan_id: CrowdloanId]  | Pallet: Crowdloan
+REGISTER = namedtuple(
+    "REGISTER",
+    [
+        "wallet",
+        "pallet",
+        "netuid",
+        "block_number",
+        "nonce",
+        "work",
+        "hotkey",
+        "coldkey",
+    ],
+)  # args: [netuid: NetUid, block_number: u64, nonce: u64, work: Vec<u8>, hotkey: T::AccountId, coldkey: T::AccountId]  | Pallet: SubtensorModule
+REGISTER_LEASED_NETWORK = namedtuple(
+    "REGISTER_LEASED_NETWORK", ["wallet", "pallet", "emissions_share", "end_block"]
+)  # args: [emissions_share: Percent, end_block: Option<BlockNumberFor<T>>]  | Pallet: SubtensorModule
+REGISTER_NETWORK = namedtuple(
+    "REGISTER_NETWORK", ["wallet", "pallet", "hotkey"]
+)  # args: [hotkey: T::AccountId]  | Pallet: SubtensorModule
+REGISTER_NETWORK_WITH_IDENTITY = namedtuple(
+    "REGISTER_NETWORK_WITH_IDENTITY", ["wallet", "pallet", "hotkey", "identity"]
+)  # args: [hotkey: T::AccountId, identity: Option<SubnetIdentityOfV3>]  | Pallet: SubtensorModule
+REJECT_ANNOUNCEMENT = namedtuple(
+    "REJECT_ANNOUNCEMENT", ["wallet", "pallet", "delegate", "call_hash"]
+)  # args: [delegate: AccountIdLookupOf<T>, call_hash: CallHashOf<T>]  | Pallet: Proxy
+RELEASE_DEPOSIT = namedtuple(
+    "RELEASE_DEPOSIT", ["wallet", "pallet", "account", "block"]
+)  # args: [account: T::AccountId, block: BlockNumberFor<T>]  | Pallet: SafeMode
+REMARK = namedtuple(
+    "REMARK", ["wallet", "pallet", "remark"]
+)  # args: [remark: Vec<u8>]  | Pallet: System
+REMARK_WITH_EVENT = namedtuple(
+    "REMARK_WITH_EVENT", ["wallet", "pallet", "remark"]
+)  # args: [remark: Vec<u8>]  | Pallet: System
+REMOVE_ANNOUNCEMENT = namedtuple(
+    "REMOVE_ANNOUNCEMENT", ["wallet", "pallet", "real", "call_hash"]
+)  # args: [real: AccountIdLookupOf<T>, call_hash: CallHashOf<T>]  | Pallet: Proxy
+REMOVE_CODE = namedtuple(
+    "REMOVE_CODE", ["wallet", "pallet", "code_hash"]
+)  # args: [code_hash: CodeHash<T>]  | Pallet: Contracts
+REMOVE_KEY = namedtuple(
+    "REMOVE_KEY",
+    [
+        "wallet",
+        "pallet",
+    ],
+)  # args: []  | Pallet: Sudo
+REMOVE_LIQUIDITY = namedtuple(
+    "REMOVE_LIQUIDITY", ["wallet", "pallet", "hotkey", "netuid", "position_id"]
+)  # args: [hotkey: T::AccountId, netuid: NetUid, position_id: PositionId]  | Pallet: Swap
+REMOVE_PROXIES = namedtuple(
+    "REMOVE_PROXIES",
+    [
+        "wallet",
+        "pallet",
+    ],
+)  # args: []  | Pallet: Proxy
+REMOVE_PROXY = namedtuple(
+    "REMOVE_PROXY", ["wallet", "pallet", "delegate", "proxy_type", "delay"]
+)  # args: [delegate: AccountIdLookupOf<T>, proxy_type: T::ProxyType, delay: BlockNumberFor<T>]  | Pallet: Proxy
+REMOVE_STAKE = namedtuple(
+    "REMOVE_STAKE", ["wallet", "pallet", "hotkey", "netuid", "amount_unstaked"]
+)  # args: [hotkey: T::AccountId, netuid: NetUid, amount_unstaked: AlphaCurrency]  | Pallet: SubtensorModule
+REMOVE_STAKE_FULL_LIMIT = namedtuple(
+    "REMOVE_STAKE_FULL_LIMIT", ["wallet", "pallet", "hotkey", "netuid", "limit_price"]
+)  # args: [hotkey: T::AccountId, netuid: NetUid, limit_price: Option<TaoCurrency>]  | Pallet: SubtensorModule
+REMOVE_STAKE_LIMIT = namedtuple(
+    "REMOVE_STAKE_LIMIT",
+    [
+        "wallet",
+        "pallet",
+        "hotkey",
+        "netuid",
+        "amount_unstaked",
+        "limit_price",
+        "allow_partial",
+    ],
+)  # args: [hotkey: T::AccountId, netuid: NetUid, amount_unstaked: AlphaCurrency, limit_price: TaoCurrency, allow_partial: bool]  | Pallet: SubtensorModule
+REPORT_EQUIVOCATION = namedtuple(
+    "REPORT_EQUIVOCATION", ["wallet", "pallet", "equivocation_proof", "key_owner_proof"]
+)  # args: [equivocation_proof: Box<EquivocationProof<T::Hash, BlockNumberFor<T>>>, key_owner_proof: T::KeyOwnerProof]  | Pallet: Grandpa
+REPORT_EQUIVOCATION_UNSIGNED = namedtuple(
+    "REPORT_EQUIVOCATION_UNSIGNED",
+    ["wallet", "pallet", "equivocation_proof", "key_owner_proof"],
+)  # args: [equivocation_proof: Box<EquivocationProof<T::Hash, BlockNumberFor<T>>>, key_owner_proof: T::KeyOwnerProof]  | Pallet: Grandpa
+REQUEST_PREIMAGE = namedtuple(
+    "REQUEST_PREIMAGE", ["wallet", "pallet", "hash"]
+)  # args: [hash: T::Hash]  | Pallet: Preimage
+RESET_COLDKEY_SWAP = namedtuple(
+    "RESET_COLDKEY_SWAP", ["wallet", "pallet", "coldkey"]
+)  # args: [coldkey: T::AccountId]  | Pallet: SubtensorModule
+REVEAL_MECHANISM_WEIGHTS = namedtuple(
+    "REVEAL_MECHANISM_WEIGHTS",
+    ["wallet", "pallet", "netuid", "mecid", "uids", "values", "salt", "version_key"],
+)  # args: [netuid: NetUid, mecid: MechId, uids: Vec<u16>, values: Vec<u16>, salt: Vec<u16>, version_key: u64]  | Pallet: SubtensorModule
+REVEAL_WEIGHTS = namedtuple(
+    "REVEAL_WEIGHTS",
+    ["wallet", "pallet", "netuid", "uids", "values", "salt", "version_key"],
+)  # args: [netuid: NetUid, uids: Vec<u16>, values: Vec<u16>, salt: Vec<u16>, version_key: u64]  | Pallet: SubtensorModule
+ROOT_DISSOLVE_NETWORK = namedtuple(
+    "ROOT_DISSOLVE_NETWORK", ["wallet", "pallet", "netuid"]
+)  # args: [netuid: NetUid]  | Pallet: SubtensorModule
+ROOT_REGISTER = namedtuple(
+    "ROOT_REGISTER", ["wallet", "pallet", "hotkey"]
+)  # args: [hotkey: T::AccountId]  | Pallet: SubtensorModule
+SCHEDULE = namedtuple(
+    "SCHEDULE", ["wallet", "pallet", "when", "maybe_periodic", "priority", "call"]
+)  # args: [when: BlockNumberFor<T>, maybe_periodic: Option<schedule::Period<BlockNumberFor<T>>>, priority: schedule::Priority, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Scheduler
+SCHEDULE_AFTER = namedtuple(
+    "SCHEDULE_AFTER",
+    ["wallet", "pallet", "after", "maybe_periodic", "priority", "call"],
+)  # args: [after: BlockNumberFor<T>, maybe_periodic: Option<schedule::Period<BlockNumberFor<T>>>, priority: schedule::Priority, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Scheduler
+SCHEDULE_GRANDPA_CHANGE = namedtuple(
+    "SCHEDULE_GRANDPA_CHANGE",
+    ["wallet", "pallet", "next_authorities", "in_blocks", "forced"],
+)  # args: [next_authorities: AuthorityList, in_blocks: BlockNumberFor<T>, forced: Option<BlockNumberFor<T>>]  | Pallet: AdminUtils
+SCHEDULE_NAMED = namedtuple(
+    "SCHEDULE_NAMED",
+    ["wallet", "pallet", "id", "when", "maybe_periodic", "priority", "call"],
+)  # args: [id: TaskName, when: BlockNumberFor<T>, maybe_periodic: Option<schedule::Period<BlockNumberFor<T>>>, priority: schedule::Priority, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Scheduler
+SCHEDULE_NAMED_AFTER = namedtuple(
+    "SCHEDULE_NAMED_AFTER",
+    ["wallet", "pallet", "id", "after", "maybe_periodic", "priority", "call"],
+)  # args: [id: TaskName, after: BlockNumberFor<T>, maybe_periodic: Option<schedule::Period<BlockNumberFor<T>>>, priority: schedule::Priority, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Scheduler
+SCHEDULE_SWAP_COLDKEY = namedtuple(
+    "SCHEDULE_SWAP_COLDKEY", ["wallet", "pallet", "new_coldkey"]
+)  # args: [new_coldkey: T::AccountId]  | Pallet: SubtensorModule
+SERVE_AXON = namedtuple(
+    "SERVE_AXON",
+    [
+        "wallet",
+        "pallet",
+        "netuid",
+        "version",
+        "ip",
+        "port",
+        "ip_type",
+        "protocol",
+        "placeholder1",
+        "placeholder2",
+    ],
+)  # args: [netuid: NetUid, version: u32, ip: u128, port: u16, ip_type: u8, protocol: u8, placeholder1: u8, placeholder2: u8]  | Pallet: SubtensorModule
+SERVE_AXON_TLS = namedtuple(
+    "SERVE_AXON_TLS",
+    [
+        "wallet",
+        "pallet",
+        "netuid",
+        "version",
+        "ip",
+        "port",
+        "ip_type",
+        "protocol",
+        "placeholder1",
+        "placeholder2",
+        "certificate",
+    ],
+)  # args: [netuid: NetUid, version: u32, ip: u128, port: u16, ip_type: u8, protocol: u8, placeholder1: u8, placeholder2: u8, certificate: Vec<u8>]  | Pallet: SubtensorModule
+SERVE_PROMETHEUS = namedtuple(
+    "SERVE_PROMETHEUS",
+    ["wallet", "pallet", "netuid", "version", "ip", "port", "ip_type"],
+)  # args: [netuid: NetUid, version: u32, ip: u128, port: u16, ip_type: u8]  | Pallet: SubtensorModule
+SET = namedtuple(
+    "SET", ["wallet", "pallet", "now"]
+)  # args: [now: T::Moment]  | Pallet: Timestamp
+SET_BASE_FEE_PER_GAS = namedtuple(
+    "SET_BASE_FEE_PER_GAS", ["wallet", "pallet", "fee"]
+)  # args: [fee: U256]  | Pallet: BaseFee
+SET_BEACON_CONFIG = namedtuple(
+    "SET_BEACON_CONFIG", ["wallet", "pallet", "config_payload", "signature"]
+)  # args: [config_payload: BeaconConfigurationPayload<T::Public, BlockNumberFor<T>>, signature: Option<T::Signature>]  | Pallet: Drand
+SET_CHILDKEY_TAKE = namedtuple(
+    "SET_CHILDKEY_TAKE", ["wallet", "pallet", "hotkey", "netuid", "take"]
+)  # args: [hotkey: T::AccountId, netuid: NetUid, take: u16]  | Pallet: SubtensorModule
+SET_CHILDREN = namedtuple(
+    "SET_CHILDREN", ["wallet", "pallet", "hotkey", "netuid", "children"]
+)  # args: [hotkey: T::AccountId, netuid: NetUid, children: Vec<(u64, T::AccountId)>]  | Pallet: SubtensorModule
+SET_CODE = namedtuple(
+    "SET_CODE", ["wallet", "pallet", "code"]
+)  # args: [code: Vec<u8>]  | Pallet: System
+SET_CODE = namedtuple(
+    "SET_CODE", ["wallet", "pallet", "dest", "code_hash"]
+)  # args: [dest: AccountIdLookupOf<T>, code_hash: CodeHash<T>]  | Pallet: Contracts
+SET_CODE_WITHOUT_CHECKS = namedtuple(
+    "SET_CODE_WITHOUT_CHECKS", ["wallet", "pallet", "code"]
+)  # args: [code: Vec<u8>]  | Pallet: System
+SET_COLDKEY_AUTO_STAKE_HOTKEY = namedtuple(
+    "SET_COLDKEY_AUTO_STAKE_HOTKEY", ["wallet", "pallet", "netuid", "hotkey"]
+)  # args: [netuid: NetUid, hotkey: T::AccountId]  | Pallet: SubtensorModule
+SET_COMMITMENT = namedtuple(
+    "SET_COMMITMENT", ["wallet", "pallet", "netuid", "info"]
+)  # args: [netuid: NetUid, info: Box<CommitmentInfo<T::MaxFields>>]  | Pallet: Commitments
+SET_ELASTICITY = namedtuple(
+    "SET_ELASTICITY", ["wallet", "pallet", "elasticity"]
+)  # args: [elasticity: Permill]  | Pallet: BaseFee
+SET_FEE_RATE = namedtuple(
+    "SET_FEE_RATE", ["wallet", "pallet", "netuid", "rate"]
+)  # args: [netuid: NetUid, rate: u16]  | Pallet: Swap
+SET_HEAP_PAGES = namedtuple(
+    "SET_HEAP_PAGES", ["wallet", "pallet", "pages"]
+)  # args: [pages: u64]  | Pallet: System
+SET_IDENTITY = namedtuple(
+    "SET_IDENTITY", ["wallet", "pallet", "identified", "info"]
+)  # args: [identified: T::AccountId, info: Box<IdentityInfo<T::MaxAdditionalFields>>]  | Pallet: Registry
+SET_IDENTITY = namedtuple(
+    "SET_IDENTITY",
+    [
+        "wallet",
+        "pallet",
+        "name",
+        "url",
+        "github_repo",
+        "image",
+        "discord",
+        "description",
+        "additional",
+    ],
+)  # args: [name: Vec<u8>, url: Vec<u8>, github_repo: Vec<u8>, image: Vec<u8>, discord: Vec<u8>, description: Vec<u8>, additional: Vec<u8>]  | Pallet: SubtensorModule
+SET_KEY = namedtuple(
+    "SET_KEY", ["wallet", "pallet", "new"]
+)  # args: [new: AccountIdLookupOf<T>]  | Pallet: Sudo
+SET_MAX_SPACE = namedtuple(
+    "SET_MAX_SPACE", ["wallet", "pallet", "new_limit"]
+)  # args: [new_limit: u32]  | Pallet: Commitments
+SET_MECHANISM_WEIGHTS = namedtuple(
+    "SET_MECHANISM_WEIGHTS",
+    ["wallet", "pallet", "netuid", "mecid", "dests", "weights", "version_key"],
+)  # args: [netuid: NetUid, mecid: MechId, dests: Vec<u16>, weights: Vec<u16>, version_key: u64]  | Pallet: SubtensorModule
+SET_OLDEST_STORED_ROUND = namedtuple(
+    "SET_OLDEST_STORED_ROUND", ["wallet", "pallet", "oldest_round"]
+)  # args: [oldest_round: u64]  | Pallet: Drand
+SET_PENDING_CHILDKEY_COOLDOWN = namedtuple(
+    "SET_PENDING_CHILDKEY_COOLDOWN", ["wallet", "pallet", "cooldown"]
+)  # args: [cooldown: u64]  | Pallet: SubtensorModule
+SET_RETRY = namedtuple(
+    "SET_RETRY", ["wallet", "pallet", "task", "retries", "period"]
+)  # args: [task: TaskAddress<BlockNumberFor<T>>, retries: u8, period: BlockNumberFor<T>]  | Pallet: Scheduler
+SET_RETRY_NAMED = namedtuple(
+    "SET_RETRY_NAMED", ["wallet", "pallet", "id", "retries", "period"]
+)  # args: [id: TaskName, retries: u8, period: BlockNumberFor<T>]  | Pallet: Scheduler
+SET_ROOT_CLAIM_TYPE = namedtuple(
+    "SET_ROOT_CLAIM_TYPE", ["wallet", "pallet", "new_root_claim_type"]
+)  # args: [new_root_claim_type: RootClaimTypeEnum]  | Pallet: SubtensorModule
+SET_STORAGE = namedtuple(
+    "SET_STORAGE", ["wallet", "pallet", "items"]
+)  # args: [items: Vec<KeyValue>]  | Pallet: System
+SET_SUBNET_IDENTITY = namedtuple(
+    "SET_SUBNET_IDENTITY",
+    [
+        "wallet",
+        "pallet",
+        "netuid",
+        "subnet_name",
+        "github_repo",
+        "subnet_contact",
+        "subnet_url",
+        "discord",
+        "description",
+        "logo_url",
+        "additional",
+    ],
+)  # args: [netuid: NetUid, subnet_name: Vec<u8>, github_repo: Vec<u8>, subnet_contact: Vec<u8>, subnet_url: Vec<u8>, discord: Vec<u8>, description: Vec<u8>, logo_url: Vec<u8>, additional: Vec<u8>]  | Pallet: SubtensorModule
+SET_WEIGHTS = namedtuple(
+    "SET_WEIGHTS", ["wallet", "pallet", "netuid", "dests", "weights", "version_key"]
+)  # args: [netuid: NetUid, dests: Vec<u16>, weights: Vec<u16>, version_key: u64]  | Pallet: SubtensorModule
+SET_WHITELIST = namedtuple(
+    "SET_WHITELIST", ["wallet", "pallet", "new"]
+)  # args: [new: Vec<H160>]  | Pallet: EVM
+START_CALL = namedtuple(
+    "START_CALL", ["wallet", "pallet", "netuid"]
+)  # args: [netuid: NetUid]  | Pallet: SubtensorModule
+SUBMIT_ENCRYPTED = namedtuple(
+    "SUBMIT_ENCRYPTED", ["wallet", "pallet", "commitment", "ciphertext"]
+)  # args: [commitment: T::Hash, ciphertext: BoundedVec<u8, ConstU32<8192>>]  | Pallet: MevShield
+SUBNET_BUYBACK = namedtuple(
+    "SUBNET_BUYBACK", ["wallet", "pallet", "hotkey", "netuid", "amount", "limit"]
+)  # args: [hotkey: T::AccountId, netuid: NetUid, amount: TaoCurrency, limit: Option<TaoCurrency>]  | Pallet: SubtensorModule
+SUDO = namedtuple(
+    "SUDO", ["wallet", "pallet", "call"]
+)  # args: [call: Box<<T as Config>::RuntimeCall>]  | Pallet: Sudo
+SWAP_AUTHORITIES = namedtuple(
+    "SWAP_AUTHORITIES", ["wallet", "pallet", "new_authorities"]
+)  # args: [new_authorities: BoundedVec<<T as Config>::AuthorityId, T::MaxAuthorities>]  | Pallet: AdminUtils
+SWAP_COLDKEY = namedtuple(
+    "SWAP_COLDKEY", ["wallet", "pallet", "old_coldkey", "new_coldkey", "swap_cost"]
+)  # args: [old_coldkey: T::AccountId, new_coldkey: T::AccountId, swap_cost: TaoCurrency]  | Pallet: SubtensorModule
+SWAP_COLDKEY_ANNOUNCED = namedtuple(
+    "SWAP_COLDKEY_ANNOUNCED", ["wallet", "pallet", "new_coldkey"]
+)  # args: [new_coldkey: T::AccountId]  | Pallet: SubtensorModule
+SWAP_HOTKEY = namedtuple(
+    "SWAP_HOTKEY", ["wallet", "pallet", "hotkey", "new_hotkey", "netuid"]
+)  # args: [hotkey: T::AccountId, new_hotkey: T::AccountId, netuid: Option<NetUid>]  | Pallet: SubtensorModule
+SWAP_STAKE = namedtuple(
+    "SWAP_STAKE",
+    [
+        "wallet",
+        "pallet",
+        "hotkey",
+        "origin_netuid",
+        "destination_netuid",
+        "alpha_amount",
+    ],
+)  # args: [hotkey: T::AccountId, origin_netuid: NetUid, destination_netuid: NetUid, alpha_amount: AlphaCurrency]  | Pallet: SubtensorModule
+SWAP_STAKE_LIMIT = namedtuple(
+    "SWAP_STAKE_LIMIT",
+    [
+        "wallet",
+        "pallet",
+        "hotkey",
+        "origin_netuid",
+        "destination_netuid",
+        "alpha_amount",
+        "limit_price",
+        "allow_partial",
+    ],
+)  # args: [hotkey: T::AccountId, origin_netuid: NetUid, destination_netuid: NetUid, alpha_amount: AlphaCurrency, limit_price: TaoCurrency, allow_partial: bool]  | Pallet: SubtensorModule
+TERMINATE_LEASE = namedtuple(
+    "TERMINATE_LEASE", ["wallet", "pallet", "lease_id", "hotkey"]
+)  # args: [lease_id: LeaseId, hotkey: T::AccountId]  | Pallet: SubtensorModule
+TOGGLE_USER_LIQUIDITY = namedtuple(
+    "TOGGLE_USER_LIQUIDITY", ["wallet", "pallet", "netuid", "enable"]
+)  # args: [netuid: NetUid, enable: bool]  | Pallet: Swap
+TRANSACT = namedtuple(
+    "TRANSACT", ["wallet", "pallet", "transaction"]
+)  # args: [transaction: Transaction]  | Pallet: Ethereum
+TRANSFER_ALL = namedtuple(
+    "TRANSFER_ALL", ["wallet", "pallet", "dest", "keep_alive"]
+)  # args: [dest: AccountIdLookupOf<T>, keep_alive: bool]  | Pallet: Balances
+TRANSFER_ALLOW_DEATH = namedtuple(
+    "TRANSFER_ALLOW_DEATH", ["wallet", "pallet", "dest", "value"]
+)  # args: [dest: AccountIdLookupOf<T>, value: T::Balance]  | Pallet: Balances
+TRANSFER_KEEP_ALIVE = namedtuple(
+    "TRANSFER_KEEP_ALIVE", ["wallet", "pallet", "dest", "value"]
+)  # args: [dest: AccountIdLookupOf<T>, value: T::Balance]  | Pallet: Balances
+TRANSFER_STAKE = namedtuple(
+    "TRANSFER_STAKE",
+    [
+        "wallet",
+        "pallet",
+        "destination_coldkey",
+        "hotkey",
+        "origin_netuid",
+        "destination_netuid",
+        "alpha_amount",
+    ],
+)  # args: [destination_coldkey: T::AccountId, hotkey: T::AccountId, origin_netuid: NetUid, destination_netuid: NetUid, alpha_amount: AlphaCurrency]  | Pallet: SubtensorModule
+TRY_ASSOCIATE_HOTKEY = namedtuple(
+    "TRY_ASSOCIATE_HOTKEY", ["wallet", "pallet", "hotkey"]
+)  # args: [hotkey: T::AccountId]  | Pallet: SubtensorModule
+UNNOTE_PREIMAGE = namedtuple(
+    "UNNOTE_PREIMAGE", ["wallet", "pallet", "hash"]
+)  # args: [hash: T::Hash]  | Pallet: Preimage
+UNREQUEST_PREIMAGE = namedtuple(
+    "UNREQUEST_PREIMAGE", ["wallet", "pallet", "hash"]
+)  # args: [hash: T::Hash]  | Pallet: Preimage
+UNSTAKE_ALL = namedtuple(
+    "UNSTAKE_ALL", ["wallet", "pallet", "hotkey"]
+)  # args: [hotkey: T::AccountId]  | Pallet: SubtensorModule
+UNSTAKE_ALL_ALPHA = namedtuple(
+    "UNSTAKE_ALL_ALPHA", ["wallet", "pallet", "hotkey"]
+)  # args: [hotkey: T::AccountId]  | Pallet: SubtensorModule
+UPDATE_CAP = namedtuple(
+    "UPDATE_CAP", ["wallet", "pallet", "crowdloan_id", "new_cap"]
+)  # args: [crowdloan_id: CrowdloanId, new_cap: BalanceOf<T>]  | Pallet: Crowdloan
+UPDATE_END = namedtuple(
+    "UPDATE_END", ["wallet", "pallet", "crowdloan_id", "new_end"]
+)  # args: [crowdloan_id: CrowdloanId, new_end: BlockNumberFor<T>]  | Pallet: Crowdloan
+UPDATE_MIN_CONTRIBUTION = namedtuple(
+    "UPDATE_MIN_CONTRIBUTION",
+    ["wallet", "pallet", "crowdloan_id", "new_min_contribution"],
+)  # args: [crowdloan_id: CrowdloanId, new_min_contribution: BalanceOf<T>]  | Pallet: Crowdloan
+UPDATE_SYMBOL = namedtuple(
+    "UPDATE_SYMBOL", ["wallet", "pallet", "netuid", "symbol"]
+)  # args: [netuid: NetUid, symbol: Vec<u8>]  | Pallet: SubtensorModule
+UPGRADE_ACCOUNTS = namedtuple(
+    "UPGRADE_ACCOUNTS", ["wallet", "pallet", "who"]
+)  # args: [who: Vec<T::AccountId>]  | Pallet: Balances
+UPLOAD_CODE = namedtuple(
+    "UPLOAD_CODE", ["wallet", "pallet", "code", "storage_deposit_limit", "determinism"]
+)  # args: [code: Vec<u8>, storage_deposit_limit: Option<<BalanceOf<T> as codec::HasCompact>::Type>, determinism: Determinism]  | Pallet: Contracts
+WITHDRAW = namedtuple(
+    "WITHDRAW", ["wallet", "pallet", "address", "value"]
+)  # args: [address: H160, value: BalanceOf<T>]  | Pallet: EVM
+WITHDRAW = namedtuple(
+    "WITHDRAW", ["wallet", "pallet", "crowdloan_id"]
+)  # args: [crowdloan_id: CrowdloanId]  | Pallet: Crowdloan
+WITH_WEIGHT = namedtuple(
+    "WITH_WEIGHT", ["wallet", "pallet", "call", "weight"]
+)  # args: [call: Box<<T as Config>::RuntimeCall>, weight: Weight]  | Pallet: Utility
+WRITE_PULSE = namedtuple(
+    "WRITE_PULSE", ["wallet", "pallet", "pulses_payload", "signature"]
+)  # args: [pulses_payload: PulsesPayload<T::Public, BlockNumberFor<T>>, signature: Option<T::Signature>]  | Pallet: Drand

--- a/bittensor/extras/dev_framework/calls/pallets.py
+++ b/bittensor/extras/dev_framework/calls/pallets.py
@@ -1,6 +1,7 @@
-""""
-    Subtensor spec version: 375 
+""" "
+Subtensor spec version: 375
 """
+
 System = "System"
 Timestamp = "Timestamp"
 Grandpa = "Grandpa"

--- a/bittensor/extras/dev_framework/calls/pallets.py
+++ b/bittensor/extras/dev_framework/calls/pallets.py
@@ -1,7 +1,6 @@
-""" "
-Subtensor spec version: 365
+""""
+    Subtensor spec version: 375 
 """
-
 System = "System"
 Timestamp = "Timestamp"
 Grandpa = "Grandpa"

--- a/bittensor/extras/dev_framework/calls/sudo_calls.py
+++ b/bittensor/extras/dev_framework/calls/sudo_calls.py
@@ -17,83 +17,275 @@ Note:
 from collections import namedtuple
 
 
-SUDO_AS = namedtuple("SUDO_AS", ["wallet", "pallet", "sudo", "who", "call"])  # args: [who: AccountIdLookupOf<T>, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Sudo
-SUDO_SET_ACTIVITY_CUTOFF = namedtuple("SUDO_SET_ACTIVITY_CUTOFF", ["wallet", "pallet", "sudo", "netuid", "activity_cutoff"])  # args: [netuid: NetUid, activity_cutoff: u16]  | Pallet: AdminUtils
-SUDO_SET_ADJUSTMENT_ALPHA = namedtuple("SUDO_SET_ADJUSTMENT_ALPHA", ["wallet", "pallet", "sudo", "netuid", "adjustment_alpha"])  # args: [netuid: NetUid, adjustment_alpha: u64]  | Pallet: AdminUtils
-SUDO_SET_ADJUSTMENT_INTERVAL = namedtuple("SUDO_SET_ADJUSTMENT_INTERVAL", ["wallet", "pallet", "sudo", "netuid", "adjustment_interval"])  # args: [netuid: NetUid, adjustment_interval: u16]  | Pallet: AdminUtils
-SUDO_SET_ADMIN_FREEZE_WINDOW = namedtuple("SUDO_SET_ADMIN_FREEZE_WINDOW", ["wallet", "pallet", "sudo", "window"])  # args: [window: u16]  | Pallet: AdminUtils
-SUDO_SET_ALPHA_SIGMOID_STEEPNESS = namedtuple("SUDO_SET_ALPHA_SIGMOID_STEEPNESS", ["wallet", "pallet", "sudo", "netuid", "steepness"])  # args: [netuid: NetUid, steepness: i16]  | Pallet: AdminUtils
-SUDO_SET_ALPHA_VALUES = namedtuple("SUDO_SET_ALPHA_VALUES", ["wallet", "pallet", "sudo", "netuid", "alpha_low", "alpha_high"])  # args: [netuid: NetUid, alpha_low: u16, alpha_high: u16]  | Pallet: AdminUtils
-SUDO_SET_BONDS_MOVING_AVERAGE = namedtuple("SUDO_SET_BONDS_MOVING_AVERAGE", ["wallet", "pallet", "sudo", "netuid", "bonds_moving_average"])  # args: [netuid: NetUid, bonds_moving_average: u64]  | Pallet: AdminUtils
-SUDO_SET_BONDS_PENALTY = namedtuple("SUDO_SET_BONDS_PENALTY", ["wallet", "pallet", "sudo", "netuid", "bonds_penalty"])  # args: [netuid: NetUid, bonds_penalty: u16]  | Pallet: AdminUtils
-SUDO_SET_BONDS_RESET_ENABLED = namedtuple("SUDO_SET_BONDS_RESET_ENABLED", ["wallet", "pallet", "sudo", "netuid", "enabled"])  # args: [netuid: NetUid, enabled: bool]  | Pallet: AdminUtils
-SUDO_SET_CK_BURN = namedtuple("SUDO_SET_CK_BURN", ["wallet", "pallet", "sudo", "burn"])  # args: [burn: u64]  | Pallet: AdminUtils
-SUDO_SET_COLDKEY_SWAP_ANNOUNCEMENT_DELAY = namedtuple("SUDO_SET_COLDKEY_SWAP_ANNOUNCEMENT_DELAY", ["wallet", "pallet", "sudo", "duration"])  # args: [duration: BlockNumberFor<T>]  | Pallet: AdminUtils
-SUDO_SET_COLDKEY_SWAP_REANNOUNCEMENT_DELAY = namedtuple("SUDO_SET_COLDKEY_SWAP_REANNOUNCEMENT_DELAY", ["wallet", "pallet", "sudo", "duration"])  # args: [duration: BlockNumberFor<T>]  | Pallet: AdminUtils
-SUDO_SET_COMMIT_REVEAL_VERSION = namedtuple("SUDO_SET_COMMIT_REVEAL_VERSION", ["wallet", "pallet", "sudo", "version"])  # args: [version: u16]  | Pallet: AdminUtils
-SUDO_SET_COMMIT_REVEAL_WEIGHTS_ENABLED = namedtuple("SUDO_SET_COMMIT_REVEAL_WEIGHTS_ENABLED", ["wallet", "pallet", "sudo", "netuid", "enabled"])  # args: [netuid: NetUid, enabled: bool]  | Pallet: AdminUtils
-SUDO_SET_COMMIT_REVEAL_WEIGHTS_INTERVAL = namedtuple("SUDO_SET_COMMIT_REVEAL_WEIGHTS_INTERVAL", ["wallet", "pallet", "sudo", "netuid", "interval"])  # args: [netuid: NetUid, interval: u64]  | Pallet: AdminUtils
-SUDO_SET_DEFAULT_TAKE = namedtuple("SUDO_SET_DEFAULT_TAKE", ["wallet", "pallet", "sudo", "default_take"])  # args: [default_take: u16]  | Pallet: AdminUtils
-SUDO_SET_DIFFICULTY = namedtuple("SUDO_SET_DIFFICULTY", ["wallet", "pallet", "sudo", "netuid", "difficulty"])  # args: [netuid: NetUid, difficulty: u64]  | Pallet: AdminUtils
-SUDO_SET_DISSOLVE_NETWORK_SCHEDULE_DURATION = namedtuple("SUDO_SET_DISSOLVE_NETWORK_SCHEDULE_DURATION", ["wallet", "pallet", "sudo", "duration"])  # args: [duration: BlockNumberFor<T>]  | Pallet: AdminUtils
-SUDO_SET_EMA_PRICE_HALVING_PERIOD = namedtuple("SUDO_SET_EMA_PRICE_HALVING_PERIOD", ["wallet", "pallet", "sudo", "netuid", "ema_halving"])  # args: [netuid: NetUid, ema_halving: u64]  | Pallet: AdminUtils
-SUDO_SET_EVM_CHAIN_ID = namedtuple("SUDO_SET_EVM_CHAIN_ID", ["wallet", "pallet", "sudo", "chain_id"])  # args: [chain_id: u64]  | Pallet: AdminUtils
-SUDO_SET_IMMUNITY_PERIOD = namedtuple("SUDO_SET_IMMUNITY_PERIOD", ["wallet", "pallet", "sudo", "netuid", "immunity_period"])  # args: [netuid: NetUid, immunity_period: u16]  | Pallet: AdminUtils
-SUDO_SET_KAPPA = namedtuple("SUDO_SET_KAPPA", ["wallet", "pallet", "sudo", "netuid", "kappa"])  # args: [netuid: NetUid, kappa: u16]  | Pallet: AdminUtils
-SUDO_SET_LIQUID_ALPHA_ENABLED = namedtuple("SUDO_SET_LIQUID_ALPHA_ENABLED", ["wallet", "pallet", "sudo", "netuid", "enabled"])  # args: [netuid: NetUid, enabled: bool]  | Pallet: AdminUtils
-SUDO_SET_LOCK_REDUCTION_INTERVAL = namedtuple("SUDO_SET_LOCK_REDUCTION_INTERVAL", ["wallet", "pallet", "sudo", "interval"])  # args: [interval: u64]  | Pallet: AdminUtils
-SUDO_SET_MAX_ALLOWED_UIDS = namedtuple("SUDO_SET_MAX_ALLOWED_UIDS", ["wallet", "pallet", "sudo", "netuid", "max_allowed_uids"])  # args: [netuid: NetUid, max_allowed_uids: u16]  | Pallet: AdminUtils
-SUDO_SET_MAX_ALLOWED_VALIDATORS = namedtuple("SUDO_SET_MAX_ALLOWED_VALIDATORS", ["wallet", "pallet", "sudo", "netuid", "max_allowed_validators"])  # args: [netuid: NetUid, max_allowed_validators: u16]  | Pallet: AdminUtils
-SUDO_SET_MAX_BURN = namedtuple("SUDO_SET_MAX_BURN", ["wallet", "pallet", "sudo", "netuid", "max_burn"])  # args: [netuid: NetUid, max_burn: TaoCurrency]  | Pallet: AdminUtils
-SUDO_SET_MAX_CHILDKEY_TAKE = namedtuple("SUDO_SET_MAX_CHILDKEY_TAKE", ["wallet", "pallet", "sudo", "take"])  # args: [take: u16]  | Pallet: SubtensorModule
-SUDO_SET_MAX_DIFFICULTY = namedtuple("SUDO_SET_MAX_DIFFICULTY", ["wallet", "pallet", "sudo", "netuid", "max_difficulty"])  # args: [netuid: NetUid, max_difficulty: u64]  | Pallet: AdminUtils
-SUDO_SET_MAX_MECHANISM_COUNT = namedtuple("SUDO_SET_MAX_MECHANISM_COUNT", ["wallet", "pallet", "sudo", "max_mechanism_count"])  # args: [max_mechanism_count: MechId]  | Pallet: AdminUtils
-SUDO_SET_MAX_REGISTRATIONS_PER_BLOCK = namedtuple("SUDO_SET_MAX_REGISTRATIONS_PER_BLOCK", ["wallet", "pallet", "sudo", "netuid", "max_registrations_per_block"])  # args: [netuid: NetUid, max_registrations_per_block: u16]  | Pallet: AdminUtils
-SUDO_SET_MECHANISM_COUNT = namedtuple("SUDO_SET_MECHANISM_COUNT", ["wallet", "pallet", "sudo", "netuid", "mechanism_count"])  # args: [netuid: NetUid, mechanism_count: MechId]  | Pallet: AdminUtils
-SUDO_SET_MECHANISM_EMISSION_SPLIT = namedtuple("SUDO_SET_MECHANISM_EMISSION_SPLIT", ["wallet", "pallet", "sudo", "netuid", "maybe_split"])  # args: [netuid: NetUid, maybe_split: Option<Vec<u16>>]  | Pallet: AdminUtils
-SUDO_SET_MIN_ALLOWED_UIDS = namedtuple("SUDO_SET_MIN_ALLOWED_UIDS", ["wallet", "pallet", "sudo", "netuid", "min_allowed_uids"])  # args: [netuid: NetUid, min_allowed_uids: u16]  | Pallet: AdminUtils
-SUDO_SET_MIN_ALLOWED_WEIGHTS = namedtuple("SUDO_SET_MIN_ALLOWED_WEIGHTS", ["wallet", "pallet", "sudo", "netuid", "min_allowed_weights"])  # args: [netuid: NetUid, min_allowed_weights: u16]  | Pallet: AdminUtils
-SUDO_SET_MIN_BURN = namedtuple("SUDO_SET_MIN_BURN", ["wallet", "pallet", "sudo", "netuid", "min_burn"])  # args: [netuid: NetUid, min_burn: TaoCurrency]  | Pallet: AdminUtils
-SUDO_SET_MIN_CHILDKEY_TAKE = namedtuple("SUDO_SET_MIN_CHILDKEY_TAKE", ["wallet", "pallet", "sudo", "take"])  # args: [take: u16]  | Pallet: SubtensorModule
-SUDO_SET_MIN_DELEGATE_TAKE = namedtuple("SUDO_SET_MIN_DELEGATE_TAKE", ["wallet", "pallet", "sudo", "take"])  # args: [take: u16]  | Pallet: AdminUtils
-SUDO_SET_MIN_DIFFICULTY = namedtuple("SUDO_SET_MIN_DIFFICULTY", ["wallet", "pallet", "sudo", "netuid", "min_difficulty"])  # args: [netuid: NetUid, min_difficulty: u64]  | Pallet: AdminUtils
-SUDO_SET_MIN_NON_IMMUNE_UIDS = namedtuple("SUDO_SET_MIN_NON_IMMUNE_UIDS", ["wallet", "pallet", "sudo", "netuid", "min"])  # args: [netuid: NetUid, min: u16]  | Pallet: AdminUtils
-SUDO_SET_NETWORK_IMMUNITY_PERIOD = namedtuple("SUDO_SET_NETWORK_IMMUNITY_PERIOD", ["wallet", "pallet", "sudo", "immunity_period"])  # args: [immunity_period: u64]  | Pallet: AdminUtils
-SUDO_SET_NETWORK_MIN_LOCK_COST = namedtuple("SUDO_SET_NETWORK_MIN_LOCK_COST", ["wallet", "pallet", "sudo", "lock_cost"])  # args: [lock_cost: TaoCurrency]  | Pallet: AdminUtils
-SUDO_SET_NETWORK_POW_REGISTRATION_ALLOWED = namedtuple("SUDO_SET_NETWORK_POW_REGISTRATION_ALLOWED", ["wallet", "pallet", "sudo", "netuid", "registration_allowed"])  # args: [netuid: NetUid, registration_allowed: bool]  | Pallet: AdminUtils
-SUDO_SET_NETWORK_RATE_LIMIT = namedtuple("SUDO_SET_NETWORK_RATE_LIMIT", ["wallet", "pallet", "sudo", "rate_limit"])  # args: [rate_limit: u64]  | Pallet: AdminUtils
-SUDO_SET_NETWORK_REGISTRATION_ALLOWED = namedtuple("SUDO_SET_NETWORK_REGISTRATION_ALLOWED", ["wallet", "pallet", "sudo", "netuid", "registration_allowed"])  # args: [netuid: NetUid, registration_allowed: bool]  | Pallet: AdminUtils
-SUDO_SET_NOMINATOR_MIN_REQUIRED_STAKE = namedtuple("SUDO_SET_NOMINATOR_MIN_REQUIRED_STAKE", ["wallet", "pallet", "sudo", "min_stake"])  # args: [min_stake: u64]  | Pallet: AdminUtils
-SUDO_SET_NUM_ROOT_CLAIMS = namedtuple("SUDO_SET_NUM_ROOT_CLAIMS", ["wallet", "pallet", "sudo", "new_value"])  # args: [new_value: u64]  | Pallet: SubtensorModule
-SUDO_SET_OWNER_HPARAM_RATE_LIMIT = namedtuple("SUDO_SET_OWNER_HPARAM_RATE_LIMIT", ["wallet", "pallet", "sudo", "epochs"])  # args: [epochs: u16]  | Pallet: AdminUtils
-SUDO_SET_OWNER_IMMUNE_NEURON_LIMIT = namedtuple("SUDO_SET_OWNER_IMMUNE_NEURON_LIMIT", ["wallet", "pallet", "sudo", "netuid", "immune_neurons"])  # args: [netuid: NetUid, immune_neurons: u16]  | Pallet: AdminUtils
-SUDO_SET_RAO_RECYCLED = namedtuple("SUDO_SET_RAO_RECYCLED", ["wallet", "pallet", "sudo", "netuid", "rao_recycled"])  # args: [netuid: NetUid, rao_recycled: TaoCurrency]  | Pallet: AdminUtils
-SUDO_SET_RECYCLE_OR_BURN = namedtuple("SUDO_SET_RECYCLE_OR_BURN", ["wallet", "pallet", "sudo", "netuid", "recycle_or_burn"])  # args: [netuid: NetUid, recycle_or_burn: pallet_subtensor::RecycleOrBurnEnum]  | Pallet: AdminUtils
-SUDO_SET_RHO = namedtuple("SUDO_SET_RHO", ["wallet", "pallet", "sudo", "netuid", "rho"])  # args: [netuid: NetUid, rho: u16]  | Pallet: AdminUtils
-SUDO_SET_ROOT_CLAIM_THRESHOLD = namedtuple("SUDO_SET_ROOT_CLAIM_THRESHOLD", ["wallet", "pallet", "sudo", "netuid", "new_value"])  # args: [netuid: NetUid, new_value: u64]  | Pallet: SubtensorModule
-SUDO_SET_SERVING_RATE_LIMIT = namedtuple("SUDO_SET_SERVING_RATE_LIMIT", ["wallet", "pallet", "sudo", "netuid", "serving_rate_limit"])  # args: [netuid: NetUid, serving_rate_limit: u64]  | Pallet: AdminUtils
-SUDO_SET_SN_OWNER_HOTKEY = namedtuple("SUDO_SET_SN_OWNER_HOTKEY", ["wallet", "pallet", "sudo", "netuid", "hotkey"])  # args: [netuid: NetUid, hotkey: <T as frame_system::Config>::AccountId]  | Pallet: AdminUtils
-SUDO_SET_STAKE_THRESHOLD = namedtuple("SUDO_SET_STAKE_THRESHOLD", ["wallet", "pallet", "sudo", "min_stake"])  # args: [min_stake: u64]  | Pallet: AdminUtils
-SUDO_SET_START_CALL_DELAY = namedtuple("SUDO_SET_START_CALL_DELAY", ["wallet", "pallet", "sudo", "delay"])  # args: [delay: u64]  | Pallet: AdminUtils
-SUDO_SET_SUBNET_LIMIT = namedtuple("SUDO_SET_SUBNET_LIMIT", ["wallet", "pallet", "sudo", "max_subnets"])  # args: [max_subnets: u16]  | Pallet: AdminUtils
-SUDO_SET_SUBNET_MOVING_ALPHA = namedtuple("SUDO_SET_SUBNET_MOVING_ALPHA", ["wallet", "pallet", "sudo", "alpha"])  # args: [alpha: I96F32]  | Pallet: AdminUtils
-SUDO_SET_SUBNET_OWNER_CUT = namedtuple("SUDO_SET_SUBNET_OWNER_CUT", ["wallet", "pallet", "sudo", "subnet_owner_cut"])  # args: [subnet_owner_cut: u16]  | Pallet: AdminUtils
-SUDO_SET_SUBNET_OWNER_HOTKEY = namedtuple("SUDO_SET_SUBNET_OWNER_HOTKEY", ["wallet", "pallet", "sudo", "netuid", "hotkey"])  # args: [netuid: NetUid, hotkey: <T as frame_system::Config>::AccountId]  | Pallet: AdminUtils
-SUDO_SET_SUBTOKEN_ENABLED = namedtuple("SUDO_SET_SUBTOKEN_ENABLED", ["wallet", "pallet", "sudo", "netuid", "subtoken_enabled"])  # args: [netuid: NetUid, subtoken_enabled: bool]  | Pallet: AdminUtils
-SUDO_SET_TAO_FLOW_CUTOFF = namedtuple("SUDO_SET_TAO_FLOW_CUTOFF", ["wallet", "pallet", "sudo", "flow_cutoff"])  # args: [flow_cutoff: I64F64]  | Pallet: AdminUtils
-SUDO_SET_TAO_FLOW_NORMALIZATION_EXPONENT = namedtuple("SUDO_SET_TAO_FLOW_NORMALIZATION_EXPONENT", ["wallet", "pallet", "sudo", "exponent"])  # args: [exponent: U64F64]  | Pallet: AdminUtils
-SUDO_SET_TAO_FLOW_SMOOTHING_FACTOR = namedtuple("SUDO_SET_TAO_FLOW_SMOOTHING_FACTOR", ["wallet", "pallet", "sudo", "smoothing_factor"])  # args: [smoothing_factor: u64]  | Pallet: AdminUtils
-SUDO_SET_TARGET_REGISTRATIONS_PER_INTERVAL = namedtuple("SUDO_SET_TARGET_REGISTRATIONS_PER_INTERVAL", ["wallet", "pallet", "sudo", "netuid", "target_registrations_per_interval"])  # args: [netuid: NetUid, target_registrations_per_interval: u16]  | Pallet: AdminUtils
-SUDO_SET_TEMPO = namedtuple("SUDO_SET_TEMPO", ["wallet", "pallet", "sudo", "netuid", "tempo"])  # args: [netuid: NetUid, tempo: u16]  | Pallet: AdminUtils
-SUDO_SET_TOGGLE_TRANSFER = namedtuple("SUDO_SET_TOGGLE_TRANSFER", ["wallet", "pallet", "sudo", "netuid", "toggle"])  # args: [netuid: NetUid, toggle: bool]  | Pallet: AdminUtils
-SUDO_SET_TOTAL_ISSUANCE = namedtuple("SUDO_SET_TOTAL_ISSUANCE", ["wallet", "pallet", "sudo", "total_issuance"])  # args: [total_issuance: TaoCurrency]  | Pallet: AdminUtils
-SUDO_SET_TX_CHILDKEY_TAKE_RATE_LIMIT = namedtuple("SUDO_SET_TX_CHILDKEY_TAKE_RATE_LIMIT", ["wallet", "pallet", "sudo", "tx_rate_limit"])  # args: [tx_rate_limit: u64]  | Pallet: SubtensorModule
-SUDO_SET_TX_DELEGATE_TAKE_RATE_LIMIT = namedtuple("SUDO_SET_TX_DELEGATE_TAKE_RATE_LIMIT", ["wallet", "pallet", "sudo", "tx_rate_limit"])  # args: [tx_rate_limit: u64]  | Pallet: AdminUtils
-SUDO_SET_TX_RATE_LIMIT = namedtuple("SUDO_SET_TX_RATE_LIMIT", ["wallet", "pallet", "sudo", "tx_rate_limit"])  # args: [tx_rate_limit: u64]  | Pallet: AdminUtils
-SUDO_SET_VOTING_POWER_EMA_ALPHA = namedtuple("SUDO_SET_VOTING_POWER_EMA_ALPHA", ["wallet", "pallet", "sudo", "netuid", "alpha"])  # args: [netuid: NetUid, alpha: u64]  | Pallet: SubtensorModule
-SUDO_SET_WEIGHTS_SET_RATE_LIMIT = namedtuple("SUDO_SET_WEIGHTS_SET_RATE_LIMIT", ["wallet", "pallet", "sudo", "netuid", "weights_set_rate_limit"])  # args: [netuid: NetUid, weights_set_rate_limit: u64]  | Pallet: AdminUtils
-SUDO_SET_WEIGHTS_VERSION_KEY = namedtuple("SUDO_SET_WEIGHTS_VERSION_KEY", ["wallet", "pallet", "sudo", "netuid", "weights_version_key"])  # args: [netuid: NetUid, weights_version_key: u64]  | Pallet: AdminUtils
-SUDO_SET_YUMA3_ENABLED = namedtuple("SUDO_SET_YUMA3_ENABLED", ["wallet", "pallet", "sudo", "netuid", "enabled"])  # args: [netuid: NetUid, enabled: bool]  | Pallet: AdminUtils
-SUDO_TOGGLE_EVM_PRECOMPILE = namedtuple("SUDO_TOGGLE_EVM_PRECOMPILE", ["wallet", "pallet", "sudo", "precompile_id", "enabled"])  # args: [precompile_id: PrecompileEnum, enabled: bool]  | Pallet: AdminUtils
-SUDO_TRIM_TO_MAX_ALLOWED_UIDS = namedtuple("SUDO_TRIM_TO_MAX_ALLOWED_UIDS", ["wallet", "pallet", "sudo", "netuid", "max_n"])  # args: [netuid: NetUid, max_n: u16]  | Pallet: AdminUtils
-SUDO_UNCHECKED_WEIGHT = namedtuple("SUDO_UNCHECKED_WEIGHT", ["wallet", "pallet", "sudo", "call", "weight"])  # args: [call: Box<<T as Config>::RuntimeCall>, weight: Weight]  | Pallet: Sudo
+SUDO_AS = namedtuple(
+    "SUDO_AS", ["wallet", "pallet", "sudo", "who", "call"]
+)  # args: [who: AccountIdLookupOf<T>, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Sudo
+SUDO_SET_ACTIVITY_CUTOFF = namedtuple(
+    "SUDO_SET_ACTIVITY_CUTOFF",
+    ["wallet", "pallet", "sudo", "netuid", "activity_cutoff"],
+)  # args: [netuid: NetUid, activity_cutoff: u16]  | Pallet: AdminUtils
+SUDO_SET_ADJUSTMENT_ALPHA = namedtuple(
+    "SUDO_SET_ADJUSTMENT_ALPHA",
+    ["wallet", "pallet", "sudo", "netuid", "adjustment_alpha"],
+)  # args: [netuid: NetUid, adjustment_alpha: u64]  | Pallet: AdminUtils
+SUDO_SET_ADJUSTMENT_INTERVAL = namedtuple(
+    "SUDO_SET_ADJUSTMENT_INTERVAL",
+    ["wallet", "pallet", "sudo", "netuid", "adjustment_interval"],
+)  # args: [netuid: NetUid, adjustment_interval: u16]  | Pallet: AdminUtils
+SUDO_SET_ADMIN_FREEZE_WINDOW = namedtuple(
+    "SUDO_SET_ADMIN_FREEZE_WINDOW", ["wallet", "pallet", "sudo", "window"]
+)  # args: [window: u16]  | Pallet: AdminUtils
+SUDO_SET_ALPHA_SIGMOID_STEEPNESS = namedtuple(
+    "SUDO_SET_ALPHA_SIGMOID_STEEPNESS",
+    ["wallet", "pallet", "sudo", "netuid", "steepness"],
+)  # args: [netuid: NetUid, steepness: i16]  | Pallet: AdminUtils
+SUDO_SET_ALPHA_VALUES = namedtuple(
+    "SUDO_SET_ALPHA_VALUES",
+    ["wallet", "pallet", "sudo", "netuid", "alpha_low", "alpha_high"],
+)  # args: [netuid: NetUid, alpha_low: u16, alpha_high: u16]  | Pallet: AdminUtils
+SUDO_SET_BONDS_MOVING_AVERAGE = namedtuple(
+    "SUDO_SET_BONDS_MOVING_AVERAGE",
+    ["wallet", "pallet", "sudo", "netuid", "bonds_moving_average"],
+)  # args: [netuid: NetUid, bonds_moving_average: u64]  | Pallet: AdminUtils
+SUDO_SET_BONDS_PENALTY = namedtuple(
+    "SUDO_SET_BONDS_PENALTY", ["wallet", "pallet", "sudo", "netuid", "bonds_penalty"]
+)  # args: [netuid: NetUid, bonds_penalty: u16]  | Pallet: AdminUtils
+SUDO_SET_BONDS_RESET_ENABLED = namedtuple(
+    "SUDO_SET_BONDS_RESET_ENABLED", ["wallet", "pallet", "sudo", "netuid", "enabled"]
+)  # args: [netuid: NetUid, enabled: bool]  | Pallet: AdminUtils
+SUDO_SET_CK_BURN = namedtuple(
+    "SUDO_SET_CK_BURN", ["wallet", "pallet", "sudo", "burn"]
+)  # args: [burn: u64]  | Pallet: AdminUtils
+SUDO_SET_COLDKEY_SWAP_ANNOUNCEMENT_DELAY = namedtuple(
+    "SUDO_SET_COLDKEY_SWAP_ANNOUNCEMENT_DELAY", ["wallet", "pallet", "sudo", "duration"]
+)  # args: [duration: BlockNumberFor<T>]  | Pallet: AdminUtils
+SUDO_SET_COLDKEY_SWAP_REANNOUNCEMENT_DELAY = namedtuple(
+    "SUDO_SET_COLDKEY_SWAP_REANNOUNCEMENT_DELAY",
+    ["wallet", "pallet", "sudo", "duration"],
+)  # args: [duration: BlockNumberFor<T>]  | Pallet: AdminUtils
+SUDO_SET_COMMIT_REVEAL_VERSION = namedtuple(
+    "SUDO_SET_COMMIT_REVEAL_VERSION", ["wallet", "pallet", "sudo", "version"]
+)  # args: [version: u16]  | Pallet: AdminUtils
+SUDO_SET_COMMIT_REVEAL_WEIGHTS_ENABLED = namedtuple(
+    "SUDO_SET_COMMIT_REVEAL_WEIGHTS_ENABLED",
+    ["wallet", "pallet", "sudo", "netuid", "enabled"],
+)  # args: [netuid: NetUid, enabled: bool]  | Pallet: AdminUtils
+SUDO_SET_COMMIT_REVEAL_WEIGHTS_INTERVAL = namedtuple(
+    "SUDO_SET_COMMIT_REVEAL_WEIGHTS_INTERVAL",
+    ["wallet", "pallet", "sudo", "netuid", "interval"],
+)  # args: [netuid: NetUid, interval: u64]  | Pallet: AdminUtils
+SUDO_SET_DEFAULT_TAKE = namedtuple(
+    "SUDO_SET_DEFAULT_TAKE", ["wallet", "pallet", "sudo", "default_take"]
+)  # args: [default_take: u16]  | Pallet: AdminUtils
+SUDO_SET_DIFFICULTY = namedtuple(
+    "SUDO_SET_DIFFICULTY", ["wallet", "pallet", "sudo", "netuid", "difficulty"]
+)  # args: [netuid: NetUid, difficulty: u64]  | Pallet: AdminUtils
+SUDO_SET_DISSOLVE_NETWORK_SCHEDULE_DURATION = namedtuple(
+    "SUDO_SET_DISSOLVE_NETWORK_SCHEDULE_DURATION",
+    ["wallet", "pallet", "sudo", "duration"],
+)  # args: [duration: BlockNumberFor<T>]  | Pallet: AdminUtils
+SUDO_SET_EMA_PRICE_HALVING_PERIOD = namedtuple(
+    "SUDO_SET_EMA_PRICE_HALVING_PERIOD",
+    ["wallet", "pallet", "sudo", "netuid", "ema_halving"],
+)  # args: [netuid: NetUid, ema_halving: u64]  | Pallet: AdminUtils
+SUDO_SET_EVM_CHAIN_ID = namedtuple(
+    "SUDO_SET_EVM_CHAIN_ID", ["wallet", "pallet", "sudo", "chain_id"]
+)  # args: [chain_id: u64]  | Pallet: AdminUtils
+SUDO_SET_IMMUNITY_PERIOD = namedtuple(
+    "SUDO_SET_IMMUNITY_PERIOD",
+    ["wallet", "pallet", "sudo", "netuid", "immunity_period"],
+)  # args: [netuid: NetUid, immunity_period: u16]  | Pallet: AdminUtils
+SUDO_SET_KAPPA = namedtuple(
+    "SUDO_SET_KAPPA", ["wallet", "pallet", "sudo", "netuid", "kappa"]
+)  # args: [netuid: NetUid, kappa: u16]  | Pallet: AdminUtils
+SUDO_SET_LIQUID_ALPHA_ENABLED = namedtuple(
+    "SUDO_SET_LIQUID_ALPHA_ENABLED", ["wallet", "pallet", "sudo", "netuid", "enabled"]
+)  # args: [netuid: NetUid, enabled: bool]  | Pallet: AdminUtils
+SUDO_SET_LOCK_REDUCTION_INTERVAL = namedtuple(
+    "SUDO_SET_LOCK_REDUCTION_INTERVAL", ["wallet", "pallet", "sudo", "interval"]
+)  # args: [interval: u64]  | Pallet: AdminUtils
+SUDO_SET_MAX_ALLOWED_UIDS = namedtuple(
+    "SUDO_SET_MAX_ALLOWED_UIDS",
+    ["wallet", "pallet", "sudo", "netuid", "max_allowed_uids"],
+)  # args: [netuid: NetUid, max_allowed_uids: u16]  | Pallet: AdminUtils
+SUDO_SET_MAX_ALLOWED_VALIDATORS = namedtuple(
+    "SUDO_SET_MAX_ALLOWED_VALIDATORS",
+    ["wallet", "pallet", "sudo", "netuid", "max_allowed_validators"],
+)  # args: [netuid: NetUid, max_allowed_validators: u16]  | Pallet: AdminUtils
+SUDO_SET_MAX_BURN = namedtuple(
+    "SUDO_SET_MAX_BURN", ["wallet", "pallet", "sudo", "netuid", "max_burn"]
+)  # args: [netuid: NetUid, max_burn: TaoCurrency]  | Pallet: AdminUtils
+SUDO_SET_MAX_CHILDKEY_TAKE = namedtuple(
+    "SUDO_SET_MAX_CHILDKEY_TAKE", ["wallet", "pallet", "sudo", "take"]
+)  # args: [take: u16]  | Pallet: SubtensorModule
+SUDO_SET_MAX_DIFFICULTY = namedtuple(
+    "SUDO_SET_MAX_DIFFICULTY", ["wallet", "pallet", "sudo", "netuid", "max_difficulty"]
+)  # args: [netuid: NetUid, max_difficulty: u64]  | Pallet: AdminUtils
+SUDO_SET_MAX_MECHANISM_COUNT = namedtuple(
+    "SUDO_SET_MAX_MECHANISM_COUNT", ["wallet", "pallet", "sudo", "max_mechanism_count"]
+)  # args: [max_mechanism_count: MechId]  | Pallet: AdminUtils
+SUDO_SET_MAX_REGISTRATIONS_PER_BLOCK = namedtuple(
+    "SUDO_SET_MAX_REGISTRATIONS_PER_BLOCK",
+    ["wallet", "pallet", "sudo", "netuid", "max_registrations_per_block"],
+)  # args: [netuid: NetUid, max_registrations_per_block: u16]  | Pallet: AdminUtils
+SUDO_SET_MECHANISM_COUNT = namedtuple(
+    "SUDO_SET_MECHANISM_COUNT",
+    ["wallet", "pallet", "sudo", "netuid", "mechanism_count"],
+)  # args: [netuid: NetUid, mechanism_count: MechId]  | Pallet: AdminUtils
+SUDO_SET_MECHANISM_EMISSION_SPLIT = namedtuple(
+    "SUDO_SET_MECHANISM_EMISSION_SPLIT",
+    ["wallet", "pallet", "sudo", "netuid", "maybe_split"],
+)  # args: [netuid: NetUid, maybe_split: Option<Vec<u16>>]  | Pallet: AdminUtils
+SUDO_SET_MIN_ALLOWED_UIDS = namedtuple(
+    "SUDO_SET_MIN_ALLOWED_UIDS",
+    ["wallet", "pallet", "sudo", "netuid", "min_allowed_uids"],
+)  # args: [netuid: NetUid, min_allowed_uids: u16]  | Pallet: AdminUtils
+SUDO_SET_MIN_ALLOWED_WEIGHTS = namedtuple(
+    "SUDO_SET_MIN_ALLOWED_WEIGHTS",
+    ["wallet", "pallet", "sudo", "netuid", "min_allowed_weights"],
+)  # args: [netuid: NetUid, min_allowed_weights: u16]  | Pallet: AdminUtils
+SUDO_SET_MIN_BURN = namedtuple(
+    "SUDO_SET_MIN_BURN", ["wallet", "pallet", "sudo", "netuid", "min_burn"]
+)  # args: [netuid: NetUid, min_burn: TaoCurrency]  | Pallet: AdminUtils
+SUDO_SET_MIN_CHILDKEY_TAKE = namedtuple(
+    "SUDO_SET_MIN_CHILDKEY_TAKE", ["wallet", "pallet", "sudo", "take"]
+)  # args: [take: u16]  | Pallet: SubtensorModule
+SUDO_SET_MIN_DELEGATE_TAKE = namedtuple(
+    "SUDO_SET_MIN_DELEGATE_TAKE", ["wallet", "pallet", "sudo", "take"]
+)  # args: [take: u16]  | Pallet: AdminUtils
+SUDO_SET_MIN_DIFFICULTY = namedtuple(
+    "SUDO_SET_MIN_DIFFICULTY", ["wallet", "pallet", "sudo", "netuid", "min_difficulty"]
+)  # args: [netuid: NetUid, min_difficulty: u64]  | Pallet: AdminUtils
+SUDO_SET_MIN_NON_IMMUNE_UIDS = namedtuple(
+    "SUDO_SET_MIN_NON_IMMUNE_UIDS", ["wallet", "pallet", "sudo", "netuid", "min"]
+)  # args: [netuid: NetUid, min: u16]  | Pallet: AdminUtils
+SUDO_SET_NETWORK_IMMUNITY_PERIOD = namedtuple(
+    "SUDO_SET_NETWORK_IMMUNITY_PERIOD", ["wallet", "pallet", "sudo", "immunity_period"]
+)  # args: [immunity_period: u64]  | Pallet: AdminUtils
+SUDO_SET_NETWORK_MIN_LOCK_COST = namedtuple(
+    "SUDO_SET_NETWORK_MIN_LOCK_COST", ["wallet", "pallet", "sudo", "lock_cost"]
+)  # args: [lock_cost: TaoCurrency]  | Pallet: AdminUtils
+SUDO_SET_NETWORK_POW_REGISTRATION_ALLOWED = namedtuple(
+    "SUDO_SET_NETWORK_POW_REGISTRATION_ALLOWED",
+    ["wallet", "pallet", "sudo", "netuid", "registration_allowed"],
+)  # args: [netuid: NetUid, registration_allowed: bool]  | Pallet: AdminUtils
+SUDO_SET_NETWORK_RATE_LIMIT = namedtuple(
+    "SUDO_SET_NETWORK_RATE_LIMIT", ["wallet", "pallet", "sudo", "rate_limit"]
+)  # args: [rate_limit: u64]  | Pallet: AdminUtils
+SUDO_SET_NETWORK_REGISTRATION_ALLOWED = namedtuple(
+    "SUDO_SET_NETWORK_REGISTRATION_ALLOWED",
+    ["wallet", "pallet", "sudo", "netuid", "registration_allowed"],
+)  # args: [netuid: NetUid, registration_allowed: bool]  | Pallet: AdminUtils
+SUDO_SET_NOMINATOR_MIN_REQUIRED_STAKE = namedtuple(
+    "SUDO_SET_NOMINATOR_MIN_REQUIRED_STAKE", ["wallet", "pallet", "sudo", "min_stake"]
+)  # args: [min_stake: u64]  | Pallet: AdminUtils
+SUDO_SET_NUM_ROOT_CLAIMS = namedtuple(
+    "SUDO_SET_NUM_ROOT_CLAIMS", ["wallet", "pallet", "sudo", "new_value"]
+)  # args: [new_value: u64]  | Pallet: SubtensorModule
+SUDO_SET_OWNER_HPARAM_RATE_LIMIT = namedtuple(
+    "SUDO_SET_OWNER_HPARAM_RATE_LIMIT", ["wallet", "pallet", "sudo", "epochs"]
+)  # args: [epochs: u16]  | Pallet: AdminUtils
+SUDO_SET_OWNER_IMMUNE_NEURON_LIMIT = namedtuple(
+    "SUDO_SET_OWNER_IMMUNE_NEURON_LIMIT",
+    ["wallet", "pallet", "sudo", "netuid", "immune_neurons"],
+)  # args: [netuid: NetUid, immune_neurons: u16]  | Pallet: AdminUtils
+SUDO_SET_RAO_RECYCLED = namedtuple(
+    "SUDO_SET_RAO_RECYCLED", ["wallet", "pallet", "sudo", "netuid", "rao_recycled"]
+)  # args: [netuid: NetUid, rao_recycled: TaoCurrency]  | Pallet: AdminUtils
+SUDO_SET_RECYCLE_OR_BURN = namedtuple(
+    "SUDO_SET_RECYCLE_OR_BURN",
+    ["wallet", "pallet", "sudo", "netuid", "recycle_or_burn"],
+)  # args: [netuid: NetUid, recycle_or_burn: pallet_subtensor::RecycleOrBurnEnum]  | Pallet: AdminUtils
+SUDO_SET_RHO = namedtuple(
+    "SUDO_SET_RHO", ["wallet", "pallet", "sudo", "netuid", "rho"]
+)  # args: [netuid: NetUid, rho: u16]  | Pallet: AdminUtils
+SUDO_SET_ROOT_CLAIM_THRESHOLD = namedtuple(
+    "SUDO_SET_ROOT_CLAIM_THRESHOLD", ["wallet", "pallet", "sudo", "netuid", "new_value"]
+)  # args: [netuid: NetUid, new_value: u64]  | Pallet: SubtensorModule
+SUDO_SET_SERVING_RATE_LIMIT = namedtuple(
+    "SUDO_SET_SERVING_RATE_LIMIT",
+    ["wallet", "pallet", "sudo", "netuid", "serving_rate_limit"],
+)  # args: [netuid: NetUid, serving_rate_limit: u64]  | Pallet: AdminUtils
+SUDO_SET_SN_OWNER_HOTKEY = namedtuple(
+    "SUDO_SET_SN_OWNER_HOTKEY", ["wallet", "pallet", "sudo", "netuid", "hotkey"]
+)  # args: [netuid: NetUid, hotkey: <T as frame_system::Config>::AccountId]  | Pallet: AdminUtils
+SUDO_SET_STAKE_THRESHOLD = namedtuple(
+    "SUDO_SET_STAKE_THRESHOLD", ["wallet", "pallet", "sudo", "min_stake"]
+)  # args: [min_stake: u64]  | Pallet: AdminUtils
+SUDO_SET_START_CALL_DELAY = namedtuple(
+    "SUDO_SET_START_CALL_DELAY", ["wallet", "pallet", "sudo", "delay"]
+)  # args: [delay: u64]  | Pallet: AdminUtils
+SUDO_SET_SUBNET_LIMIT = namedtuple(
+    "SUDO_SET_SUBNET_LIMIT", ["wallet", "pallet", "sudo", "max_subnets"]
+)  # args: [max_subnets: u16]  | Pallet: AdminUtils
+SUDO_SET_SUBNET_MOVING_ALPHA = namedtuple(
+    "SUDO_SET_SUBNET_MOVING_ALPHA", ["wallet", "pallet", "sudo", "alpha"]
+)  # args: [alpha: I96F32]  | Pallet: AdminUtils
+SUDO_SET_SUBNET_OWNER_CUT = namedtuple(
+    "SUDO_SET_SUBNET_OWNER_CUT", ["wallet", "pallet", "sudo", "subnet_owner_cut"]
+)  # args: [subnet_owner_cut: u16]  | Pallet: AdminUtils
+SUDO_SET_SUBNET_OWNER_HOTKEY = namedtuple(
+    "SUDO_SET_SUBNET_OWNER_HOTKEY", ["wallet", "pallet", "sudo", "netuid", "hotkey"]
+)  # args: [netuid: NetUid, hotkey: <T as frame_system::Config>::AccountId]  | Pallet: AdminUtils
+SUDO_SET_SUBTOKEN_ENABLED = namedtuple(
+    "SUDO_SET_SUBTOKEN_ENABLED",
+    ["wallet", "pallet", "sudo", "netuid", "subtoken_enabled"],
+)  # args: [netuid: NetUid, subtoken_enabled: bool]  | Pallet: AdminUtils
+SUDO_SET_TAO_FLOW_CUTOFF = namedtuple(
+    "SUDO_SET_TAO_FLOW_CUTOFF", ["wallet", "pallet", "sudo", "flow_cutoff"]
+)  # args: [flow_cutoff: I64F64]  | Pallet: AdminUtils
+SUDO_SET_TAO_FLOW_NORMALIZATION_EXPONENT = namedtuple(
+    "SUDO_SET_TAO_FLOW_NORMALIZATION_EXPONENT", ["wallet", "pallet", "sudo", "exponent"]
+)  # args: [exponent: U64F64]  | Pallet: AdminUtils
+SUDO_SET_TAO_FLOW_SMOOTHING_FACTOR = namedtuple(
+    "SUDO_SET_TAO_FLOW_SMOOTHING_FACTOR",
+    ["wallet", "pallet", "sudo", "smoothing_factor"],
+)  # args: [smoothing_factor: u64]  | Pallet: AdminUtils
+SUDO_SET_TARGET_REGISTRATIONS_PER_INTERVAL = namedtuple(
+    "SUDO_SET_TARGET_REGISTRATIONS_PER_INTERVAL",
+    ["wallet", "pallet", "sudo", "netuid", "target_registrations_per_interval"],
+)  # args: [netuid: NetUid, target_registrations_per_interval: u16]  | Pallet: AdminUtils
+SUDO_SET_TEMPO = namedtuple(
+    "SUDO_SET_TEMPO", ["wallet", "pallet", "sudo", "netuid", "tempo"]
+)  # args: [netuid: NetUid, tempo: u16]  | Pallet: AdminUtils
+SUDO_SET_TOGGLE_TRANSFER = namedtuple(
+    "SUDO_SET_TOGGLE_TRANSFER", ["wallet", "pallet", "sudo", "netuid", "toggle"]
+)  # args: [netuid: NetUid, toggle: bool]  | Pallet: AdminUtils
+SUDO_SET_TOTAL_ISSUANCE = namedtuple(
+    "SUDO_SET_TOTAL_ISSUANCE", ["wallet", "pallet", "sudo", "total_issuance"]
+)  # args: [total_issuance: TaoCurrency]  | Pallet: AdminUtils
+SUDO_SET_TX_CHILDKEY_TAKE_RATE_LIMIT = namedtuple(
+    "SUDO_SET_TX_CHILDKEY_TAKE_RATE_LIMIT",
+    ["wallet", "pallet", "sudo", "tx_rate_limit"],
+)  # args: [tx_rate_limit: u64]  | Pallet: SubtensorModule
+SUDO_SET_TX_DELEGATE_TAKE_RATE_LIMIT = namedtuple(
+    "SUDO_SET_TX_DELEGATE_TAKE_RATE_LIMIT",
+    ["wallet", "pallet", "sudo", "tx_rate_limit"],
+)  # args: [tx_rate_limit: u64]  | Pallet: AdminUtils
+SUDO_SET_TX_RATE_LIMIT = namedtuple(
+    "SUDO_SET_TX_RATE_LIMIT", ["wallet", "pallet", "sudo", "tx_rate_limit"]
+)  # args: [tx_rate_limit: u64]  | Pallet: AdminUtils
+SUDO_SET_VOTING_POWER_EMA_ALPHA = namedtuple(
+    "SUDO_SET_VOTING_POWER_EMA_ALPHA", ["wallet", "pallet", "sudo", "netuid", "alpha"]
+)  # args: [netuid: NetUid, alpha: u64]  | Pallet: SubtensorModule
+SUDO_SET_WEIGHTS_SET_RATE_LIMIT = namedtuple(
+    "SUDO_SET_WEIGHTS_SET_RATE_LIMIT",
+    ["wallet", "pallet", "sudo", "netuid", "weights_set_rate_limit"],
+)  # args: [netuid: NetUid, weights_set_rate_limit: u64]  | Pallet: AdminUtils
+SUDO_SET_WEIGHTS_VERSION_KEY = namedtuple(
+    "SUDO_SET_WEIGHTS_VERSION_KEY",
+    ["wallet", "pallet", "sudo", "netuid", "weights_version_key"],
+)  # args: [netuid: NetUid, weights_version_key: u64]  | Pallet: AdminUtils
+SUDO_SET_YUMA3_ENABLED = namedtuple(
+    "SUDO_SET_YUMA3_ENABLED", ["wallet", "pallet", "sudo", "netuid", "enabled"]
+)  # args: [netuid: NetUid, enabled: bool]  | Pallet: AdminUtils
+SUDO_TOGGLE_EVM_PRECOMPILE = namedtuple(
+    "SUDO_TOGGLE_EVM_PRECOMPILE",
+    ["wallet", "pallet", "sudo", "precompile_id", "enabled"],
+)  # args: [precompile_id: PrecompileEnum, enabled: bool]  | Pallet: AdminUtils
+SUDO_TRIM_TO_MAX_ALLOWED_UIDS = namedtuple(
+    "SUDO_TRIM_TO_MAX_ALLOWED_UIDS", ["wallet", "pallet", "sudo", "netuid", "max_n"]
+)  # args: [netuid: NetUid, max_n: u16]  | Pallet: AdminUtils
+SUDO_UNCHECKED_WEIGHT = namedtuple(
+    "SUDO_UNCHECKED_WEIGHT", ["wallet", "pallet", "sudo", "call", "weight"]
+)  # args: [call: Box<<T as Config>::RuntimeCall>, weight: Weight]  | Pallet: Sudo

--- a/bittensor/extras/dev_framework/calls/sudo_calls.py
+++ b/bittensor/extras/dev_framework/calls/sudo_calls.py
@@ -11,271 +11,89 @@ For developers:
 
 Note:
     Any manual changes will be overwritten the next time the generator is run.
-    Subtensor spec version: 365
+    Subtensor spec version: 375
 """
 
 from collections import namedtuple
 
 
-SUDO_AS = namedtuple(
-    "SUDO_AS", ["wallet", "pallet", "sudo", "who", "call"]
-)  # args: [who: AccountIdLookupOf<T>, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Sudo
-SUDO_SET_ACTIVITY_CUTOFF = namedtuple(
-    "SUDO_SET_ACTIVITY_CUTOFF",
-    ["wallet", "pallet", "sudo", "netuid", "activity_cutoff"],
-)  # args: [netuid: NetUid, activity_cutoff: u16]  | Pallet: AdminUtils
-SUDO_SET_ADJUSTMENT_ALPHA = namedtuple(
-    "SUDO_SET_ADJUSTMENT_ALPHA",
-    ["wallet", "pallet", "sudo", "netuid", "adjustment_alpha"],
-)  # args: [netuid: NetUid, adjustment_alpha: u64]  | Pallet: AdminUtils
-SUDO_SET_ADJUSTMENT_INTERVAL = namedtuple(
-    "SUDO_SET_ADJUSTMENT_INTERVAL",
-    ["wallet", "pallet", "sudo", "netuid", "adjustment_interval"],
-)  # args: [netuid: NetUid, adjustment_interval: u16]  | Pallet: AdminUtils
-SUDO_SET_ADMIN_FREEZE_WINDOW = namedtuple(
-    "SUDO_SET_ADMIN_FREEZE_WINDOW", ["wallet", "pallet", "sudo", "window"]
-)  # args: [window: u16]  | Pallet: AdminUtils
-SUDO_SET_ALPHA_SIGMOID_STEEPNESS = namedtuple(
-    "SUDO_SET_ALPHA_SIGMOID_STEEPNESS",
-    ["wallet", "pallet", "sudo", "netuid", "steepness"],
-)  # args: [netuid: NetUid, steepness: i16]  | Pallet: AdminUtils
-SUDO_SET_ALPHA_VALUES = namedtuple(
-    "SUDO_SET_ALPHA_VALUES",
-    ["wallet", "pallet", "sudo", "netuid", "alpha_low", "alpha_high"],
-)  # args: [netuid: NetUid, alpha_low: u16, alpha_high: u16]  | Pallet: AdminUtils
-SUDO_SET_BONDS_MOVING_AVERAGE = namedtuple(
-    "SUDO_SET_BONDS_MOVING_AVERAGE",
-    ["wallet", "pallet", "sudo", "netuid", "bonds_moving_average"],
-)  # args: [netuid: NetUid, bonds_moving_average: u64]  | Pallet: AdminUtils
-SUDO_SET_BONDS_PENALTY = namedtuple(
-    "SUDO_SET_BONDS_PENALTY", ["wallet", "pallet", "sudo", "netuid", "bonds_penalty"]
-)  # args: [netuid: NetUid, bonds_penalty: u16]  | Pallet: AdminUtils
-SUDO_SET_BONDS_RESET_ENABLED = namedtuple(
-    "SUDO_SET_BONDS_RESET_ENABLED", ["wallet", "pallet", "sudo", "netuid", "enabled"]
-)  # args: [netuid: NetUid, enabled: bool]  | Pallet: AdminUtils
-SUDO_SET_CK_BURN = namedtuple(
-    "SUDO_SET_CK_BURN", ["wallet", "pallet", "sudo", "burn"]
-)  # args: [burn: u64]  | Pallet: AdminUtils
-SUDO_SET_COLDKEY_SWAP_SCHEDULE_DURATION = namedtuple(
-    "SUDO_SET_COLDKEY_SWAP_SCHEDULE_DURATION", ["wallet", "pallet", "sudo", "duration"]
-)  # args: [duration: BlockNumberFor<T>]  | Pallet: AdminUtils
-SUDO_SET_COMMIT_REVEAL_VERSION = namedtuple(
-    "SUDO_SET_COMMIT_REVEAL_VERSION", ["wallet", "pallet", "sudo", "version"]
-)  # args: [version: u16]  | Pallet: AdminUtils
-SUDO_SET_COMMIT_REVEAL_WEIGHTS_ENABLED = namedtuple(
-    "SUDO_SET_COMMIT_REVEAL_WEIGHTS_ENABLED",
-    ["wallet", "pallet", "sudo", "netuid", "enabled"],
-)  # args: [netuid: NetUid, enabled: bool]  | Pallet: AdminUtils
-SUDO_SET_COMMIT_REVEAL_WEIGHTS_INTERVAL = namedtuple(
-    "SUDO_SET_COMMIT_REVEAL_WEIGHTS_INTERVAL",
-    ["wallet", "pallet", "sudo", "netuid", "interval"],
-)  # args: [netuid: NetUid, interval: u64]  | Pallet: AdminUtils
-SUDO_SET_DEFAULT_TAKE = namedtuple(
-    "SUDO_SET_DEFAULT_TAKE", ["wallet", "pallet", "sudo", "default_take"]
-)  # args: [default_take: u16]  | Pallet: AdminUtils
-SUDO_SET_DIFFICULTY = namedtuple(
-    "SUDO_SET_DIFFICULTY", ["wallet", "pallet", "sudo", "netuid", "difficulty"]
-)  # args: [netuid: NetUid, difficulty: u64]  | Pallet: AdminUtils
-SUDO_SET_DISSOLVE_NETWORK_SCHEDULE_DURATION = namedtuple(
-    "SUDO_SET_DISSOLVE_NETWORK_SCHEDULE_DURATION",
-    ["wallet", "pallet", "sudo", "duration"],
-)  # args: [duration: BlockNumberFor<T>]  | Pallet: AdminUtils
-SUDO_SET_EMA_PRICE_HALVING_PERIOD = namedtuple(
-    "SUDO_SET_EMA_PRICE_HALVING_PERIOD",
-    ["wallet", "pallet", "sudo", "netuid", "ema_halving"],
-)  # args: [netuid: NetUid, ema_halving: u64]  | Pallet: AdminUtils
-SUDO_SET_EVM_CHAIN_ID = namedtuple(
-    "SUDO_SET_EVM_CHAIN_ID", ["wallet", "pallet", "sudo", "chain_id"]
-)  # args: [chain_id: u64]  | Pallet: AdminUtils
-SUDO_SET_IMMUNITY_PERIOD = namedtuple(
-    "SUDO_SET_IMMUNITY_PERIOD",
-    ["wallet", "pallet", "sudo", "netuid", "immunity_period"],
-)  # args: [netuid: NetUid, immunity_period: u16]  | Pallet: AdminUtils
-SUDO_SET_KAPPA = namedtuple(
-    "SUDO_SET_KAPPA", ["wallet", "pallet", "sudo", "netuid", "kappa"]
-)  # args: [netuid: NetUid, kappa: u16]  | Pallet: AdminUtils
-SUDO_SET_LIQUID_ALPHA_ENABLED = namedtuple(
-    "SUDO_SET_LIQUID_ALPHA_ENABLED", ["wallet", "pallet", "sudo", "netuid", "enabled"]
-)  # args: [netuid: NetUid, enabled: bool]  | Pallet: AdminUtils
-SUDO_SET_LOCK_REDUCTION_INTERVAL = namedtuple(
-    "SUDO_SET_LOCK_REDUCTION_INTERVAL", ["wallet", "pallet", "sudo", "interval"]
-)  # args: [interval: u64]  | Pallet: AdminUtils
-SUDO_SET_MAX_ALLOWED_UIDS = namedtuple(
-    "SUDO_SET_MAX_ALLOWED_UIDS",
-    ["wallet", "pallet", "sudo", "netuid", "max_allowed_uids"],
-)  # args: [netuid: NetUid, max_allowed_uids: u16]  | Pallet: AdminUtils
-SUDO_SET_MAX_ALLOWED_VALIDATORS = namedtuple(
-    "SUDO_SET_MAX_ALLOWED_VALIDATORS",
-    ["wallet", "pallet", "sudo", "netuid", "max_allowed_validators"],
-)  # args: [netuid: NetUid, max_allowed_validators: u16]  | Pallet: AdminUtils
-SUDO_SET_MAX_BURN = namedtuple(
-    "SUDO_SET_MAX_BURN", ["wallet", "pallet", "sudo", "netuid", "max_burn"]
-)  # args: [netuid: NetUid, max_burn: TaoCurrency]  | Pallet: AdminUtils
-SUDO_SET_MAX_CHILDKEY_TAKE = namedtuple(
-    "SUDO_SET_MAX_CHILDKEY_TAKE", ["wallet", "pallet", "sudo", "take"]
-)  # args: [take: u16]  | Pallet: SubtensorModule
-SUDO_SET_MAX_DIFFICULTY = namedtuple(
-    "SUDO_SET_MAX_DIFFICULTY", ["wallet", "pallet", "sudo", "netuid", "max_difficulty"]
-)  # args: [netuid: NetUid, max_difficulty: u64]  | Pallet: AdminUtils
-SUDO_SET_MAX_REGISTRATIONS_PER_BLOCK = namedtuple(
-    "SUDO_SET_MAX_REGISTRATIONS_PER_BLOCK",
-    ["wallet", "pallet", "sudo", "netuid", "max_registrations_per_block"],
-)  # args: [netuid: NetUid, max_registrations_per_block: u16]  | Pallet: AdminUtils
-SUDO_SET_MECHANISM_COUNT = namedtuple(
-    "SUDO_SET_MECHANISM_COUNT",
-    ["wallet", "pallet", "sudo", "netuid", "mechanism_count"],
-)  # args: [netuid: NetUid, mechanism_count: MechId]  | Pallet: AdminUtils
-SUDO_SET_MECHANISM_EMISSION_SPLIT = namedtuple(
-    "SUDO_SET_MECHANISM_EMISSION_SPLIT",
-    ["wallet", "pallet", "sudo", "netuid", "maybe_split"],
-)  # args: [netuid: NetUid, maybe_split: Option<Vec<u16>>]  | Pallet: AdminUtils
-SUDO_SET_MIN_ALLOWED_UIDS = namedtuple(
-    "SUDO_SET_MIN_ALLOWED_UIDS",
-    ["wallet", "pallet", "sudo", "netuid", "min_allowed_uids"],
-)  # args: [netuid: NetUid, min_allowed_uids: u16]  | Pallet: AdminUtils
-SUDO_SET_MIN_ALLOWED_WEIGHTS = namedtuple(
-    "SUDO_SET_MIN_ALLOWED_WEIGHTS",
-    ["wallet", "pallet", "sudo", "netuid", "min_allowed_weights"],
-)  # args: [netuid: NetUid, min_allowed_weights: u16]  | Pallet: AdminUtils
-SUDO_SET_MIN_BURN = namedtuple(
-    "SUDO_SET_MIN_BURN", ["wallet", "pallet", "sudo", "netuid", "min_burn"]
-)  # args: [netuid: NetUid, min_burn: TaoCurrency]  | Pallet: AdminUtils
-SUDO_SET_MIN_CHILDKEY_TAKE = namedtuple(
-    "SUDO_SET_MIN_CHILDKEY_TAKE", ["wallet", "pallet", "sudo", "take"]
-)  # args: [take: u16]  | Pallet: SubtensorModule
-SUDO_SET_MIN_DELEGATE_TAKE = namedtuple(
-    "SUDO_SET_MIN_DELEGATE_TAKE", ["wallet", "pallet", "sudo", "take"]
-)  # args: [take: u16]  | Pallet: AdminUtils
-SUDO_SET_MIN_DIFFICULTY = namedtuple(
-    "SUDO_SET_MIN_DIFFICULTY", ["wallet", "pallet", "sudo", "netuid", "min_difficulty"]
-)  # args: [netuid: NetUid, min_difficulty: u64]  | Pallet: AdminUtils
-SUDO_SET_MIN_NON_IMMUNE_UIDS = namedtuple(
-    "SUDO_SET_MIN_NON_IMMUNE_UIDS", ["wallet", "pallet", "sudo", "netuid", "min"]
-)  # args: [netuid: NetUid, min: u16]  | Pallet: AdminUtils
-SUDO_SET_NETWORK_IMMUNITY_PERIOD = namedtuple(
-    "SUDO_SET_NETWORK_IMMUNITY_PERIOD", ["wallet", "pallet", "sudo", "immunity_period"]
-)  # args: [immunity_period: u64]  | Pallet: AdminUtils
-SUDO_SET_NETWORK_MIN_LOCK_COST = namedtuple(
-    "SUDO_SET_NETWORK_MIN_LOCK_COST", ["wallet", "pallet", "sudo", "lock_cost"]
-)  # args: [lock_cost: TaoCurrency]  | Pallet: AdminUtils
-SUDO_SET_NETWORK_POW_REGISTRATION_ALLOWED = namedtuple(
-    "SUDO_SET_NETWORK_POW_REGISTRATION_ALLOWED",
-    ["wallet", "pallet", "sudo", "netuid", "registration_allowed"],
-)  # args: [netuid: NetUid, registration_allowed: bool]  | Pallet: AdminUtils
-SUDO_SET_NETWORK_RATE_LIMIT = namedtuple(
-    "SUDO_SET_NETWORK_RATE_LIMIT", ["wallet", "pallet", "sudo", "rate_limit"]
-)  # args: [rate_limit: u64]  | Pallet: AdminUtils
-SUDO_SET_NETWORK_REGISTRATION_ALLOWED = namedtuple(
-    "SUDO_SET_NETWORK_REGISTRATION_ALLOWED",
-    ["wallet", "pallet", "sudo", "netuid", "registration_allowed"],
-)  # args: [netuid: NetUid, registration_allowed: bool]  | Pallet: AdminUtils
-SUDO_SET_NOMINATOR_MIN_REQUIRED_STAKE = namedtuple(
-    "SUDO_SET_NOMINATOR_MIN_REQUIRED_STAKE", ["wallet", "pallet", "sudo", "min_stake"]
-)  # args: [min_stake: u64]  | Pallet: AdminUtils
-SUDO_SET_NUM_ROOT_CLAIMS = namedtuple(
-    "SUDO_SET_NUM_ROOT_CLAIMS", ["wallet", "pallet", "sudo", "new_value"]
-)  # args: [new_value: u64]  | Pallet: SubtensorModule
-SUDO_SET_OWNER_HPARAM_RATE_LIMIT = namedtuple(
-    "SUDO_SET_OWNER_HPARAM_RATE_LIMIT", ["wallet", "pallet", "sudo", "epochs"]
-)  # args: [epochs: u16]  | Pallet: AdminUtils
-SUDO_SET_OWNER_IMMUNE_NEURON_LIMIT = namedtuple(
-    "SUDO_SET_OWNER_IMMUNE_NEURON_LIMIT",
-    ["wallet", "pallet", "sudo", "netuid", "immune_neurons"],
-)  # args: [netuid: NetUid, immune_neurons: u16]  | Pallet: AdminUtils
-SUDO_SET_RAO_RECYCLED = namedtuple(
-    "SUDO_SET_RAO_RECYCLED", ["wallet", "pallet", "sudo", "netuid", "rao_recycled"]
-)  # args: [netuid: NetUid, rao_recycled: TaoCurrency]  | Pallet: AdminUtils
-SUDO_SET_RECYCLE_OR_BURN = namedtuple(
-    "SUDO_SET_RECYCLE_OR_BURN",
-    ["wallet", "pallet", "sudo", "netuid", "recycle_or_burn"],
-)  # args: [netuid: NetUid, recycle_or_burn: pallet_subtensor::RecycleOrBurnEnum]  | Pallet: AdminUtils
-SUDO_SET_RHO = namedtuple(
-    "SUDO_SET_RHO", ["wallet", "pallet", "sudo", "netuid", "rho"]
-)  # args: [netuid: NetUid, rho: u16]  | Pallet: AdminUtils
-SUDO_SET_ROOT_CLAIM_THRESHOLD = namedtuple(
-    "SUDO_SET_ROOT_CLAIM_THRESHOLD", ["wallet", "pallet", "sudo", "netuid", "new_value"]
-)  # args: [netuid: NetUid, new_value: u64]  | Pallet: SubtensorModule
-SUDO_SET_SERVING_RATE_LIMIT = namedtuple(
-    "SUDO_SET_SERVING_RATE_LIMIT",
-    ["wallet", "pallet", "sudo", "netuid", "serving_rate_limit"],
-)  # args: [netuid: NetUid, serving_rate_limit: u64]  | Pallet: AdminUtils
-SUDO_SET_SN_OWNER_HOTKEY = namedtuple(
-    "SUDO_SET_SN_OWNER_HOTKEY", ["wallet", "pallet", "sudo", "netuid", "hotkey"]
-)  # args: [netuid: NetUid, hotkey: <T as frame_system::Config>::AccountId]  | Pallet: AdminUtils
-SUDO_SET_STAKE_THRESHOLD = namedtuple(
-    "SUDO_SET_STAKE_THRESHOLD", ["wallet", "pallet", "sudo", "min_stake"]
-)  # args: [min_stake: u64]  | Pallet: AdminUtils
-SUDO_SET_START_CALL_DELAY = namedtuple(
-    "SUDO_SET_START_CALL_DELAY", ["wallet", "pallet", "sudo", "delay"]
-)  # args: [delay: u64]  | Pallet: AdminUtils
-SUDO_SET_SUBNET_LIMIT = namedtuple(
-    "SUDO_SET_SUBNET_LIMIT", ["wallet", "pallet", "sudo", "max_subnets"]
-)  # args: [max_subnets: u16]  | Pallet: AdminUtils
-SUDO_SET_SUBNET_MOVING_ALPHA = namedtuple(
-    "SUDO_SET_SUBNET_MOVING_ALPHA", ["wallet", "pallet", "sudo", "alpha"]
-)  # args: [alpha: I96F32]  | Pallet: AdminUtils
-SUDO_SET_SUBNET_OWNER_CUT = namedtuple(
-    "SUDO_SET_SUBNET_OWNER_CUT", ["wallet", "pallet", "sudo", "subnet_owner_cut"]
-)  # args: [subnet_owner_cut: u16]  | Pallet: AdminUtils
-SUDO_SET_SUBNET_OWNER_HOTKEY = namedtuple(
-    "SUDO_SET_SUBNET_OWNER_HOTKEY", ["wallet", "pallet", "sudo", "netuid", "hotkey"]
-)  # args: [netuid: NetUid, hotkey: <T as frame_system::Config>::AccountId]  | Pallet: AdminUtils
-SUDO_SET_SUBTOKEN_ENABLED = namedtuple(
-    "SUDO_SET_SUBTOKEN_ENABLED",
-    ["wallet", "pallet", "sudo", "netuid", "subtoken_enabled"],
-)  # args: [netuid: NetUid, subtoken_enabled: bool]  | Pallet: AdminUtils
-SUDO_SET_TAO_FLOW_CUTOFF = namedtuple(
-    "SUDO_SET_TAO_FLOW_CUTOFF", ["wallet", "pallet", "sudo", "flow_cutoff"]
-)  # args: [flow_cutoff: I64F64]  | Pallet: AdminUtils
-SUDO_SET_TAO_FLOW_NORMALIZATION_EXPONENT = namedtuple(
-    "SUDO_SET_TAO_FLOW_NORMALIZATION_EXPONENT", ["wallet", "pallet", "sudo", "exponent"]
-)  # args: [exponent: U64F64]  | Pallet: AdminUtils
-SUDO_SET_TAO_FLOW_SMOOTHING_FACTOR = namedtuple(
-    "SUDO_SET_TAO_FLOW_SMOOTHING_FACTOR",
-    ["wallet", "pallet", "sudo", "smoothing_factor"],
-)  # args: [smoothing_factor: u64]  | Pallet: AdminUtils
-SUDO_SET_TARGET_REGISTRATIONS_PER_INTERVAL = namedtuple(
-    "SUDO_SET_TARGET_REGISTRATIONS_PER_INTERVAL",
-    ["wallet", "pallet", "sudo", "netuid", "target_registrations_per_interval"],
-)  # args: [netuid: NetUid, target_registrations_per_interval: u16]  | Pallet: AdminUtils
-SUDO_SET_TEMPO = namedtuple(
-    "SUDO_SET_TEMPO", ["wallet", "pallet", "sudo", "netuid", "tempo"]
-)  # args: [netuid: NetUid, tempo: u16]  | Pallet: AdminUtils
-SUDO_SET_TOGGLE_TRANSFER = namedtuple(
-    "SUDO_SET_TOGGLE_TRANSFER", ["wallet", "pallet", "sudo", "netuid", "toggle"]
-)  # args: [netuid: NetUid, toggle: bool]  | Pallet: AdminUtils
-SUDO_SET_TOTAL_ISSUANCE = namedtuple(
-    "SUDO_SET_TOTAL_ISSUANCE", ["wallet", "pallet", "sudo", "total_issuance"]
-)  # args: [total_issuance: TaoCurrency]  | Pallet: AdminUtils
-SUDO_SET_TX_CHILDKEY_TAKE_RATE_LIMIT = namedtuple(
-    "SUDO_SET_TX_CHILDKEY_TAKE_RATE_LIMIT",
-    ["wallet", "pallet", "sudo", "tx_rate_limit"],
-)  # args: [tx_rate_limit: u64]  | Pallet: SubtensorModule
-SUDO_SET_TX_DELEGATE_TAKE_RATE_LIMIT = namedtuple(
-    "SUDO_SET_TX_DELEGATE_TAKE_RATE_LIMIT",
-    ["wallet", "pallet", "sudo", "tx_rate_limit"],
-)  # args: [tx_rate_limit: u64]  | Pallet: AdminUtils
-SUDO_SET_TX_RATE_LIMIT = namedtuple(
-    "SUDO_SET_TX_RATE_LIMIT", ["wallet", "pallet", "sudo", "tx_rate_limit"]
-)  # args: [tx_rate_limit: u64]  | Pallet: AdminUtils
-SUDO_SET_WEIGHTS_SET_RATE_LIMIT = namedtuple(
-    "SUDO_SET_WEIGHTS_SET_RATE_LIMIT",
-    ["wallet", "pallet", "sudo", "netuid", "weights_set_rate_limit"],
-)  # args: [netuid: NetUid, weights_set_rate_limit: u64]  | Pallet: AdminUtils
-SUDO_SET_WEIGHTS_VERSION_KEY = namedtuple(
-    "SUDO_SET_WEIGHTS_VERSION_KEY",
-    ["wallet", "pallet", "sudo", "netuid", "weights_version_key"],
-)  # args: [netuid: NetUid, weights_version_key: u64]  | Pallet: AdminUtils
-SUDO_SET_YUMA3_ENABLED = namedtuple(
-    "SUDO_SET_YUMA3_ENABLED", ["wallet", "pallet", "sudo", "netuid", "enabled"]
-)  # args: [netuid: NetUid, enabled: bool]  | Pallet: AdminUtils
-SUDO_TOGGLE_EVM_PRECOMPILE = namedtuple(
-    "SUDO_TOGGLE_EVM_PRECOMPILE",
-    ["wallet", "pallet", "sudo", "precompile_id", "enabled"],
-)  # args: [precompile_id: PrecompileEnum, enabled: bool]  | Pallet: AdminUtils
-SUDO_TRIM_TO_MAX_ALLOWED_UIDS = namedtuple(
-    "SUDO_TRIM_TO_MAX_ALLOWED_UIDS", ["wallet", "pallet", "sudo", "netuid", "max_n"]
-)  # args: [netuid: NetUid, max_n: u16]  | Pallet: AdminUtils
-SUDO_UNCHECKED_WEIGHT = namedtuple(
-    "SUDO_UNCHECKED_WEIGHT", ["wallet", "pallet", "sudo", "call", "weight"]
-)  # args: [call: Box<<T as Config>::RuntimeCall>, weight: Weight]  | Pallet: Sudo
+SUDO_AS = namedtuple("SUDO_AS", ["wallet", "pallet", "sudo", "who", "call"])  # args: [who: AccountIdLookupOf<T>, call: Box<<T as Config>::RuntimeCall>]  | Pallet: Sudo
+SUDO_SET_ACTIVITY_CUTOFF = namedtuple("SUDO_SET_ACTIVITY_CUTOFF", ["wallet", "pallet", "sudo", "netuid", "activity_cutoff"])  # args: [netuid: NetUid, activity_cutoff: u16]  | Pallet: AdminUtils
+SUDO_SET_ADJUSTMENT_ALPHA = namedtuple("SUDO_SET_ADJUSTMENT_ALPHA", ["wallet", "pallet", "sudo", "netuid", "adjustment_alpha"])  # args: [netuid: NetUid, adjustment_alpha: u64]  | Pallet: AdminUtils
+SUDO_SET_ADJUSTMENT_INTERVAL = namedtuple("SUDO_SET_ADJUSTMENT_INTERVAL", ["wallet", "pallet", "sudo", "netuid", "adjustment_interval"])  # args: [netuid: NetUid, adjustment_interval: u16]  | Pallet: AdminUtils
+SUDO_SET_ADMIN_FREEZE_WINDOW = namedtuple("SUDO_SET_ADMIN_FREEZE_WINDOW", ["wallet", "pallet", "sudo", "window"])  # args: [window: u16]  | Pallet: AdminUtils
+SUDO_SET_ALPHA_SIGMOID_STEEPNESS = namedtuple("SUDO_SET_ALPHA_SIGMOID_STEEPNESS", ["wallet", "pallet", "sudo", "netuid", "steepness"])  # args: [netuid: NetUid, steepness: i16]  | Pallet: AdminUtils
+SUDO_SET_ALPHA_VALUES = namedtuple("SUDO_SET_ALPHA_VALUES", ["wallet", "pallet", "sudo", "netuid", "alpha_low", "alpha_high"])  # args: [netuid: NetUid, alpha_low: u16, alpha_high: u16]  | Pallet: AdminUtils
+SUDO_SET_BONDS_MOVING_AVERAGE = namedtuple("SUDO_SET_BONDS_MOVING_AVERAGE", ["wallet", "pallet", "sudo", "netuid", "bonds_moving_average"])  # args: [netuid: NetUid, bonds_moving_average: u64]  | Pallet: AdminUtils
+SUDO_SET_BONDS_PENALTY = namedtuple("SUDO_SET_BONDS_PENALTY", ["wallet", "pallet", "sudo", "netuid", "bonds_penalty"])  # args: [netuid: NetUid, bonds_penalty: u16]  | Pallet: AdminUtils
+SUDO_SET_BONDS_RESET_ENABLED = namedtuple("SUDO_SET_BONDS_RESET_ENABLED", ["wallet", "pallet", "sudo", "netuid", "enabled"])  # args: [netuid: NetUid, enabled: bool]  | Pallet: AdminUtils
+SUDO_SET_CK_BURN = namedtuple("SUDO_SET_CK_BURN", ["wallet", "pallet", "sudo", "burn"])  # args: [burn: u64]  | Pallet: AdminUtils
+SUDO_SET_COLDKEY_SWAP_ANNOUNCEMENT_DELAY = namedtuple("SUDO_SET_COLDKEY_SWAP_ANNOUNCEMENT_DELAY", ["wallet", "pallet", "sudo", "duration"])  # args: [duration: BlockNumberFor<T>]  | Pallet: AdminUtils
+SUDO_SET_COLDKEY_SWAP_REANNOUNCEMENT_DELAY = namedtuple("SUDO_SET_COLDKEY_SWAP_REANNOUNCEMENT_DELAY", ["wallet", "pallet", "sudo", "duration"])  # args: [duration: BlockNumberFor<T>]  | Pallet: AdminUtils
+SUDO_SET_COMMIT_REVEAL_VERSION = namedtuple("SUDO_SET_COMMIT_REVEAL_VERSION", ["wallet", "pallet", "sudo", "version"])  # args: [version: u16]  | Pallet: AdminUtils
+SUDO_SET_COMMIT_REVEAL_WEIGHTS_ENABLED = namedtuple("SUDO_SET_COMMIT_REVEAL_WEIGHTS_ENABLED", ["wallet", "pallet", "sudo", "netuid", "enabled"])  # args: [netuid: NetUid, enabled: bool]  | Pallet: AdminUtils
+SUDO_SET_COMMIT_REVEAL_WEIGHTS_INTERVAL = namedtuple("SUDO_SET_COMMIT_REVEAL_WEIGHTS_INTERVAL", ["wallet", "pallet", "sudo", "netuid", "interval"])  # args: [netuid: NetUid, interval: u64]  | Pallet: AdminUtils
+SUDO_SET_DEFAULT_TAKE = namedtuple("SUDO_SET_DEFAULT_TAKE", ["wallet", "pallet", "sudo", "default_take"])  # args: [default_take: u16]  | Pallet: AdminUtils
+SUDO_SET_DIFFICULTY = namedtuple("SUDO_SET_DIFFICULTY", ["wallet", "pallet", "sudo", "netuid", "difficulty"])  # args: [netuid: NetUid, difficulty: u64]  | Pallet: AdminUtils
+SUDO_SET_DISSOLVE_NETWORK_SCHEDULE_DURATION = namedtuple("SUDO_SET_DISSOLVE_NETWORK_SCHEDULE_DURATION", ["wallet", "pallet", "sudo", "duration"])  # args: [duration: BlockNumberFor<T>]  | Pallet: AdminUtils
+SUDO_SET_EMA_PRICE_HALVING_PERIOD = namedtuple("SUDO_SET_EMA_PRICE_HALVING_PERIOD", ["wallet", "pallet", "sudo", "netuid", "ema_halving"])  # args: [netuid: NetUid, ema_halving: u64]  | Pallet: AdminUtils
+SUDO_SET_EVM_CHAIN_ID = namedtuple("SUDO_SET_EVM_CHAIN_ID", ["wallet", "pallet", "sudo", "chain_id"])  # args: [chain_id: u64]  | Pallet: AdminUtils
+SUDO_SET_IMMUNITY_PERIOD = namedtuple("SUDO_SET_IMMUNITY_PERIOD", ["wallet", "pallet", "sudo", "netuid", "immunity_period"])  # args: [netuid: NetUid, immunity_period: u16]  | Pallet: AdminUtils
+SUDO_SET_KAPPA = namedtuple("SUDO_SET_KAPPA", ["wallet", "pallet", "sudo", "netuid", "kappa"])  # args: [netuid: NetUid, kappa: u16]  | Pallet: AdminUtils
+SUDO_SET_LIQUID_ALPHA_ENABLED = namedtuple("SUDO_SET_LIQUID_ALPHA_ENABLED", ["wallet", "pallet", "sudo", "netuid", "enabled"])  # args: [netuid: NetUid, enabled: bool]  | Pallet: AdminUtils
+SUDO_SET_LOCK_REDUCTION_INTERVAL = namedtuple("SUDO_SET_LOCK_REDUCTION_INTERVAL", ["wallet", "pallet", "sudo", "interval"])  # args: [interval: u64]  | Pallet: AdminUtils
+SUDO_SET_MAX_ALLOWED_UIDS = namedtuple("SUDO_SET_MAX_ALLOWED_UIDS", ["wallet", "pallet", "sudo", "netuid", "max_allowed_uids"])  # args: [netuid: NetUid, max_allowed_uids: u16]  | Pallet: AdminUtils
+SUDO_SET_MAX_ALLOWED_VALIDATORS = namedtuple("SUDO_SET_MAX_ALLOWED_VALIDATORS", ["wallet", "pallet", "sudo", "netuid", "max_allowed_validators"])  # args: [netuid: NetUid, max_allowed_validators: u16]  | Pallet: AdminUtils
+SUDO_SET_MAX_BURN = namedtuple("SUDO_SET_MAX_BURN", ["wallet", "pallet", "sudo", "netuid", "max_burn"])  # args: [netuid: NetUid, max_burn: TaoCurrency]  | Pallet: AdminUtils
+SUDO_SET_MAX_CHILDKEY_TAKE = namedtuple("SUDO_SET_MAX_CHILDKEY_TAKE", ["wallet", "pallet", "sudo", "take"])  # args: [take: u16]  | Pallet: SubtensorModule
+SUDO_SET_MAX_DIFFICULTY = namedtuple("SUDO_SET_MAX_DIFFICULTY", ["wallet", "pallet", "sudo", "netuid", "max_difficulty"])  # args: [netuid: NetUid, max_difficulty: u64]  | Pallet: AdminUtils
+SUDO_SET_MAX_MECHANISM_COUNT = namedtuple("SUDO_SET_MAX_MECHANISM_COUNT", ["wallet", "pallet", "sudo", "max_mechanism_count"])  # args: [max_mechanism_count: MechId]  | Pallet: AdminUtils
+SUDO_SET_MAX_REGISTRATIONS_PER_BLOCK = namedtuple("SUDO_SET_MAX_REGISTRATIONS_PER_BLOCK", ["wallet", "pallet", "sudo", "netuid", "max_registrations_per_block"])  # args: [netuid: NetUid, max_registrations_per_block: u16]  | Pallet: AdminUtils
+SUDO_SET_MECHANISM_COUNT = namedtuple("SUDO_SET_MECHANISM_COUNT", ["wallet", "pallet", "sudo", "netuid", "mechanism_count"])  # args: [netuid: NetUid, mechanism_count: MechId]  | Pallet: AdminUtils
+SUDO_SET_MECHANISM_EMISSION_SPLIT = namedtuple("SUDO_SET_MECHANISM_EMISSION_SPLIT", ["wallet", "pallet", "sudo", "netuid", "maybe_split"])  # args: [netuid: NetUid, maybe_split: Option<Vec<u16>>]  | Pallet: AdminUtils
+SUDO_SET_MIN_ALLOWED_UIDS = namedtuple("SUDO_SET_MIN_ALLOWED_UIDS", ["wallet", "pallet", "sudo", "netuid", "min_allowed_uids"])  # args: [netuid: NetUid, min_allowed_uids: u16]  | Pallet: AdminUtils
+SUDO_SET_MIN_ALLOWED_WEIGHTS = namedtuple("SUDO_SET_MIN_ALLOWED_WEIGHTS", ["wallet", "pallet", "sudo", "netuid", "min_allowed_weights"])  # args: [netuid: NetUid, min_allowed_weights: u16]  | Pallet: AdminUtils
+SUDO_SET_MIN_BURN = namedtuple("SUDO_SET_MIN_BURN", ["wallet", "pallet", "sudo", "netuid", "min_burn"])  # args: [netuid: NetUid, min_burn: TaoCurrency]  | Pallet: AdminUtils
+SUDO_SET_MIN_CHILDKEY_TAKE = namedtuple("SUDO_SET_MIN_CHILDKEY_TAKE", ["wallet", "pallet", "sudo", "take"])  # args: [take: u16]  | Pallet: SubtensorModule
+SUDO_SET_MIN_DELEGATE_TAKE = namedtuple("SUDO_SET_MIN_DELEGATE_TAKE", ["wallet", "pallet", "sudo", "take"])  # args: [take: u16]  | Pallet: AdminUtils
+SUDO_SET_MIN_DIFFICULTY = namedtuple("SUDO_SET_MIN_DIFFICULTY", ["wallet", "pallet", "sudo", "netuid", "min_difficulty"])  # args: [netuid: NetUid, min_difficulty: u64]  | Pallet: AdminUtils
+SUDO_SET_MIN_NON_IMMUNE_UIDS = namedtuple("SUDO_SET_MIN_NON_IMMUNE_UIDS", ["wallet", "pallet", "sudo", "netuid", "min"])  # args: [netuid: NetUid, min: u16]  | Pallet: AdminUtils
+SUDO_SET_NETWORK_IMMUNITY_PERIOD = namedtuple("SUDO_SET_NETWORK_IMMUNITY_PERIOD", ["wallet", "pallet", "sudo", "immunity_period"])  # args: [immunity_period: u64]  | Pallet: AdminUtils
+SUDO_SET_NETWORK_MIN_LOCK_COST = namedtuple("SUDO_SET_NETWORK_MIN_LOCK_COST", ["wallet", "pallet", "sudo", "lock_cost"])  # args: [lock_cost: TaoCurrency]  | Pallet: AdminUtils
+SUDO_SET_NETWORK_POW_REGISTRATION_ALLOWED = namedtuple("SUDO_SET_NETWORK_POW_REGISTRATION_ALLOWED", ["wallet", "pallet", "sudo", "netuid", "registration_allowed"])  # args: [netuid: NetUid, registration_allowed: bool]  | Pallet: AdminUtils
+SUDO_SET_NETWORK_RATE_LIMIT = namedtuple("SUDO_SET_NETWORK_RATE_LIMIT", ["wallet", "pallet", "sudo", "rate_limit"])  # args: [rate_limit: u64]  | Pallet: AdminUtils
+SUDO_SET_NETWORK_REGISTRATION_ALLOWED = namedtuple("SUDO_SET_NETWORK_REGISTRATION_ALLOWED", ["wallet", "pallet", "sudo", "netuid", "registration_allowed"])  # args: [netuid: NetUid, registration_allowed: bool]  | Pallet: AdminUtils
+SUDO_SET_NOMINATOR_MIN_REQUIRED_STAKE = namedtuple("SUDO_SET_NOMINATOR_MIN_REQUIRED_STAKE", ["wallet", "pallet", "sudo", "min_stake"])  # args: [min_stake: u64]  | Pallet: AdminUtils
+SUDO_SET_NUM_ROOT_CLAIMS = namedtuple("SUDO_SET_NUM_ROOT_CLAIMS", ["wallet", "pallet", "sudo", "new_value"])  # args: [new_value: u64]  | Pallet: SubtensorModule
+SUDO_SET_OWNER_HPARAM_RATE_LIMIT = namedtuple("SUDO_SET_OWNER_HPARAM_RATE_LIMIT", ["wallet", "pallet", "sudo", "epochs"])  # args: [epochs: u16]  | Pallet: AdminUtils
+SUDO_SET_OWNER_IMMUNE_NEURON_LIMIT = namedtuple("SUDO_SET_OWNER_IMMUNE_NEURON_LIMIT", ["wallet", "pallet", "sudo", "netuid", "immune_neurons"])  # args: [netuid: NetUid, immune_neurons: u16]  | Pallet: AdminUtils
+SUDO_SET_RAO_RECYCLED = namedtuple("SUDO_SET_RAO_RECYCLED", ["wallet", "pallet", "sudo", "netuid", "rao_recycled"])  # args: [netuid: NetUid, rao_recycled: TaoCurrency]  | Pallet: AdminUtils
+SUDO_SET_RECYCLE_OR_BURN = namedtuple("SUDO_SET_RECYCLE_OR_BURN", ["wallet", "pallet", "sudo", "netuid", "recycle_or_burn"])  # args: [netuid: NetUid, recycle_or_burn: pallet_subtensor::RecycleOrBurnEnum]  | Pallet: AdminUtils
+SUDO_SET_RHO = namedtuple("SUDO_SET_RHO", ["wallet", "pallet", "sudo", "netuid", "rho"])  # args: [netuid: NetUid, rho: u16]  | Pallet: AdminUtils
+SUDO_SET_ROOT_CLAIM_THRESHOLD = namedtuple("SUDO_SET_ROOT_CLAIM_THRESHOLD", ["wallet", "pallet", "sudo", "netuid", "new_value"])  # args: [netuid: NetUid, new_value: u64]  | Pallet: SubtensorModule
+SUDO_SET_SERVING_RATE_LIMIT = namedtuple("SUDO_SET_SERVING_RATE_LIMIT", ["wallet", "pallet", "sudo", "netuid", "serving_rate_limit"])  # args: [netuid: NetUid, serving_rate_limit: u64]  | Pallet: AdminUtils
+SUDO_SET_SN_OWNER_HOTKEY = namedtuple("SUDO_SET_SN_OWNER_HOTKEY", ["wallet", "pallet", "sudo", "netuid", "hotkey"])  # args: [netuid: NetUid, hotkey: <T as frame_system::Config>::AccountId]  | Pallet: AdminUtils
+SUDO_SET_STAKE_THRESHOLD = namedtuple("SUDO_SET_STAKE_THRESHOLD", ["wallet", "pallet", "sudo", "min_stake"])  # args: [min_stake: u64]  | Pallet: AdminUtils
+SUDO_SET_START_CALL_DELAY = namedtuple("SUDO_SET_START_CALL_DELAY", ["wallet", "pallet", "sudo", "delay"])  # args: [delay: u64]  | Pallet: AdminUtils
+SUDO_SET_SUBNET_LIMIT = namedtuple("SUDO_SET_SUBNET_LIMIT", ["wallet", "pallet", "sudo", "max_subnets"])  # args: [max_subnets: u16]  | Pallet: AdminUtils
+SUDO_SET_SUBNET_MOVING_ALPHA = namedtuple("SUDO_SET_SUBNET_MOVING_ALPHA", ["wallet", "pallet", "sudo", "alpha"])  # args: [alpha: I96F32]  | Pallet: AdminUtils
+SUDO_SET_SUBNET_OWNER_CUT = namedtuple("SUDO_SET_SUBNET_OWNER_CUT", ["wallet", "pallet", "sudo", "subnet_owner_cut"])  # args: [subnet_owner_cut: u16]  | Pallet: AdminUtils
+SUDO_SET_SUBNET_OWNER_HOTKEY = namedtuple("SUDO_SET_SUBNET_OWNER_HOTKEY", ["wallet", "pallet", "sudo", "netuid", "hotkey"])  # args: [netuid: NetUid, hotkey: <T as frame_system::Config>::AccountId]  | Pallet: AdminUtils
+SUDO_SET_SUBTOKEN_ENABLED = namedtuple("SUDO_SET_SUBTOKEN_ENABLED", ["wallet", "pallet", "sudo", "netuid", "subtoken_enabled"])  # args: [netuid: NetUid, subtoken_enabled: bool]  | Pallet: AdminUtils
+SUDO_SET_TAO_FLOW_CUTOFF = namedtuple("SUDO_SET_TAO_FLOW_CUTOFF", ["wallet", "pallet", "sudo", "flow_cutoff"])  # args: [flow_cutoff: I64F64]  | Pallet: AdminUtils
+SUDO_SET_TAO_FLOW_NORMALIZATION_EXPONENT = namedtuple("SUDO_SET_TAO_FLOW_NORMALIZATION_EXPONENT", ["wallet", "pallet", "sudo", "exponent"])  # args: [exponent: U64F64]  | Pallet: AdminUtils
+SUDO_SET_TAO_FLOW_SMOOTHING_FACTOR = namedtuple("SUDO_SET_TAO_FLOW_SMOOTHING_FACTOR", ["wallet", "pallet", "sudo", "smoothing_factor"])  # args: [smoothing_factor: u64]  | Pallet: AdminUtils
+SUDO_SET_TARGET_REGISTRATIONS_PER_INTERVAL = namedtuple("SUDO_SET_TARGET_REGISTRATIONS_PER_INTERVAL", ["wallet", "pallet", "sudo", "netuid", "target_registrations_per_interval"])  # args: [netuid: NetUid, target_registrations_per_interval: u16]  | Pallet: AdminUtils
+SUDO_SET_TEMPO = namedtuple("SUDO_SET_TEMPO", ["wallet", "pallet", "sudo", "netuid", "tempo"])  # args: [netuid: NetUid, tempo: u16]  | Pallet: AdminUtils
+SUDO_SET_TOGGLE_TRANSFER = namedtuple("SUDO_SET_TOGGLE_TRANSFER", ["wallet", "pallet", "sudo", "netuid", "toggle"])  # args: [netuid: NetUid, toggle: bool]  | Pallet: AdminUtils
+SUDO_SET_TOTAL_ISSUANCE = namedtuple("SUDO_SET_TOTAL_ISSUANCE", ["wallet", "pallet", "sudo", "total_issuance"])  # args: [total_issuance: TaoCurrency]  | Pallet: AdminUtils
+SUDO_SET_TX_CHILDKEY_TAKE_RATE_LIMIT = namedtuple("SUDO_SET_TX_CHILDKEY_TAKE_RATE_LIMIT", ["wallet", "pallet", "sudo", "tx_rate_limit"])  # args: [tx_rate_limit: u64]  | Pallet: SubtensorModule
+SUDO_SET_TX_DELEGATE_TAKE_RATE_LIMIT = namedtuple("SUDO_SET_TX_DELEGATE_TAKE_RATE_LIMIT", ["wallet", "pallet", "sudo", "tx_rate_limit"])  # args: [tx_rate_limit: u64]  | Pallet: AdminUtils
+SUDO_SET_TX_RATE_LIMIT = namedtuple("SUDO_SET_TX_RATE_LIMIT", ["wallet", "pallet", "sudo", "tx_rate_limit"])  # args: [tx_rate_limit: u64]  | Pallet: AdminUtils
+SUDO_SET_VOTING_POWER_EMA_ALPHA = namedtuple("SUDO_SET_VOTING_POWER_EMA_ALPHA", ["wallet", "pallet", "sudo", "netuid", "alpha"])  # args: [netuid: NetUid, alpha: u64]  | Pallet: SubtensorModule
+SUDO_SET_WEIGHTS_SET_RATE_LIMIT = namedtuple("SUDO_SET_WEIGHTS_SET_RATE_LIMIT", ["wallet", "pallet", "sudo", "netuid", "weights_set_rate_limit"])  # args: [netuid: NetUid, weights_set_rate_limit: u64]  | Pallet: AdminUtils
+SUDO_SET_WEIGHTS_VERSION_KEY = namedtuple("SUDO_SET_WEIGHTS_VERSION_KEY", ["wallet", "pallet", "sudo", "netuid", "weights_version_key"])  # args: [netuid: NetUid, weights_version_key: u64]  | Pallet: AdminUtils
+SUDO_SET_YUMA3_ENABLED = namedtuple("SUDO_SET_YUMA3_ENABLED", ["wallet", "pallet", "sudo", "netuid", "enabled"])  # args: [netuid: NetUid, enabled: bool]  | Pallet: AdminUtils
+SUDO_TOGGLE_EVM_PRECOMPILE = namedtuple("SUDO_TOGGLE_EVM_PRECOMPILE", ["wallet", "pallet", "sudo", "precompile_id", "enabled"])  # args: [precompile_id: PrecompileEnum, enabled: bool]  | Pallet: AdminUtils
+SUDO_TRIM_TO_MAX_ALLOWED_UIDS = namedtuple("SUDO_TRIM_TO_MAX_ALLOWED_UIDS", ["wallet", "pallet", "sudo", "netuid", "max_n"])  # args: [netuid: NetUid, max_n: u16]  | Pallet: AdminUtils
+SUDO_UNCHECKED_WEIGHT = namedtuple("SUDO_UNCHECKED_WEIGHT", ["wallet", "pallet", "sudo", "call", "weight"])  # args: [call: Box<<T as Config>::RuntimeCall>, weight: Weight]  | Pallet: Sudo

--- a/bittensor/extras/subtensor_api/extrinsics.py
+++ b/bittensor/extras/subtensor_api/extrinsics.py
@@ -39,6 +39,7 @@ class Extrinsics:
         self.set_commitment = subtensor.set_commitment
         self.set_root_claim_type = subtensor.set_root_claim_type
         self.start_call = subtensor.start_call
+        self.subnet_buyback = subtensor.subnet_buyback
         self.swap_coldkey_announced = subtensor.swap_coldkey_announced
         self.swap_stake = subtensor.swap_stake
         self.toggle_user_liquidity = subtensor.toggle_user_liquidity

--- a/bittensor/extras/subtensor_api/staking.py
+++ b/bittensor/extras/subtensor_api/staking.py
@@ -35,6 +35,7 @@ class Staking:
         self.set_auto_stake = subtensor.set_auto_stake
         self.set_root_claim_type = subtensor.set_root_claim_type
         self.sim_swap = subtensor.sim_swap
+        self.subnet_buyback = subtensor.subnet_buyback
         self.swap_stake = subtensor.swap_stake
         self.transfer_stake = subtensor.transfer_stake
         self.unstake = subtensor.unstake

--- a/tests/e2e_tests/test_commit_reveal.py
+++ b/tests/e2e_tests/test_commit_reveal.py
@@ -50,7 +50,9 @@ def test_commit_and_reveal_weights_cr4(subtensor, alice_wallet):
     steps = [
         SUDO_SET_ADMIN_FREEZE_WINDOW(alice_wallet, AdminUtils, True, 0),
         REGISTER_SUBNET(alice_wallet),
-        SUDO_SET_MAX_ALLOWED_UIDS(alice_wallet, AdminUtils, True, NETUID, int(256/TESTED_MECHANISMS)),
+        SUDO_SET_MAX_ALLOWED_UIDS(
+            alice_wallet, AdminUtils, True, NETUID, int(256 / TESTED_MECHANISMS)
+        ),
         SUDO_SET_MECHANISM_COUNT(
             alice_wallet, AdminUtils, True, NETUID, TESTED_MECHANISMS
         ),
@@ -239,7 +241,9 @@ async def test_commit_and_reveal_weights_cr4_async(async_subtensor, alice_wallet
     steps = [
         SUDO_SET_ADMIN_FREEZE_WINDOW(alice_wallet, AdminUtils, True, 0),
         REGISTER_SUBNET(alice_wallet),
-        SUDO_SET_MAX_ALLOWED_UIDS(alice_wallet, AdminUtils, True, NETUID, int(256 / TESTED_MECHANISMS)),
+        SUDO_SET_MAX_ALLOWED_UIDS(
+            alice_wallet, AdminUtils, True, NETUID, int(256 / TESTED_MECHANISMS)
+        ),
         SUDO_SET_MECHANISM_COUNT(
             alice_wallet, AdminUtils, True, NETUID, TESTED_MECHANISMS
         ),

--- a/tests/e2e_tests/test_commit_reveal.py
+++ b/tests/e2e_tests/test_commit_reveal.py
@@ -12,6 +12,7 @@ from tests.e2e_tests.utils import (
     REGISTER_SUBNET,
     SUDO_SET_ADMIN_FREEZE_WINDOW,
     SUDO_SET_TEMPO,
+    SUDO_SET_MAX_ALLOWED_UIDS,
     SUDO_SET_MECHANISM_COUNT,
     SUDO_SET_COMMIT_REVEAL_WEIGHTS_ENABLED,
     SUDO_SET_WEIGHTS_SET_RATE_LIMIT,
@@ -49,6 +50,7 @@ def test_commit_and_reveal_weights_cr4(subtensor, alice_wallet):
     steps = [
         SUDO_SET_ADMIN_FREEZE_WINDOW(alice_wallet, AdminUtils, True, 0),
         REGISTER_SUBNET(alice_wallet),
+        SUDO_SET_MAX_ALLOWED_UIDS(alice_wallet, AdminUtils, True, NETUID, int(256/TESTED_MECHANISMS)),
         SUDO_SET_MECHANISM_COUNT(
             alice_wallet, AdminUtils, True, NETUID, TESTED_MECHANISMS
         ),
@@ -121,6 +123,7 @@ def test_commit_and_reveal_weights_cr4(subtensor, alice_wallet):
             wait_for_finalization=True,
             block_time=BLOCK_TIME,
             period=16,
+            raise_error=True,
         )
 
         # Assert committing was a success
@@ -236,6 +239,7 @@ async def test_commit_and_reveal_weights_cr4_async(async_subtensor, alice_wallet
     steps = [
         SUDO_SET_ADMIN_FREEZE_WINDOW(alice_wallet, AdminUtils, True, 0),
         REGISTER_SUBNET(alice_wallet),
+        SUDO_SET_MAX_ALLOWED_UIDS(alice_wallet, AdminUtils, True, NETUID, int(256 / TESTED_MECHANISMS)),
         SUDO_SET_MECHANISM_COUNT(
             alice_wallet, AdminUtils, True, NETUID, TESTED_MECHANISMS
         ),

--- a/tests/e2e_tests/test_commit_weights.py
+++ b/tests/e2e_tests/test_commit_weights.py
@@ -15,13 +15,14 @@ from tests.e2e_tests.utils import (
     NETUID,
     SUDO_SET_ADMIN_FREEZE_WINDOW,
     SUDO_SET_TEMPO,
+    SUDO_SET_MAX_ALLOWED_UIDS,
     SUDO_SET_MECHANISM_COUNT,
     SUDO_SET_COMMIT_REVEAL_WEIGHTS_ENABLED,
     SUDO_SET_WEIGHTS_SET_RATE_LIMIT,
     AdminUtils,
 )
 
-TESTED_SUB_SUBNETS = 2
+TESTED_MECHANISMS = 2
 
 
 def test_commit_and_reveal_weights_legacy(subtensor, alice_wallet):
@@ -44,8 +45,9 @@ def test_commit_and_reveal_weights_legacy(subtensor, alice_wallet):
     steps = [
         SUDO_SET_ADMIN_FREEZE_WINDOW(alice_wallet, AdminUtils, True, 0),
         REGISTER_SUBNET(alice_wallet),
+        SUDO_SET_MAX_ALLOWED_UIDS(alice_wallet, AdminUtils, True, NETUID, int(256 / TESTED_MECHANISMS)),
         SUDO_SET_MECHANISM_COUNT(
-            alice_wallet, AdminUtils, True, NETUID, TESTED_SUB_SUBNETS
+            alice_wallet, AdminUtils, True, NETUID, TESTED_MECHANISMS
         ),
         ACTIVATE_SUBNET(alice_wallet),
         SUDO_SET_TEMPO(alice_wallet, AdminUtils, True, NETUID, TEMPO_TO_SET),
@@ -77,7 +79,7 @@ def test_commit_and_reveal_weights_legacy(subtensor, alice_wallet):
     assert response.success, response.message
     assert subtensor.subnets.weights_rate_limit(netuid=alice_sn.netuid) == 0
 
-    for mechid in range(TESTED_SUB_SUBNETS):
+    for mechid in range(TESTED_MECHANISMS):
         logging.console.info(
             f"[magenta]Testing subnet mechanism {alice_sn.netuid}.{mechid}[/magenta]"
         )
@@ -174,7 +176,7 @@ async def test_commit_and_reveal_weights_legacy_async(async_subtensor, alice_wal
         SUDO_SET_ADMIN_FREEZE_WINDOW(alice_wallet, AdminUtils, True, 0),
         REGISTER_SUBNET(alice_wallet),
         SUDO_SET_MECHANISM_COUNT(
-            alice_wallet, AdminUtils, True, NETUID, TESTED_SUB_SUBNETS
+            alice_wallet, AdminUtils, True, NETUID, TESTED_MECHANISMS
         ),
         ACTIVATE_SUBNET(alice_wallet),
         SUDO_SET_TEMPO(alice_wallet, AdminUtils, True, NETUID, TEMPO_TO_SET),
@@ -429,6 +431,7 @@ async def test_commit_weights_uses_next_nonce_async(async_subtensor, alice_walle
     steps = [
         SUDO_SET_ADMIN_FREEZE_WINDOW(alice_wallet, AdminUtils, True, 0),
         REGISTER_SUBNET(alice_wallet),
+        SUDO_SET_MAX_ALLOWED_UIDS(alice_wallet, AdminUtils, True, NETUID, int(256 / TESTED_MECHANISMS)),
         ACTIVATE_SUBNET(alice_wallet),
         SUDO_SET_TEMPO(alice_wallet, AdminUtils, True, NETUID, TEMPO_TO_SET),
         SUDO_SET_COMMIT_REVEAL_WEIGHTS_ENABLED(

--- a/tests/e2e_tests/test_commit_weights.py
+++ b/tests/e2e_tests/test_commit_weights.py
@@ -45,7 +45,9 @@ def test_commit_and_reveal_weights_legacy(subtensor, alice_wallet):
     steps = [
         SUDO_SET_ADMIN_FREEZE_WINDOW(alice_wallet, AdminUtils, True, 0),
         REGISTER_SUBNET(alice_wallet),
-        SUDO_SET_MAX_ALLOWED_UIDS(alice_wallet, AdminUtils, True, NETUID, int(256 / TESTED_MECHANISMS)),
+        SUDO_SET_MAX_ALLOWED_UIDS(
+            alice_wallet, AdminUtils, True, NETUID, int(256 / TESTED_MECHANISMS)
+        ),
         SUDO_SET_MECHANISM_COUNT(
             alice_wallet, AdminUtils, True, NETUID, TESTED_MECHANISMS
         ),
@@ -431,7 +433,9 @@ async def test_commit_weights_uses_next_nonce_async(async_subtensor, alice_walle
     steps = [
         SUDO_SET_ADMIN_FREEZE_WINDOW(alice_wallet, AdminUtils, True, 0),
         REGISTER_SUBNET(alice_wallet),
-        SUDO_SET_MAX_ALLOWED_UIDS(alice_wallet, AdminUtils, True, NETUID, int(256 / TESTED_MECHANISMS)),
+        SUDO_SET_MAX_ALLOWED_UIDS(
+            alice_wallet, AdminUtils, True, NETUID, int(256 / TESTED_MECHANISMS)
+        ),
         ACTIVATE_SUBNET(alice_wallet),
         SUDO_SET_TEMPO(alice_wallet, AdminUtils, True, NETUID, TEMPO_TO_SET),
         SUDO_SET_COMMIT_REVEAL_WEIGHTS_ENABLED(

--- a/tests/e2e_tests/test_set_weights.py
+++ b/tests/e2e_tests/test_set_weights.py
@@ -58,7 +58,9 @@ def test_set_weights_uses_next_nonce(subtensor, alice_wallet):
 
     sns_steps = [
         REGISTER_SUBNET(alice_wallet),
-        SUDO_SET_MAX_ALLOWED_UIDS(alice_wallet, AdminUtils, True, NETUID, int(256 / TESTED_MECHANISMS)),
+        SUDO_SET_MAX_ALLOWED_UIDS(
+            alice_wallet, AdminUtils, True, NETUID, int(256 / TESTED_MECHANISMS)
+        ),
         SUDO_SET_TEMPO(alice_wallet, AdminUtils, True, NETUID, subnet_tempo),
         SUDO_SET_MECHANISM_COUNT(
             alice_wallet, AdminUtils, True, NETUID, TESTED_MECHANISMS
@@ -201,7 +203,9 @@ async def test_set_weights_uses_next_nonce_async(async_subtensor, alice_wallet):
 
     sns_steps = [
         REGISTER_SUBNET(alice_wallet),
-        SUDO_SET_MAX_ALLOWED_UIDS(alice_wallet, AdminUtils, True, NETUID, int(256 / TESTED_MECHANISMS)),
+        SUDO_SET_MAX_ALLOWED_UIDS(
+            alice_wallet, AdminUtils, True, NETUID, int(256 / TESTED_MECHANISMS)
+        ),
         SUDO_SET_TEMPO(alice_wallet, AdminUtils, True, NETUID, subnet_tempo),
         SUDO_SET_MECHANISM_COUNT(
             alice_wallet, AdminUtils, True, NETUID, TESTED_MECHANISMS

--- a/tests/e2e_tests/test_set_weights.py
+++ b/tests/e2e_tests/test_set_weights.py
@@ -17,6 +17,7 @@ from tests.e2e_tests.utils import (
     SUDO_SET_ADMIN_FREEZE_WINDOW,
     SUDO_SET_COMMIT_REVEAL_WEIGHTS_ENABLED,
     SUDO_SET_LOCK_REDUCTION_INTERVAL,
+    SUDO_SET_MAX_ALLOWED_UIDS,
     SUDO_SET_MECHANISM_COUNT,
     SUDO_SET_NETWORK_RATE_LIMIT,
     SUDO_SET_TEMPO,
@@ -57,6 +58,7 @@ def test_set_weights_uses_next_nonce(subtensor, alice_wallet):
 
     sns_steps = [
         REGISTER_SUBNET(alice_wallet),
+        SUDO_SET_MAX_ALLOWED_UIDS(alice_wallet, AdminUtils, True, NETUID, int(256 / TESTED_MECHANISMS)),
         SUDO_SET_TEMPO(alice_wallet, AdminUtils, True, NETUID, subnet_tempo),
         SUDO_SET_MECHANISM_COUNT(
             alice_wallet, AdminUtils, True, NETUID, TESTED_MECHANISMS
@@ -199,6 +201,7 @@ async def test_set_weights_uses_next_nonce_async(async_subtensor, alice_wallet):
 
     sns_steps = [
         REGISTER_SUBNET(alice_wallet),
+        SUDO_SET_MAX_ALLOWED_UIDS(alice_wallet, AdminUtils, True, NETUID, int(256 / TESTED_MECHANISMS)),
         SUDO_SET_TEMPO(alice_wallet, AdminUtils, True, NETUID, subnet_tempo),
         SUDO_SET_MECHANISM_COUNT(
             alice_wallet, AdminUtils, True, NETUID, TESTED_MECHANISMS

--- a/tests/e2e_tests/test_subnet_buyback.py
+++ b/tests/e2e_tests/test_subnet_buyback.py
@@ -1,0 +1,231 @@
+import pytest
+
+from bittensor.utils.balance import Balance
+from tests.e2e_tests.utils import (
+    ACTIVATE_SUBNET,
+    REGISTER_NEURON,
+    REGISTER_SUBNET,
+    TestSubnet,
+)
+
+
+def test_subnet_buyback(subtensor, alice_wallet, bob_wallet):
+    """Tests subnet buyback without limit price.
+
+    Steps:
+    - Create subnet and register neuron for the target hotkey
+    - Verify no stake before buyback
+    - Execute subnet buyback as subnet owner
+    - Confirm stake is burned and coldkey balance decreases
+    """
+    alice_sn = TestSubnet(subtensor)
+    steps = [
+        REGISTER_SUBNET(alice_wallet),
+        ACTIVATE_SUBNET(alice_wallet),
+        REGISTER_NEURON(bob_wallet),
+    ]
+    alice_sn.execute_steps(steps)
+
+    # no stake before buyback
+    stake_before = subtensor.staking.get_stake(
+        coldkey_ss58=alice_wallet.coldkey.ss58_address,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    assert stake_before == Balance(0).set_unit(alice_sn.netuid)
+
+    # track coldkey balance before buyback
+    balance_before = subtensor.wallets.get_balance(
+        address=alice_wallet.coldkeypub.ss58_address
+    )
+
+    response = subtensor.staking.subnet_buyback(
+        wallet=alice_wallet,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        amount=Balance.from_tao(10),
+        period=16,
+    )
+    assert response.success, response.message
+
+    # stake is burned immediately after buyback
+    stake_after = subtensor.staking.get_stake(
+        coldkey_ss58=alice_wallet.coldkey.ss58_address,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    assert stake_after == Balance(0).set_unit(alice_sn.netuid)
+
+    # buyback spends TAO from the subnet owner coldkey
+    balance_after = subtensor.wallets.get_balance(
+        address=alice_wallet.coldkeypub.ss58_address
+    )
+    assert balance_after < balance_before
+
+
+@pytest.mark.asyncio
+async def test_subnet_buyback_async(async_subtensor, alice_wallet, bob_wallet):
+    """Tests subnet buyback without limit price (async).
+
+    Steps:
+    - Create subnet and register neuron for the target hotkey
+    - Verify no stake before buyback
+    - Execute subnet buyback as subnet owner
+    - Confirm stake is burned and coldkey balance decreases
+    """
+    alice_sn = TestSubnet(async_subtensor)
+    steps = [
+        REGISTER_SUBNET(alice_wallet),
+        ACTIVATE_SUBNET(alice_wallet),
+        REGISTER_NEURON(bob_wallet),
+    ]
+    await alice_sn.async_execute_steps(steps)
+
+    # no stake before buyback
+    stake_before = await async_subtensor.staking.get_stake(
+        coldkey_ss58=alice_wallet.coldkey.ss58_address,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    assert stake_before == Balance(0).set_unit(alice_sn.netuid)
+
+    # track coldkey balance before buyback
+    balance_before = await async_subtensor.wallets.get_balance(
+        address=alice_wallet.coldkeypub.ss58_address
+    )
+
+    response = await async_subtensor.staking.subnet_buyback(
+        wallet=alice_wallet,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        amount=Balance.from_tao(10),
+        period=16,
+    )
+    assert response.success, response.message
+
+    # stake is burned immediately after buyback
+    stake_after = await async_subtensor.staking.get_stake(
+        coldkey_ss58=alice_wallet.coldkey.ss58_address,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    assert stake_after == Balance(0).set_unit(alice_sn.netuid)
+
+    # buyback spends TAO from the subnet owner coldkey
+    balance_after = await async_subtensor.wallets.get_balance(
+        address=alice_wallet.coldkeypub.ss58_address
+    )
+    assert balance_after < balance_before
+
+
+def test_subnet_buyback_with_limit_price(subtensor, alice_wallet, bob_wallet):
+    """Tests subnet buyback with limit price.
+
+    Steps:
+    - Create subnet and register neuron for the target hotkey
+    - Verify no stake before buyback
+    - Execute subnet buyback with limit price as subnet owner
+    - Confirm stake is burned and coldkey balance decreases
+    """
+    alice_sn = TestSubnet(subtensor)
+    steps = [
+        REGISTER_SUBNET(alice_wallet),
+        ACTIVATE_SUBNET(alice_wallet),
+        REGISTER_NEURON(bob_wallet),
+    ]
+    alice_sn.execute_steps(steps)
+
+    # no stake before buyback
+    stake_before = subtensor.staking.get_stake(
+        coldkey_ss58=alice_wallet.coldkey.ss58_address,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    assert stake_before == Balance(0).set_unit(alice_sn.netuid)
+
+    # track coldkey balance before buyback
+    balance_before = subtensor.wallets.get_balance(
+        address=alice_wallet.coldkeypub.ss58_address
+    )
+
+    response = subtensor.staking.subnet_buyback(
+        wallet=alice_wallet,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        amount=Balance.from_tao(10),
+        limit_price=Balance.from_tao(2),
+        period=16,
+    )
+    assert response.success, response.message
+
+    # stake is burned immediately after buyback
+    stake_after = subtensor.staking.get_stake(
+        coldkey_ss58=alice_wallet.coldkey.ss58_address,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    assert stake_after == Balance(0).set_unit(alice_sn.netuid)
+
+    # buyback spends TAO from the subnet owner coldkey
+    balance_after = subtensor.wallets.get_balance(
+        address=alice_wallet.coldkeypub.ss58_address
+    )
+    assert balance_after < balance_before
+
+
+@pytest.mark.asyncio
+async def test_subnet_buyback_with_limit_price_async(
+    async_subtensor, alice_wallet, bob_wallet
+):
+    """Tests subnet buyback with limit price (async).
+
+    Steps:
+    - Create subnet and register neuron for the target hotkey
+    - Verify no stake before buyback
+    - Execute subnet buyback with limit price as subnet owner
+    - Confirm stake is burned and coldkey balance decreases
+    """
+    alice_sn = TestSubnet(async_subtensor)
+    steps = [
+        REGISTER_SUBNET(alice_wallet),
+        ACTIVATE_SUBNET(alice_wallet),
+        REGISTER_NEURON(bob_wallet),
+    ]
+    await alice_sn.async_execute_steps(steps)
+
+    # no stake before buyback
+    stake_before = await async_subtensor.staking.get_stake(
+        coldkey_ss58=alice_wallet.coldkey.ss58_address,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    assert stake_before == Balance(0).set_unit(alice_sn.netuid)
+
+    # track coldkey balance before buyback
+    balance_before = await async_subtensor.wallets.get_balance(
+        address=alice_wallet.coldkeypub.ss58_address
+    )
+
+    response = await async_subtensor.staking.subnet_buyback(
+        wallet=alice_wallet,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        amount=Balance.from_tao(10),
+        limit_price=Balance.from_tao(2),
+        period=16,
+    )
+    assert response.success, response.message
+
+    # stake is burned immediately after buyback
+    stake_after = await async_subtensor.staking.get_stake(
+        coldkey_ss58=alice_wallet.coldkey.ss58_address,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    assert stake_after == Balance(0).set_unit(alice_sn.netuid)
+
+    # buyback spends TAO from the subnet owner coldkey
+    balance_after = await async_subtensor.wallets.get_balance(
+        address=alice_wallet.coldkeypub.ss58_address
+    )
+    assert balance_after < balance_before

--- a/tests/unit_tests/extrinsics/asyncex/test_staking.py
+++ b/tests/unit_tests/extrinsics/asyncex/test_staking.py
@@ -1,7 +1,9 @@
 import pytest
 
 from bittensor.core.extrinsics.asyncex import staking
+from bittensor.core.settings import DEFAULT_MEV_PROTECTION
 from bittensor.core.types import ExtrinsicResponse
+from bittensor.utils.balance import Balance
 
 
 @pytest.mark.parametrize(
@@ -53,3 +55,117 @@ async def test_set_auto_stake_extrinsic(
 
     assert success is res_success
     assert message == res_message
+
+
+@pytest.mark.asyncio
+async def test_subnet_buyback_extrinsic(fake_wallet, mocker):
+    """Verify that async `subnet_buyback_extrinsic` method calls proper methods."""
+    # Preps
+    fake_substrate = mocker.AsyncMock(**{"get_chain_head.return_value": "0xhead"})
+    fake_subtensor = mocker.AsyncMock(
+        **{
+            "get_balance.return_value": Balance.from_tao(10),
+            "get_existential_deposit.return_value": Balance.from_tao(1),
+            "get_stake.return_value": Balance.from_tao(0),
+            "get_block_hash.return_value": "0xblock",
+            "sign_and_send_extrinsic.return_value": ExtrinsicResponse(True, "Success"),
+            "substrate": fake_substrate,
+        }
+    )
+    fake_wallet.coldkeypub.ss58_address = "coldkey"
+    hotkey_ss58 = "hotkey"
+    netuid = 1
+    amount = Balance.from_tao(2)
+
+    mocked_pallet_compose_call = mocker.AsyncMock()
+    mocker.patch.object(
+        staking.SubtensorModule, "subnet_buyback", new=mocked_pallet_compose_call
+    )
+    fake_subtensor.sim_swap = mocker.AsyncMock(
+        return_value=mocker.Mock(tao_fee=Balance.from_rao(1), alpha_fee=mocker.Mock())
+    )
+
+    # Call
+    result = await staking.subnet_buyback_extrinsic(
+        subtensor=fake_subtensor,
+        wallet=fake_wallet,
+        hotkey_ss58=hotkey_ss58,
+        netuid=netuid,
+        amount=amount,
+        mev_protection=DEFAULT_MEV_PROTECTION,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+        wait_for_revealed_execution=True,
+    )
+
+    # Asserts
+    assert result.success is True
+    mocked_pallet_compose_call.assert_awaited_once_with(
+        netuid=netuid,
+        hotkey=hotkey_ss58,
+        amount=amount.rao,
+        limit=None,
+    )
+    fake_subtensor.sign_and_send_extrinsic.assert_awaited_once_with(
+        call=mocked_pallet_compose_call.return_value,
+        wallet=fake_wallet,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+        nonce_key="coldkeypub",
+        use_nonce=True,
+        period=None,
+        raise_error=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_subnet_buyback_extrinsic_with_limit(fake_wallet, mocker):
+    """Verify that async `subnet_buyback_extrinsic` passes limit price."""
+    # Preps
+    fake_substrate = mocker.AsyncMock(**{"get_chain_head.return_value": "0xhead"})
+    fake_subtensor = mocker.AsyncMock(
+        **{
+            "get_balance.return_value": Balance.from_tao(10),
+            "get_existential_deposit.return_value": Balance.from_tao(1),
+            "get_stake.return_value": Balance.from_tao(0),
+            "get_block_hash.return_value": "0xblock",
+            "sign_and_send_extrinsic.return_value": ExtrinsicResponse(True, "Success"),
+            "substrate": fake_substrate,
+        }
+    )
+    fake_wallet.coldkeypub.ss58_address = "coldkey"
+    hotkey_ss58 = "hotkey"
+    netuid = 1
+    amount = Balance.from_tao(2)
+    limit_price = Balance.from_tao(2)
+
+    mocked_pallet_compose_call = mocker.AsyncMock()
+    mocker.patch.object(
+        staking.SubtensorModule, "subnet_buyback", new=mocked_pallet_compose_call
+    )
+    fake_subtensor.sim_swap = mocker.AsyncMock(
+        return_value=mocker.Mock(tao_fee=Balance.from_rao(1), alpha_fee=mocker.Mock())
+    )
+
+    # Call
+    result = await staking.subnet_buyback_extrinsic(
+        subtensor=fake_subtensor,
+        wallet=fake_wallet,
+        hotkey_ss58=hotkey_ss58,
+        netuid=netuid,
+        amount=amount,
+        limit_price=limit_price,
+        mev_protection=DEFAULT_MEV_PROTECTION,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+        wait_for_revealed_execution=True,
+    )
+
+    # Asserts
+    assert result.success is True
+    mocked_pallet_compose_call.assert_awaited_once_with(
+        netuid=netuid,
+        hotkey=hotkey_ss58,
+        amount=amount.rao,
+        limit=limit_price.rao,
+    )

--- a/tests/unit_tests/extrinsics/test_staking.py
+++ b/tests/unit_tests/extrinsics/test_staking.py
@@ -2,8 +2,8 @@ import pytest
 
 from bittensor.core.extrinsics import staking
 from bittensor.core.settings import DEFAULT_MEV_PROTECTION
-from bittensor.utils.balance import Balance
 from bittensor.core.types import ExtrinsicResponse
+from bittensor.utils.balance import Balance
 
 
 def test_add_stake_extrinsic(mocker):
@@ -62,6 +62,114 @@ def test_add_stake_extrinsic(mocker):
         use_nonce=True,
         period=None,
         raise_error=False,
+    )
+
+
+def test_subnet_buyback_extrinsic(mocker):
+    """Verify that sync `subnet_buyback_extrinsic` method calls proper methods."""
+    # Preps
+    fake_subtensor = mocker.Mock(
+        **{
+            "get_balance.return_value": Balance.from_tao(10),
+            "get_existential_deposit.return_value": Balance.from_tao(1),
+            "get_current_block.return_value": 123,
+            "get_stake.return_value": Balance.from_tao(0),
+            "sign_and_send_extrinsic.return_value": ExtrinsicResponse(True, "Success"),
+        }
+    )
+    fake_wallet = mocker.Mock(
+        **{
+            "coldkeypub.ss58_address": "coldkey",
+        }
+    )
+    hotkey_ss58 = "hotkey"
+    netuid = 1
+    amount = Balance.from_tao(2)
+
+    # Call
+    result = staking.subnet_buyback_extrinsic(
+        subtensor=fake_subtensor,
+        wallet=fake_wallet,
+        hotkey_ss58=hotkey_ss58,
+        netuid=netuid,
+        amount=amount,
+        mev_protection=DEFAULT_MEV_PROTECTION,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+        wait_for_revealed_execution=True,
+    )
+
+    # Asserts
+    assert result.success is True
+    fake_subtensor.compose_call.assert_called_once_with(
+        call_module="SubtensorModule",
+        call_function="subnet_buyback",
+        call_params={
+            "hotkey": hotkey_ss58,
+            "netuid": netuid,
+            "amount": amount.rao,
+            "limit": None,
+        },
+    )
+    fake_subtensor.sign_and_send_extrinsic.assert_called_once_with(
+        call=fake_subtensor.compose_call.return_value,
+        wallet=fake_wallet,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+        nonce_key="coldkeypub",
+        use_nonce=True,
+        period=None,
+        raise_error=False,
+    )
+
+
+def test_subnet_buyback_extrinsic_with_limit(mocker):
+    """Verify that sync `subnet_buyback_extrinsic` passes limit price."""
+    # Preps
+    fake_subtensor = mocker.Mock(
+        **{
+            "get_balance.return_value": Balance.from_tao(10),
+            "get_existential_deposit.return_value": Balance.from_tao(1),
+            "get_current_block.return_value": 123,
+            "get_stake.return_value": Balance.from_tao(0),
+            "sign_and_send_extrinsic.return_value": ExtrinsicResponse(True, "Success"),
+        }
+    )
+    fake_wallet = mocker.Mock(
+        **{
+            "coldkeypub.ss58_address": "coldkey",
+        }
+    )
+    hotkey_ss58 = "hotkey"
+    netuid = 1
+    amount = Balance.from_tao(2)
+    limit_price = Balance.from_tao(2)
+
+    # Call
+    result = staking.subnet_buyback_extrinsic(
+        subtensor=fake_subtensor,
+        wallet=fake_wallet,
+        hotkey_ss58=hotkey_ss58,
+        netuid=netuid,
+        amount=amount,
+        limit_price=limit_price,
+        mev_protection=DEFAULT_MEV_PROTECTION,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+        wait_for_revealed_execution=True,
+    )
+
+    # Asserts
+    assert result.success is True
+    fake_subtensor.compose_call.assert_called_once_with(
+        call_module="SubtensorModule",
+        call_function="subnet_buyback",
+        call_params={
+            "hotkey": hotkey_ss58,
+            "netuid": netuid,
+            "amount": amount.rao,
+            "limit": limit_price.rao,
+        },
     )
 
 

--- a/tests/unit_tests/test_async_subtensor.py
+++ b/tests/unit_tests/test_async_subtensor.py
@@ -2921,6 +2921,71 @@ async def test_start_call(subtensor, mocker):
 
 
 @pytest.mark.asyncio
+async def test_subnet_buyback(subtensor, mocker):
+    """Test subnet_buyback extrinsic calls properly."""
+    # Preps
+    wallet_name = mocker.Mock(spec=Wallet)
+    netuid = 123
+    hotkey_ss58 = "hotkey"
+    amount = Balance.from_tao(1.0)
+    mocked_extrinsic = mocker.patch.object(async_subtensor, "subnet_buyback_extrinsic")
+
+    # Call
+    result = await subtensor.subnet_buyback(wallet_name, netuid, hotkey_ss58, amount)
+
+    # Asserts
+    mocked_extrinsic.assert_awaited_once_with(
+        subtensor=subtensor,
+        wallet=wallet_name,
+        netuid=netuid,
+        hotkey_ss58=hotkey_ss58,
+        amount=amount,
+        limit_price=None,
+        mev_protection=DEFAULT_MEV_PROTECTION,
+        period=DEFAULT_PERIOD,
+        raise_error=False,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+        wait_for_revealed_execution=True,
+    )
+    assert result == mocked_extrinsic.return_value
+
+
+@pytest.mark.asyncio
+async def test_subnet_buyback_with_limit_price(subtensor, mocker):
+    """Test subnet_buyback extrinsic passes limit price."""
+    # Preps
+    wallet_name = mocker.Mock(spec=Wallet)
+    netuid = 123
+    hotkey_ss58 = "hotkey"
+    amount = Balance.from_tao(1.0)
+    limit_price = Balance.from_tao(2.0)
+    mocked_extrinsic = mocker.patch.object(async_subtensor, "subnet_buyback_extrinsic")
+
+    # Call
+    result = await subtensor.subnet_buyback(
+        wallet_name, netuid, hotkey_ss58, amount, limit_price=limit_price
+    )
+
+    # Asserts
+    mocked_extrinsic.assert_awaited_once_with(
+        subtensor=subtensor,
+        wallet=wallet_name,
+        netuid=netuid,
+        hotkey_ss58=hotkey_ss58,
+        amount=amount,
+        limit_price=limit_price,
+        mev_protection=DEFAULT_MEV_PROTECTION,
+        period=DEFAULT_PERIOD,
+        raise_error=False,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+        wait_for_revealed_execution=True,
+    )
+    assert result == mocked_extrinsic.return_value
+
+
+@pytest.mark.asyncio
 async def test_get_metagraph_info_all_fields(subtensor, mocker):
     """Test get_metagraph_info with all fields (default behavior)."""
     # Preps

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -3182,6 +3182,76 @@ def test_start_call(subtensor, mocker):
     assert result == mocked_extrinsic.return_value
 
 
+def test_subnet_buyback(subtensor, fake_wallet, mocker):
+    """Test subnet_buyback extrinsic calls properly."""
+    # Preps
+    netuid = 123
+    hotkey_ss58 = "hotkey"
+    amount = Balance.from_tao(1.0)
+    mocked_extrinsic = mocker.patch.object(subtensor_module, "subnet_buyback_extrinsic")
+
+    # Call
+    result = subtensor.subnet_buyback(
+        wallet=fake_wallet,
+        netuid=netuid,
+        hotkey_ss58=hotkey_ss58,
+        amount=amount,
+    )
+
+    # Asserts
+    mocked_extrinsic.assert_called_once_with(
+        subtensor=subtensor,
+        wallet=fake_wallet,
+        netuid=netuid,
+        hotkey_ss58=hotkey_ss58,
+        amount=amount,
+        limit_price=None,
+        mev_protection=DEFAULT_MEV_PROTECTION,
+        period=DEFAULT_PERIOD,
+        raise_error=False,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+        wait_for_revealed_execution=True,
+    )
+    assert result == mocked_extrinsic.return_value
+
+
+def test_subnet_buyback_with_limit_price(subtensor, fake_wallet, mocker):
+    """Test subnet_buyback extrinsic passes limit price."""
+    # Preps
+    netuid = 123
+    hotkey_ss58 = "hotkey"
+    amount = Balance.from_tao(1.0)
+    limit_price = Balance.from_tao(2.0)
+    mocked_extrinsic = mocker.patch.object(subtensor_module, "subnet_buyback_extrinsic")
+
+    # Call
+    result = subtensor.subnet_buyback(
+        wallet=fake_wallet,
+        netuid=netuid,
+        hotkey_ss58=hotkey_ss58,
+        amount=amount,
+        limit_price=limit_price,
+    )
+
+    # Asserts
+    mocked_extrinsic.assert_called_once_with(
+        subtensor=subtensor,
+        wallet=fake_wallet,
+        netuid=netuid,
+        hotkey_ss58=hotkey_ss58,
+        amount=amount,
+        limit_price=limit_price,
+        mev_protection=DEFAULT_MEV_PROTECTION,
+        period=DEFAULT_PERIOD,
+        raise_error=False,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+        wait_for_revealed_execution=True,
+    )
+    assert result == mocked_extrinsic.return_value
+
+
 def test_get_metagraph_info_all_fields(subtensor, mocker):
     """Test get_metagraph_info with all fields (default behavior)."""
     # Preps


### PR DESCRIPTION
### Context 
Subtensor added a `subnet_buyback` extrinsic. Expose subnet owner buyback flow through the SDK with parity to chain behavior and test coverage.

### Contains:
- Pallet call builder
- sync/async extrinsic helpers
- Subtensor/AsyncSubtensor wrappers, 
- unit tests
- e2e tests

Subtensor base PR: https://github.com/opentensor/subtensor/pull/2381