### PR TITLE
docs: fix double space in DEBUGGING.md

### DIFF
--- a/contrib/DEBUGGING.md
+++ b/contrib/DEBUGGING.md
@@ -136,7 +136,7 @@ import pdb; pdb.set_trace() # breakpoint!
 This will stop execution at the breakpoint you set and can operate on the stack directly in the terminal.
 
 ## Searching for strings
-Use `ag`.  It's fast, convenient, and widely available on unix systems. Ag will highlight all occurrences of a given pattern.
+Use `ag`. It's fast, convenient, and widely available on unix systems. Ag will highlight all occurrences of a given pattern.
 
 ```bash
 apt-get install silversearcher-ag


### PR DESCRIPTION
## Summary
Fix double space after period in `contrib/DEBUGGING.md` for consistent formatting.

## Changes
- Remove extra space after period in "Use `ag`." sentence

## Type of Change
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing
- [x] Verified formatting correction
- [x] No functional code changes

## Related Issues
None - proactive formatting fix

## Contributor Checklist
- [x] Branch from `staging` (not master)
- [x] <50 files changed
- [x] Minimal diff (1 line)
- [x] Commit message follows guidelines
- [x] Read contrib/ folder

See contrib/CONTRIBUTING.md for full guidelines.
