### PR TITLE
docs: fix broken changelog URL and typo in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 * @Dairus01 made their first contribution in https://github.com/opentensor/bittensor/pull/3231
 * @Olexandr88 made their first contribution in https://github.com/opentensor/bittensor/pull/3238
 
-**Full Changelog**: https://github.com/opentensor/bittensor/compare/v10.1.0...v10.0.2
+**Full Changelog**: https://github.com/opentensor/bittensor/compare/v10.0.1...v10.1.0
 
 ## 10.0.1 /2025-12-22
 

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ pytest tests/unit_tests
 - `LOCALNET_SH_PATH` - path to `localnet.sh` script in cloned subtensor repository (for legacy runner);
 - `BUILD_BINARY` - (`=0` or `=1`) - used with `LOCALNET_SH_PATH` for build or not before start localnet node (for legacy runner);
 - `USE_DOCKER` - (`=0` or `=1`) - used if you want to use specific runner to run e2e tests (for docker runner);
-- `FAST_BLOCKS` - (`=0` or `=1`) - allows you to run a localnet node in fast or non-fast blocks mode (for both types of runers).
+- `FAST_BLOCKS` - (`=0` or `=1`) - allows you to run a localnet node in fast or non-fast blocks mode (for both types of runners).
 - `SKIP_PULL` - used if you are using a Docker image, but for some reason you want to temporarily limit the logic of updating the image from the repository.
 
 #### Using `docker runner` (default for now):


### PR DESCRIPTION
## Summary
Fix two small documentation errors found in `CHANGELOG.md` and `README.md`.

## Motivation
- `CHANGELOG.md`: The Full Changelog link for v10.1.0 references a non-existent tag (`v10.0.2`) with a reversed version order, resulting in a 404. Corrected to `v10.0.1...v10.1.0`.
- `README.md`: Typo `runers` → `runners` in the e2e test environment variable docs.

## Changes Made
- `CHANGELOG.md`: Fix Full Changelog compare URL for v10.1.0 (broken link → working link)
- `README.md`: Fix spelling of `runners` in `FAST_BLOCKS` env var description

## Tests Added
- [ ] N/A — docs-only change

## Compliance Checklist
- [x] Branched from `staging`
- [x] <50 files changed (2 files)
- [x] Docs-only: no Python code changed, no `make check` needed
- [x] Commit messages follow [style guide](https://github.com/opentensor/bittensor/blob/master/contrib/STYLE.md)
- [x] Followed [contrib guidelines](https://github.com/opentensor/bittensor/tree/master/contrib)

## Contrib Reference
This PR follows guidance from: [contrib/CONTRIBUTING.md](https://github.com/opentensor/bittensor/blob/master/contrib/CONTRIBUTING.md)