### PR TITLE
docs: fix stray backtick in migration guide checklist

### DIFF
--- a/MIGRATION-GUIDE.md
+++ b/MIGRATION-GUIDE.md
@@ -1030,7 +1030,7 @@ The async `AsyncMetagraph.sync` method no longer terminates the subtensor instan
 1. **Update Python version** to 3.10 or higher
 2. **Update bittensor package**: `pip install bittensor>=10.0.0` (until the public release, you should install the latest available release candidate).
 3. **Update all imports** to use PascalCase class names (`Subtensor`, `Wallet`, etc.), also known as the CapWords convention.
-4. **Replace all amount parameters** with `Balance` objects.`
+4. **Replace all amount parameters** with `Balance` objects.
 5. **Update all functions that submit extrinsics** to handle `ExtrinsicResponse` return type instead of `bool` or tuples[bool, str]
 6. **Rename parameters** according to the standardization (`hotkey` → `hotkey_ss58`, `dest` → `destination`, etc.)
 7. **Update environment variables** (`BT_CHAIN_ENDPOINT` → `BT_SUBTENSOR_CHAIN_ENDPOINT`, `BT_NETWORK` → `BT_SUBTENSOR_NETWORK`)


### PR DESCRIPTION
## Summary
Fix a stray backtick at the end of step 4 in the Migration Checklist of `MIGRATION-GUIDE.md`.

## Motivation
The trailing backtick on the line:
```
4. **Replace all amount parameters** with `Balance` objects.`
```
is an unmatched backtick that breaks Markdown rendering — the trailing `` ` `` starts an unclosed inline code span, causing the following checklist items to render incorrectly in some Markdown parsers.

## Changes Made
- Remove the stray backtick at the end of Migration Checklist step 4 in `MIGRATION-GUIDE.md`

## Tests Added
- N/A — documentation-only fix

## Compliance Checklist
- [x] Branched from `staging`
- [x] <50 files changed (1 file, 1 line)
- [x] Commit messages follow [style guide](https://github.com/opentensor/bittensor/blob/master/contrib/STYLE.md)
- [x] Followed [contrib guidelines](https://github.com/opentensor/bittensor/tree/master/contrib)

## Contrib Reference
This PR follows guidance from: [CONTRIBUTING.md](https://github.com/opentensor/bittensor/blob/master/contrib/CONTRIBUTING.md)