### PR TITLE
Handle scaleobj from asi in fixed_to_float

### DIFF
--- a/bittensor/utils/balance.py
+++ b/bittensor/utils/balance.py
@@ -1,6 +1,7 @@
 from typing import Optional, TypedDict, Union
 
 from scalecodec import ScaleType
+from async_substrate_interface.types import ScaleObj
 
 from bittensor.core import settings
 from bittensor.core.errors import BalanceTypeError, BalanceUnitMismatchError
@@ -374,12 +375,14 @@ class FixedPoint(TypedDict):
 
 
 def fixed_to_float(
-    fixed: Union[FixedPoint, ScaleType], frac_bits: int = 64, total_bits: int = 128
+    fixed: FixedPoint | ScaleType | ScaleObj, frac_bits: int = 64, total_bits: int = 128
 ) -> float:
     """Converts a fixed-point value (e.g., U64F64) into a floating-point number."""
     # By default, this is a U64F64
     # which is 64 bits of integer and 64 bits of fractional
-    data: int = fb.value if isinstance((fb := fixed["bits"]), ScaleType) else fb
+    data: int = (
+        fb.value if isinstance((fb := fixed["bits"]), (ScaleType, ScaleObj)) else fb
+    )
 
     # Logical and to get the fractional part; remaining is the integer part
     fractional_part = data & (2**frac_bits - 1)


### PR DESCRIPTION
`fixed_to_float` only handles `ScaleType` which we don't use anymore. 