### PR TITLE
docs: fix incorrect rule count in STYLE.md

### DIFF
--- a/contrib/STYLE.md
+++ b/contrib/STYLE.md
@@ -200,7 +200,7 @@ Imperative mood just means “spoken or written as if giving a command or instru
     Close the door
     Take out the trash
 
-Each of the seven rules you’re reading about right now is written in the imperative (“Wrap the body at 72 characters”, etc.).
+Each of the six rules you’re reading about right now is written in the imperative (“Wrap the body at 72 characters”, etc.).
 
 The imperative can sound a little rude; that’s why we don’t often use it. But it’s perfect for Git commit subject lines. One reason for this is that Git itself uses the imperative whenever it creates a commit on your behalf.
 


### PR DESCRIPTION
The section body at line 203 refers to "the seven rules" but the section heading and table of contents both say "six rules", and only six rules are listed. This changes "seven" to "six" for consistency.

---
- 1 file changed, 1 line