### PR TITLE
perf: parallelize sequential awaits with asyncio in async_subtensor

### DIFF
--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -1014,24 +1014,31 @@ class AsyncSubtensor(SubtensorMixin):
         if not block_hash and reuse_block:
             block_hash = self.substrate.last_block_hash
 
-        query = await self.substrate.runtime_call(
-            api="SubnetInfoRuntimeApi",
-            method="get_all_dynamic_info",
-            block_hash=block_hash,
+        async def _safe_get_prices():
+            try:
+                return await self.get_subnet_prices(block_hash=block_hash)
+            except (SubstrateRequestException, ValueError) as e:
+                logging.warning(
+                    f"Unable to fetch subnet prices for block {block}, block hash {block_hash}: {e}"
+                )
+                return None
+
+        query, subnet_prices = await asyncio.gather(
+            self.substrate.runtime_call(
+                api="SubnetInfoRuntimeApi",
+                method="get_all_dynamic_info",
+                block_hash=block_hash,
+            ),
+            _safe_get_prices(),
         )
-        subnet_prices = await self.get_subnet_prices(block_hash=block_hash)
 
         decoded = query.decode()
 
-        if not isinstance(subnet_prices, (SubstrateRequestException, ValueError)):
+        if subnet_prices is not None:
             for sn in decoded:
                 sn.update(
                     {"price": subnet_prices.get(sn["netuid"], Balance.from_tao(0))}
                 )
-        else:
-            logging.warning(
-                f"Unable to fetch subnet prices for block {block}, block hash {block_hash}: {subnet_prices}"
-            )
         return DynamicInfo.list_from_dicts(decoded)
 
     async def blocks_since_last_step(
@@ -1087,14 +1094,18 @@ class AsyncSubtensor(SubtensorMixin):
             The number of blocks since the last update, or None if the subnetwork or UID does not exist.
         """
         block_hash = await self.determine_block_hash(block, block_hash, reuse_block)
-        block = block or await self.substrate.get_block_number(block_hash)
-        call = await self.get_hyperparameter(
+        if block_hash is None:
+            block_hash = await self.get_block_hash()
+        block_coro = self.substrate.get_block_number(block_hash) if block is None else None
+        call_coro = self.get_hyperparameter(
             param_name="LastUpdate",
             netuid=netuid,
-            block=block,
             block_hash=block_hash,
-            reuse_block=reuse_block,
         )
+        if block_coro is not None:
+            block, call = await asyncio.gather(block_coro, call_coro)
+        else:
+            call = await call_coro
         return None if call is None else (block - int(call[uid]))
 
     async def blocks_until_next_epoch(
@@ -1118,8 +1129,17 @@ class AsyncSubtensor(SubtensorMixin):
             The number of blocks until the next epoch of the subnet with provided netuid.
         """
         block_hash = await self.determine_block_hash(block, block_hash, reuse_block)
-        block = block or await self.substrate.get_block_number(block_hash=block_hash)
-        tempo = tempo or await self.tempo(netuid=netuid, block_hash=block_hash)
+        tasks = {}
+        if block is None:
+            tasks["block"] = self.substrate.get_block_number(block_hash=block_hash)
+        if tempo is None:
+            tasks["tempo"] = self.tempo(netuid=netuid, block_hash=block_hash)
+        if tasks:
+            results = dict(
+                zip(tasks.keys(), await asyncio.gather(*tasks.values()))
+            )
+            block = results.get("block", block)
+            tempo = results.get("tempo", tempo)
 
         if not tempo:
             return None

--- a/tests/unit_tests/test_async_subtensor.py
+++ b/tests/unit_tests/test_async_subtensor.py
@@ -2462,7 +2462,11 @@ async def test_blocks_since_last_update_success(subtensor, mocker):
     last_update_block = 50
     current_block = 100
     fake_blocks_since_update = current_block - last_update_block
+    fake_block_hash = "fake_block_hash"
 
+    mocker.patch.object(
+        subtensor, "determine_block_hash", return_value=fake_block_hash
+    )
     mocker.patch.object(
         subtensor.substrate,
         "get_block_number",
@@ -2481,9 +2485,7 @@ async def test_blocks_since_last_update_success(subtensor, mocker):
     mocked_get_hyperparameter.assert_called_once_with(
         param_name="LastUpdate",
         netuid=fake_netuid,
-        block=subtensor.substrate.get_block_number.return_value,
-        block_hash=None,
-        reuse_block=False,
+        block_hash=fake_block_hash,
     )
     assert result == fake_blocks_since_update
 
@@ -2495,7 +2497,11 @@ async def test_blocks_since_last_update_no_last_update(subtensor, mocker):
     fake_netuid = 1
     fake_uid = 5
     fake_result = None
+    fake_block_hash = "fake_block_hash"
 
+    mocker.patch.object(
+        subtensor, "determine_block_hash", return_value=fake_block_hash
+    )
     mocked_get_hyperparameter = mocker.patch.object(
         subtensor,
         "get_hyperparameter",
@@ -2512,9 +2518,7 @@ async def test_blocks_since_last_update_no_last_update(subtensor, mocker):
     mocked_get_hyperparameter.assert_called_once_with(
         param_name="LastUpdate",
         netuid=fake_netuid,
-        block=subtensor.substrate.get_block_number.return_value,
-        block_hash=None,
-        reuse_block=False,
+        block_hash=fake_block_hash,
     )
     assert result is None
 


### PR DESCRIPTION
Fixes #3129

## Summary
Apply `asyncio.gather` to three methods to run sequential RPC calls concurrently:

- **`get_all_dynamic_info`**: `runtime_call` and `get_subnet_prices` in parallel
- **`blocks_since_last_update`**: `get_block_number` and `get_hyperparameter` in parallel, with pre-resolved `block_hash` for chain state consistency
- **`blocks_until_next_epoch`**: dynamic gather for `get_block_number` and `tempo` when both need fetching

Each parallelized pair saves ~1 RPC round-trip (50-200ms depending on node latency).

## Test plan
- [x] Updated `test_blocks_since_last_update_success` and `test_blocks_since_last_update_no_last_update` for new calling convention
- [ ] CI passes