### PR TITLE
Ensures we don't accidentally install ASI 2.0 on this

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "uvicorn",
     "bittensor-drand>=1.3.0,<2.0.0",
     "bittensor-wallet==4.0.1",
-    "async-substrate-interface>=1.6.2"
+    "async-substrate-interface>=1.6.2,<2.0.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
With the upcoming release of ASI 2.0 (probably in a month or two), we want to ensure users of old versions don't accidentally bump use an incompatible version.