### PR TITLE
Fix: Updates exception check for Commitment Pallet extension

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ requires-python = ">=3.10,<3.15"
 dependencies = [
     "wheel",
     "setuptools~=70.0",
-    "aiohttp>=3.9,<3.13.3",
+    "aiohttp>=3.9,<4.0",
     "asyncstdlib~=3.13.0",
     "colorama~=0.4.6",
     "fastapi>=0.110.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ requires-python = ">=3.10,<3.15"
 dependencies = [
     "wheel",
     "setuptools~=70.0",
-    "aiohttp>=3.9,<4.0",
+    "aiohttp>=3.9,<3.13.3",
     "asyncstdlib~=3.13.0",
     "colorama~=0.4.6",
     "fastapi>=0.110.1",

--- a/tests/e2e_tests/test_commitment.py
+++ b/tests/e2e_tests/test_commitment.py
@@ -24,7 +24,10 @@ def test_commitment(subtensor, alice_wallet, dave_wallet):
     ]
     dave_sn.execute_steps(steps)
 
-    with pytest.raises(SubstrateRequestException, match="AccountNotAllowedCommit"):
+    with pytest.raises(
+        SubstrateRequestException,
+        match=r"AccountNotAllowedCommit|Invalid signing address",
+    ):
         subtensor.commitments.set_commitment(
             wallet=alice_wallet,
             netuid=dave_sn.netuid,
@@ -89,7 +92,10 @@ async def test_commitment_async(async_subtensor, alice_wallet, dave_wallet):
     ]
     await dave_sn.async_execute_steps(steps)
 
-    with pytest.raises(SubstrateRequestException, match="AccountNotAllowedCommit"):
+    with pytest.raises(
+        SubstrateRequestException,
+        match=r"AccountNotAllowedCommit|Invalid signing address",
+    ):
         await async_subtensor.commitments.set_commitment(
             wallet=alice_wallet,
             netuid=dave_sn.netuid,


### PR DESCRIPTION
- Backwards compatible with current exception. 
- We can remove the legacy check once extension is merged in

Related: https://github.com/opentensor/subtensor/pull/2544