### PR TITLE
Adds note to httpx in dev reqs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dev = [
     "types-retry==0.9.9.4",
     "typing_extensions>= 4.0.0; python_version<'3.11'",
     "freezegun==1.5.0",
+    "httpx==0.27.0", # used by tests/unit_tests/test_axon: The starlette.testclient module requires the httpx package to be installed.
     "ruff==0.11.5",
     "aioresponses==0.7.6",
     "factory-boy==3.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ dev = [
     "types-retry==0.9.9.4",
     "typing_extensions>= 4.0.0; python_version<'3.11'",
     "freezegun==1.5.0",
-    "httpx==0.27.0",
     "ruff==0.11.5",
     "aioresponses==0.7.6",
     "factory-boy==3.3.0",


### PR DESCRIPTION
Adds note The starlette.testclient module requires the httpx package to be installed.