### PR TITLE
build: migrate linter from flake8 to ruff check

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-max-line-length = 120
-exclude = .git,__pycache__, __init__.py, docs/source/conf.py,old,build,dist,venv,.venv,.tox
-select = E9,F63,F7,F82,F401

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,4 +1,4 @@
-name: Flake8 and Mypy - linters check
+name: Linters check
 permissions:
   contents: read
 
@@ -55,8 +55,8 @@ jobs:
       - name: Sync dev deps
         run: uv sync --extra dev --dev
 
-      - name: Flake8
-        run: uv run flake8 bittensor/ --count
+      - name: Ruff check
+        run: uv run ruff check bittensor/
 
       - name: Mypy
         run: uv run mypy --ignore-missing-imports bittensor/

--- a/Makefile
+++ b/Makefile
@@ -35,4 +35,4 @@ check: ruff
 	@mypy --ignore-missing-imports bittensor/ --python-version=3.12
 	@mypy --ignore-missing-imports bittensor/ --python-version=3.13
 	@mypy --ignore-missing-imports bittensor/ --python-version=3.14
-	@flake8 bittensor/ --count
+	@python -m ruff check bittensor/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ dev = [
     "pytest-cov==4.0.0",
     "ddt==1.6.0",
     "hypothesis==6.81.1",
-    "flake8==7.0.0",
     "mypy==1.8.0",
     "types-retry==0.9.9.4",
     "typing_extensions>= 4.0.0; python_version<'3.11'",
@@ -97,3 +96,20 @@ classifiers = [
 [tool.setuptools]
 package-dir = {"bittensor" = "bittensor"}
 script-files = ["bittensor/utils/certifi.sh"]
+
+[tool.ruff.lint]
+# Migrated from .flake8 `select`. Enforces runtime errors (E9), undefined
+# names/bad comparisons (F63/F7/F82), and unused-import detection (F401).
+select = ["E9", "F63", "F7", "F82", "F401"]
+exclude = [
+    "docs/source/conf.py",
+    "old",
+    "build",
+    "dist",
+    "venv",
+    ".venv",
+    ".tox",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]


### PR DESCRIPTION
Closes #3312.

Ruff already runs for formatting in this repo; the project also pins
ruff==0.11.5 alongside flake8==7.0.0 in dev deps. This replaces the
flake8 linter pass with `ruff check`, using the same rule set that
`.flake8` selected (E9, F63, F7, F82, F401) so no new diagnostics are
introduced.

**Changes**
- `.flake8` removed; equivalent config moved to `[tool.ruff.lint]` in `pyproject.toml`.
- `flake8==7.0.0` dropped from `[project.optional-dependencies].dev`.
- `Makefile` `lint` target calls `python -m ruff check bittensor/`.
- `.github/workflows/flake8-and-mypy.yml` renamed to `linters.yml`; the
  `Flake8` step is now `Ruff check` running `uv run ruff check bittensor/`.

**Verification**
- `uv run ruff check bittensor/` — 0 diagnostics.
- No functional change; replaces one linter invocation with another.

Per-file ignore (`__init__.py` = F401) retained so re-exports don't trip
the unused-import rule.