### PR TITLE
perf(async): parallelise block + tempo lookups in blocks_until_next_epoch

### DIFF
--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -1118,8 +1118,21 @@ class AsyncSubtensor(SubtensorMixin):
             The number of blocks until the next epoch of the subnet with provided netuid.
         """
         block_hash = await self.determine_block_hash(block, block_hash, reuse_block)
-        block = block or await self.substrate.get_block_number(block_hash=block_hash)
-        tempo = tempo or await self.tempo(netuid=netuid, block_hash=block_hash)
+
+        # Resolve `block` and `tempo` concurrently when both still need
+        # fetching — the common case for callers that pass only `netuid`.
+        # Both lookups are gated on the now-known `block_hash` and don't
+        # depend on each other, so the prior sequential `await`s doubled
+        # the user-perceived latency to ~2× substrate roundtrip per call.
+        if block is None and tempo is None:
+            block, tempo = await asyncio.gather(
+                self.substrate.get_block_number(block_hash=block_hash),
+                self.tempo(netuid=netuid, block_hash=block_hash),
+            )
+        elif block is None:
+            block = await self.substrate.get_block_number(block_hash=block_hash)
+        elif tempo is None:
+            tempo = await self.tempo(netuid=netuid, block_hash=block_hash)
 
         if not tempo:
             return None

--- a/tests/unit_tests/test_async_subtensor.py
+++ b/tests/unit_tests/test_async_subtensor.py
@@ -5657,6 +5657,90 @@ async def test_blocks_until_next_epoch_uses_default_tempo(subtensor, mocker):
 
 
 @pytest.mark.asyncio
+async def test_blocks_until_next_epoch_resolves_block_and_tempo_in_parallel(
+    subtensor, mocker
+):
+    """When neither block nor tempo is supplied, both lookups run via a
+    single ``asyncio.gather`` instead of two sequential awaits. Pins down
+    the optimization called out in latent-to/bittensor#3129 ("apply
+    asyncio.gather where this can improve performance")."""
+    # Prep
+    netuid = 0
+    fake_block_hash = "0xdeadbeef"
+    resolved_block = 21
+    resolved_tempo = 50
+
+    mocker.patch.object(subtensor, "determine_block_hash", return_value=fake_block_hash)
+    subtensor.substrate.get_block_number = mocker.AsyncMock(return_value=resolved_block)
+    mocker.patch.object(subtensor, "tempo", return_value=resolved_tempo)
+    gather_spy = mocker.spy(async_subtensor.asyncio, "gather")
+
+    # Call
+    result = await subtensor.blocks_until_next_epoch(netuid=netuid)
+
+    # Assert — gather called once with both lookups; result reflects them
+    assert gather_spy.call_count == 1
+    subtensor.substrate.get_block_number.assert_awaited_once_with(
+        block_hash=fake_block_hash
+    )
+    subtensor.tempo.assert_awaited_once_with(netuid=netuid, block_hash=fake_block_hash)
+    netuid_plus_one = netuid + 1
+    tempo_plus_one = resolved_tempo + 1
+    adjusted = (resolved_block + netuid_plus_one) % (2**64)
+    expected = resolved_tempo - (adjusted % tempo_plus_one)
+    assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_blocks_until_next_epoch_only_block_missing_skips_gather(
+    subtensor, mocker
+):
+    """When tempo is supplied and block isn't, only the block lookup runs
+    — no ``asyncio.gather`` (would just wrap a single coroutine)."""
+    netuid = 0
+    tempo = 100
+    fake_block_hash = "0xabc"
+    resolved_block = 7
+
+    mocker.patch.object(subtensor, "determine_block_hash", return_value=fake_block_hash)
+    subtensor.substrate.get_block_number = mocker.AsyncMock(return_value=resolved_block)
+    spy_tempo = mocker.spy(subtensor, "tempo")
+    gather_spy = mocker.spy(async_subtensor.asyncio, "gather")
+
+    result = await subtensor.blocks_until_next_epoch(netuid=netuid, tempo=tempo)
+
+    gather_spy.assert_not_called()
+    subtensor.substrate.get_block_number.assert_awaited_once_with(
+        block_hash=fake_block_hash
+    )
+    spy_tempo.assert_not_awaited()
+    assert isinstance(result, int)
+
+
+@pytest.mark.asyncio
+async def test_blocks_until_next_epoch_only_tempo_missing_skips_gather(
+    subtensor, mocker
+):
+    """When block is supplied and tempo isn't, only the tempo lookup runs."""
+    netuid = 0
+    block = 12
+    fake_block_hash = "0xabc"
+    resolved_tempo = 80
+
+    mocker.patch.object(subtensor, "determine_block_hash", return_value=fake_block_hash)
+    subtensor.substrate.get_block_number = mocker.AsyncMock()
+    mocker.patch.object(subtensor, "tempo", return_value=resolved_tempo)
+    gather_spy = mocker.spy(async_subtensor.asyncio, "gather")
+
+    result = await subtensor.blocks_until_next_epoch(netuid=netuid, block=block)
+
+    gather_spy.assert_not_called()
+    subtensor.substrate.get_block_number.assert_not_awaited()
+    subtensor.tempo.assert_awaited_once_with(netuid=netuid, block_hash=fake_block_hash)
+    assert isinstance(result, int)
+
+
+@pytest.mark.asyncio
 async def test_get_stake_info_for_coldkeys_none(subtensor, mocker):
     """Tests get_stake_info_for_coldkeys method when query_runtime_api returns None."""
     # Preps


### PR DESCRIPTION
```
## Summary

`AsyncSubtensor.blocks_until_next_epoch` resolves three values before its
arithmetic: `block_hash` (via `determine_block_hash`), `block` (via
`substrate.get_block_number(block_hash=...)`), and `tempo` (via
`self.tempo(netuid=..., block_hash=...)`). The latter two only depend on
`block_hash`, not on each other, but were `await`'d sequentially. For the
common-case caller that supplies only `netuid`, this doubled the user-
perceived latency to roughly 2× substrate roundtrip per call.

Wrap the both-None branch in `asyncio.gather`. The partial-input branches
(only-block-missing or only-tempo-missing) keep the existing single-await
form so we don't introduce a wrapper around a single coroutine. Behaviour
for fully-supplied callers is unchanged — neither lookup runs.

This is a direct companion to the `get_balances` parallelisation in
PR #6 (same author, same branch family) and addresses the second bullet
of the issue: "apply `asyncio.gather` where this can improve
performance".

Closes #3129 (in part).

## Categorisation

- [x] Performance improvement — no API change.
- [ ] No behaviour change for fully-supplied callers.
- [ ] No new dependencies.

## Tests

- New `test_blocks_until_next_epoch_resolves_block_and_tempo_in_parallel`
  spies on `asyncio.gather` to assert it is called exactly once when both
  block and tempo are None, then verifies the result reflects the
  resolved values via the same arithmetic prod uses.
- New `test_blocks_until_next_epoch_only_block_missing_skips_gather` and
  `test_blocks_until_next_epoch_only_tempo_missing_skips_gather` cover
  the partial-input branches and assert `gather` is not called.
- Existing `test_blocks_until_next_epoch_uses_default_tempo` (both
  supplied → no awaits beyond `determine_block_hash`) continues to pass
  unchanged.

All 4 tests pass; ruff check + format clean.
```