### PR TITLE
fix(axon): narrow preprocess exception handling and chain causes

### DIFF
--- a/bittensor/core/axon.py
+++ b/bittensor/core/axon.py
@@ -15,6 +15,7 @@ from inspect import signature, Signature, Parameter
 from typing import Any, Awaitable, Callable, Optional, Tuple
 
 from async_substrate_interface.utils import json
+from pydantic import ValidationError
 import uvicorn
 from bittensor_wallet import Wallet, Keypair
 from fastapi import APIRouter, Depends, FastAPI
@@ -1233,13 +1234,17 @@ class AxonMiddleware(BaseHTTPMiddleware):
         This method sets the foundation for the subsequent steps in the request handling process,
         ensuring that all necessary information is encapsulated within the Synapse object.
         """
-        # Extracts the request name from the URL path.
+        # Extracts the request name from the URL path. `split("/")[1]` can
+        # only realistically fail with `IndexError` (empty path) or
+        # `AttributeError` (malformed/mocked request without a `url`); a bare
+        # `except Exception` here would swallow `MemoryError`, real bugs from
+        # `starlette`, etc., and relabel them as malformed-request errors.
         try:
             request_name = request.url.path.split("/")[1]
-        except Exception:
+        except (IndexError, AttributeError) as e:
             raise InvalidRequestNameError(
                 f"Improperly formatted request. Could not parser request {request.url.path}."
-            )
+            ) from e
 
         # Creates a synapse instance from the headers using the appropriate forward class type
         # based on the request name obtained from the URL path.
@@ -1249,12 +1254,17 @@ class AxonMiddleware(BaseHTTPMiddleware):
                 f"Synapse name '{request_name}' not found. Available synapses {list(self.axon.forward_class_types.keys())}"
             )
 
+        # `from_headers` constructs a pydantic model from header inputs; the
+        # realistic failure modes are `ValidationError` (field-level),
+        # `TypeError` (bad kwarg types), and `ValueError` (custom validators).
+        # Narrowing keeps unrelated infrastructure failures visible instead of
+        # relabeling them as malformed-request errors.
         try:
             synapse = request_synapse.from_headers(request.headers)  # type: ignore
-        except Exception:
+        except (ValidationError, TypeError, ValueError) as e:
             raise SynapseParsingError(
                 f"Improperly formatted request. Could not parse headers {request.headers} into synapse of type {request_name}."
-            )
+            ) from e
         synapse.name = request_name
 
         # Fills the local axon information into the synapse.

--- a/tests/unit_tests/test_axon.py
+++ b/tests/unit_tests/test_axon.py
@@ -507,6 +507,50 @@ class TestAxonMiddleware(IsolatedAsyncioTestCase):
         # Check if the preprocess function sets the request name correctly
         assert synapse.name == "request_name"
 
+    @pytest.mark.asyncio
+    async def test_preprocess_wraps_validation_error_with_cause(self):
+        # Regression: pydantic ValidationError from `from_headers` is wrapped
+        # as SynapseParsingError, but `__cause__` preserves the original so
+        # the field-level validation failure remains debuggable.
+        class ValidationFailingSynapse(Synapse):
+            @classmethod
+            def from_headers(cls, headers):
+                raise pydantic.ValidationError.from_exception_data(
+                    "Synapse", [{"type": "missing", "loc": ("name",), "input": {}}]
+                )
+
+        self.mock_axon.forward_class_types = {"vfail": ValidationFailingSynapse}
+
+        request = MagicMock(spec=Request)
+        request.url.path = "/vfail"
+        request.headers = {}
+
+        from bittensor.core.errors import SynapseParsingError
+
+        with pytest.raises(SynapseParsingError) as exc_info:
+            await self.axon_middleware.preprocess(request)
+
+        assert isinstance(exc_info.value.__cause__, pydantic.ValidationError)
+
+    @pytest.mark.asyncio
+    async def test_preprocess_does_not_swallow_unrelated_errors(self):
+        # Regression: `preprocess` no longer catches every `Exception` from
+        # `from_headers`. Unrelated infrastructure errors propagate unchanged
+        # instead of being relabeled as a malformed request.
+        class BoomSynapse(Synapse):
+            @classmethod
+            def from_headers(cls, headers):
+                raise RuntimeError("infra exploded")
+
+        self.mock_axon.forward_class_types = {"boom": BoomSynapse}
+
+        request = MagicMock(spec=Request)
+        request.url.path = "/boom"
+        request.headers = {}
+
+        with pytest.raises(RuntimeError, match="infra exploded"):
+            await self.axon_middleware.preprocess(request)
+
 
 class SynapseHTTPClient(TestClient):
     def post_synapse(self, synapse: Synapse):


### PR DESCRIPTION
## Summary

`AxonMiddleware.preprocess` previously wrapped any `Exception` from URL path parsing and `Synapse.from_headers` as `InvalidRequestNameError` / `SynapseParsingError`. This caused two problems:

1. **Unrelated infrastructure failures got mislabeled.** A `RuntimeError`, `MemoryError`, or a real bug in starlette/pydantic plugins would surface to the client as a misleading "improperly formatted request" — making the actual cause invisible.
2. **Original tracebacks were lost.** The bare `raise X(...)` (without `from e`) dropped the chained cause, so even when the wrapping was appropriate (e.g. pydantic validation), the underlying failure couldn't be inspected.

## Changes

- Narrow the path-parse catch to `(IndexError, AttributeError)` — the only failures `request.url.path.split(\"/\")[1]` can realistically produce.
- Narrow the synapse-parse catch to `(ValidationError, TypeError, ValueError)` — the realistic failure modes of pydantic model construction from header inputs. `parse_headers_to_inputs` already catches its own per-header decode errors internally, so what propagates is pydantic validation failures at the `cls(**input_dict)` step.
- `raise ... from e` on both paths so the original exception remains on `__cause__` for debugging.

## Tests

Two regression tests added to `TestAxonMiddleware`:
- `test_preprocess_wraps_validation_error_with_cause` — asserts `ValidationError` from `from_headers` becomes `SynapseParsingError` AND `__cause__` is preserved.
- `test_preprocess_does_not_swallow_unrelated_errors` — asserts an unrelated `RuntimeError` from `from_headers` propagates unchanged.

## Style match

Mirrors the exception-narrowing approach already accepted in #3318 (`fix(networking): catch real exceptions in get_external_ip fallback chain`).