### PR TITLE
Fix `--help` hijacking on import bittensor

### DIFF
--- a/bittensor/core/config.py
+++ b/bittensor/core/config.py
@@ -148,8 +148,9 @@ class Config(DefaultMunch):
 
         self.__is_set = {}
 
+        print(">>> no_parse_cli", no_parse_cli())
         # If CLI parsing disabled, stop here
-        if no_parse_cli or parser is None:
+        if no_parse_cli() or parser is None:
             return
 
         self._add_default_arguments(parser)

--- a/bittensor/core/config.py
+++ b/bittensor/core/config.py
@@ -21,8 +21,10 @@ import os
 import sys
 from copy import deepcopy
 from typing import Any, Optional
-from bittensor.core.settings import DEFAULTS
+
 import yaml
+
+from bittensor.core.settings import DEFAULTS, no_parse_cli
 
 
 class DefaultMunch(dict):
@@ -130,12 +132,6 @@ class Config(DefaultMunch):
         strict: bool = False,
         default: Any = DEFAULTS,
     ) -> None:
-        no_parse_cli = os.getenv("BT_NO_PARSE_CLI_ARGS", "").lower() in (
-            "1",
-            "true",
-            "yes",
-            "on",
-        )
 
         # Fallback to defaults if not provided
         default = deepcopy(default or DEFAULTS)

--- a/bittensor/core/config.py
+++ b/bittensor/core/config.py
@@ -148,7 +148,6 @@ class Config(DefaultMunch):
 
         self.__is_set = {}
 
-        print(">>> no_parse_cli", no_parse_cli())
         # If CLI parsing disabled, stop here
         if no_parse_cli() or parser is None:
             return

--- a/bittensor/core/settings.py
+++ b/bittensor/core/settings.py
@@ -166,3 +166,11 @@ version_as_int: int = sum(
     e * (_version_int_base**i) for i, e in enumerate(reversed(_version_info))
 )
 assert version_as_int < 2**31  # fits in int32
+
+# used for backwards compatibility in config.py and loggingmachine.py
+no_parse_cli = os.getenv("BT_NO_PARSE_CLI_ARGS", "true").lower() in (
+    "1",
+    "true",
+    "yes",
+    "on",
+)

--- a/bittensor/core/settings.py
+++ b/bittensor/core/settings.py
@@ -170,9 +170,9 @@ assert version_as_int < 2**31  # fits in int32
 
 # used for backwards compatibility in config.py and loggingmachine.py
 def no_parse_cli():
-    return os.getenv("BT_NO_PARSE_CLI_ARGS", "true").lower() in (
-        "1",
-        "true",
-        "yes",
-        "on",
+    return not os.getenv("BT_NO_PARSE_CLI_ARGS", "true").lower() in (
+        "0",
+        "false",
+        "no",
+        "off",
     )

--- a/bittensor/core/settings.py
+++ b/bittensor/core/settings.py
@@ -167,10 +167,12 @@ version_as_int: int = sum(
 )
 assert version_as_int < 2**31  # fits in int32
 
+
 # used for backwards compatibility in config.py and loggingmachine.py
-no_parse_cli = os.getenv("BT_NO_PARSE_CLI_ARGS", "true").lower() in (
-    "1",
-    "true",
-    "yes",
-    "on",
-)
+def no_parse_cli():
+    return os.getenv("BT_NO_PARSE_CLI_ARGS", "true").lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )

--- a/bittensor/utils/btlogging/loggingmachine.py
+++ b/bittensor/utils/btlogging/loggingmachine.py
@@ -686,7 +686,7 @@ class LoggingMachine(StateMachine, Logger):
         Return:
             Configuration object with settings from command-line arguments.
         """
-        if no_parse_cli:
+        if no_parse_cli():
             return Config()
         parser = argparse.ArgumentParser()
         cls.add_args(parser)

--- a/bittensor/utils/btlogging/loggingmachine.py
+++ b/bittensor/utils/btlogging/loggingmachine.py
@@ -17,7 +17,7 @@ from typing import NamedTuple, Union
 from statemachine import State, StateMachine
 
 from bittensor.core.config import Config
-from bittensor.core.settings import DEFAULTS
+from bittensor.core.settings import DEFAULTS, no_parse_cli
 from bittensor.utils.btlogging.console import BittensorConsole
 from .defines import (
     BITTENSOR_LOGGER_NAME,
@@ -686,6 +686,8 @@ class LoggingMachine(StateMachine, Logger):
         Return:
             Configuration object with settings from command-line arguments.
         """
+        if no_parse_cli:
+            return Config()
         parser = argparse.ArgumentParser()
         cls.add_args(parser)
         return Config(parser)

--- a/tests/e2e_tests/utils/e2e_test_utils.py
+++ b/tests/e2e_tests/utils/e2e_test_utils.py
@@ -196,6 +196,7 @@ class Templates:
         async def __aenter__(self):
             env = os.environ.copy()
             env["BT_LOGGING_DEBUG"] = "1"
+            env["BT_NO_PARSE_CLI_ARGS"] = "false"
             self.process = await asyncio.create_subprocess_exec(
                 sys.executable,
                 f"{self.dir}/validator.py",

--- a/tests/e2e_tests/utils/e2e_test_utils.py
+++ b/tests/e2e_tests/utils/e2e_test_utils.py
@@ -131,6 +131,7 @@ class Templates:
         async def __aenter__(self):
             env = os.environ.copy()
             env["BT_LOGGING_DEBUG"] = "1"
+            env["BT_NO_PARSE_CLI_ARGS"] = "false"
             self.process = await asyncio.create_subprocess_exec(
                 sys.executable,
                 f"{self.dir}/miner.py",

--- a/tests/integration_tests/test_config_does_not_process_cli_args.py
+++ b/tests/integration_tests/test_config_does_not_process_cli_args.py
@@ -1,8 +1,8 @@
 import argparse
 import sys
-
+import subprocess
 import pytest
-
+import os
 import bittensor as bt
 from bittensor.core.config import InvalidConfigFile
 
@@ -32,6 +32,7 @@ TEST_ARGS = [
 def test_bittensor_cli_parser_enabled(monkeypatch):
     """Tests that the bt cli args are processed."""
 
+    monkeypatch.setenv("BT_NO_PARSE_CLI_ARGS", "false")
     monkeypatch.setattr(sys, "argv", TEST_ARGS)
 
     with pytest.raises(InvalidConfigFile) as error:
@@ -42,7 +43,6 @@ def test_bittensor_cli_parser_enabled(monkeypatch):
 
 def test_bittensor_cli_parser_disabled(monkeypatch):
     """Tests that the bt cli args are not processed."""
-    monkeypatch.setenv("BT_NO_PARSE_CLI_ARGS", "true")
     monkeypatch.setattr(sys, "argv", TEST_ARGS)
 
     config = _config_call()
@@ -50,3 +50,23 @@ def test_bittensor_cli_parser_disabled(monkeypatch):
     assert config.config is False
     assert config.strict is False
     assert config.no_version_checking is False
+
+
+def test_import_does_not_hijack_help():
+    """Importing bittensor should not intercept --help."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import bittensor; import argparse; "
+            "p = argparse.ArgumentParser('user_script'); "
+            "p.add_argument('--my-arg', default=1); "
+            "p.parse_args()",
+            "--help",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "--my-arg" in result.stdout
+    assert "--logging" not in result.stdout

--- a/tests/integration_tests/test_config_does_not_process_cli_args.py
+++ b/tests/integration_tests/test_config_does_not_process_cli_args.py
@@ -2,7 +2,7 @@ import argparse
 import sys
 import subprocess
 import pytest
-import os
+
 import bittensor as bt
 from bittensor.core.config import InvalidConfigFile
 


### PR DESCRIPTION
## Short explanation:
`LoggingMachine.config()` parsed sys.argv at import time, intercepting `--help` before user scripts could handle it. 
Now defaults to not parsing CLI args. 
Old behavior available via `BT_NO_PARSE_CLI_ARGS=0`

## Long context:
**What:** `import bittensor` no longer reads your script's command-line arguments.

**Why:** Previously the SDK parsed `sys.argv` at import time, hijacking `--help`, breaking user argparse, and silently consuming arguments. Most subnet developers only discovered this when their script crashed.

**What changed:** The default for `BT_NO_PARSE_CLI_ARGS` is inverted. CLI parsing is now **off** by default.

**Who is affected:** Those passing SDK flags via command line (`python miner.py --logging.debug --subtensor.network finney`). Now you need:

```bash
BT_NO_PARSE_CLI_ARGS=false python miner.py --logging.debug
```

**Note:** you could use `false`, `no`, `0`, `off`

**Who is NOT affected:** Those configuring the SDK programmatically via `Config()`, constructors (`Subtensor(network="finney")`), or env vars (`BT_SUBTENSOR_NETWORK`).

@latent-to/docs please update the [existing doc](https://docs.learnbittensor.org/sdk/migration-guide#disabling-cli-argument-parsing) regarding these changes for the community. These changes could prove critical for some developers, and we need to cover them in detail. 


## Good example how we use it to keep the backward compatibility in e2e tests:
- https://github.com/latent-to/bittensor/pull/3347/changes#diff-7feb528a99753d3da7bb24fbfc1625ff4d8852b1ae5c6491c052b9741d7fa756R134
- https://github.com/latent-to/bittensor/pull/3347/changes#diff-7feb528a99753d3da7bb24fbfc1625ff4d8852b1ae5c6491c052b9741d7fa756R199