### PR TITLE
run do_take_checks at pool validation

### DIFF
--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -48,7 +48,11 @@ from bittensor.core.chain_data.utils import (
     decode_revealed_commitment_with_hotkey,
 )
 from bittensor.core.config import Config
-from bittensor.core.errors import ChainError, SubstrateRequestException
+from bittensor.core.errors import (
+    ChainError,
+    SubstrateRequestException,
+    chain_error_from_substrate_exception,
+)
 from bittensor.core.extrinsics.asyncex.children import (
     root_set_pending_childkey_cooldown_extrinsic,
     set_children_extrinsic,
@@ -6145,8 +6149,11 @@ class AsyncSubtensor(SubtensorMixin):
             return extrinsic_response
 
         except SubstrateRequestException as error:
+            typed = chain_error_from_substrate_exception(error)
+            if typed is not None:
+                error = typed
             if raise_error:
-                raise
+                raise error from None
 
             extrinsic_response.success = False
             extrinsic_response.message = format_error_message(error)

--- a/bittensor/core/errors.py
+++ b/bittensor/core/errors.py
@@ -1,3 +1,4 @@
+import ast
 from typing import Optional, TYPE_CHECKING
 
 from async_substrate_interface.errors import (
@@ -58,6 +59,7 @@ __all__ = [
     "UnknownSynapseError",
     "UnstakeError",
     "SHIELD_VALIDATION_ERRORS",
+    "chain_error_from_substrate_exception",
     "map_shield_error",
 ]
 
@@ -276,6 +278,57 @@ SHIELD_VALIDATION_ERRORS = {
         "The key may have rotated between reading NextKey and submitting the transaction."
     ),
 }
+
+
+_CUSTOM_ERROR_CODE_TO_EXCEPTION: dict[int, type["ChainError"]] = {
+    3: SubnetNotExists,
+    4: HotKeyAccountNotExists,
+    6: TxRateLimitExceeded,
+    25: NonAssociatedColdKey,
+}
+
+
+def _extract_custom_error_code(error: Exception) -> Optional[int]:
+    """Walk a SubstrateRequestException's args looking for a transaction-pool
+    validity error like ``{'error': {'code': 1010, ..., 'data': 'Custom error: N'}}``
+    and return ``N``. Returns ``None`` if the shape doesn't match."""
+    for arg in getattr(error, "args", ()):
+        parsed = arg
+        if isinstance(parsed, str):
+            try:
+                parsed = ast.literal_eval(parsed)
+            except (ValueError, SyntaxError, MemoryError, RecursionError, TypeError):
+                continue
+        if not isinstance(parsed, dict):
+            continue
+        inner = parsed.get("error", parsed)
+        if not isinstance(inner, dict):
+            continue
+        data = inner.get("data")
+        if isinstance(data, str) and data.startswith("Custom error:"):
+            try:
+                return int(data.split(":", 1)[1].strip())
+            except ValueError:
+                continue
+    return None
+
+
+def chain_error_from_substrate_exception(
+    error: SubstrateRequestException,
+) -> Optional["ChainError"]:
+    """Translate a transaction-pool validation error into a typed
+    :class:`ChainError`. Returns ``None`` when the exception doesn't carry a
+    recognised ``Custom error: N`` code from subtensor's
+    ``CustomTransactionError`` enum, so callers can keep the original."""
+    if isinstance(error, ChainError):
+        return None
+    code = _extract_custom_error_code(error)
+    if code is None:
+        return None
+    exc_cls = _CUSTOM_ERROR_CODE_TO_EXCEPTION.get(code)
+    if exc_cls is None:
+        return None
+    return exc_cls(*error.args)
 
 
 def map_shield_error(raw_message: str) -> str:

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -48,7 +48,7 @@ from bittensor.core.chain_data.utils import (
     decode_revealed_commitment_with_hotkey,
 )
 from bittensor.core.config import Config
-from bittensor.core.errors import ChainError
+from bittensor.core.errors import ChainError, chain_error_from_substrate_exception
 from bittensor.core.extrinsics.children import (
     root_set_pending_childkey_cooldown_extrinsic,
     set_children_extrinsic,
@@ -5012,8 +5012,11 @@ class Subtensor(SubtensorMixin):
             return extrinsic_response
 
         except SubstrateRequestException as error:
+            typed = chain_error_from_substrate_exception(error)
+            if typed is not None:
+                error = typed
             if raise_error:
-                raise
+                raise error from None
 
             extrinsic_response.success = False
             extrinsic_response.message = format_error_message(error)

--- a/tests/unit_tests/test_errors.py
+++ b/tests/unit_tests/test_errors.py
@@ -1,6 +1,12 @@
+from async_substrate_interface.errors import SubstrateRequestException
+
 from bittensor.core.errors import (
     ChainError,
     HotKeyAccountNotExists,
+    NonAssociatedColdKey,
+    SubnetNotExists,
+    TxRateLimitExceeded,
+    chain_error_from_substrate_exception,
     map_shield_error,
 )
 
@@ -74,3 +80,45 @@ class TestMapShieldError:
         msg = "Something completely unrelated went wrong"
         result = map_shield_error(msg)
         assert result == msg
+
+
+def _validity_error(code: int) -> SubstrateRequestException:
+    payload = {
+        "jsonrpc": "2.0",
+        "id": "Xc18",
+        "error": {
+            "code": 1010,
+            "message": "Invalid Transaction",
+            "data": f"Custom error: {code}",
+        },
+    }
+    return SubstrateRequestException(str(payload))
+
+
+class TestChainErrorFromSubstrateException:
+    def test_maps_hotkey_account_not_exists(self):
+        exc = chain_error_from_substrate_exception(_validity_error(4))
+        assert isinstance(exc, HotKeyAccountNotExists)
+
+    def test_maps_non_associated_coldkey(self):
+        exc = chain_error_from_substrate_exception(_validity_error(25))
+        assert isinstance(exc, NonAssociatedColdKey)
+
+    def test_maps_rate_limit_exceeded(self):
+        exc = chain_error_from_substrate_exception(_validity_error(6))
+        assert isinstance(exc, TxRateLimitExceeded)
+
+    def test_maps_subnet_not_exists(self):
+        exc = chain_error_from_substrate_exception(_validity_error(3))
+        assert isinstance(exc, SubnetNotExists)
+
+    def test_unmapped_code_returns_none(self):
+        assert chain_error_from_substrate_exception(_validity_error(255)) is None
+
+    def test_non_validity_error_returns_none(self):
+        err = SubstrateRequestException("not a validity error")
+        assert chain_error_from_substrate_exception(err) is None
+
+    def test_already_typed_returns_none(self):
+        err = HotKeyAccountNotExists("already typed")
+        assert chain_error_from_substrate_exception(err) is None


### PR DESCRIPTION
This fixes one of the two tests in https://github.com/opentensor/subtensor/pull/2569

`increase_take`/`decrease_take` now run `do_take_checks` at pool validation (lines 305-309). Failures are returned as `Invalid Transaction { code: 1010, data: "Custom error: N"}` (mapped via result_to_validity), they never enter a block. Our existing error path only translated dispatch errors (which carry a name field), not pool-rejection custom-code errors, so callers saw a raw `SubstrateRequestException` instead of the typed `HotKeyAccountNotExists` / `NonAssociatedColdKey` they used to get. 