### PR TITLE
Test Fixes

### DIFF
--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -6149,6 +6149,10 @@ class AsyncSubtensor(SubtensorMixin):
             return extrinsic_response
 
         except SubstrateRequestException as error:
+            # The extrinsic was rejected before inclusion (pool validation, dropped,
+            # invalid, etc.), so the nonce was not consumed on-chain. Clear the cached
+            # next-index so the next call refetches the true on-chain value.
+            self.substrate.clear_nonce_cache_for_account(signing_keypair.ss58_address)
             typed = chain_error_from_substrate_exception(error)
             if typed is not None:
                 error = typed

--- a/tests/e2e_tests/test_commit_weights.py
+++ b/tests/e2e_tests/test_commit_weights.py
@@ -245,6 +245,11 @@ async def test_commit_and_reveal_weights_legacy_async(async_subtensor, alice_wal
         > 0
     ), "Invalid RevealPeriodEpochs"
 
+    # Wait until the reveal block range
+    await async_subtensor.wait_for_block(
+        await async_subtensor.subnets.get_next_epoch_start_block(alice_sn.netuid) + 1
+    )
+
     # Reveal weights
     success, message = await async_subtensor.extrinsics.reveal_weights(
         wallet=alice_wallet,


### PR DESCRIPTION
- async commit weights now waits for block
- clears the nonce cache on extrinsic submission failure

Fixes failing tests in https://github.com/opentensor/subtensor/pull/2569