### PR TITLE
PR guard workflow

### DIFF
--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -19,6 +19,6 @@ jobs:
         id: changed
       - name: Ensure CHANGELOG.md updated
         if: contains(steps.changed.outputs.all_changed_files, 'CHANGELOG.md') == false
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: core.setFailed('CHANGELOG.md must be updated.')

--- a/.github/workflows/monitor_requirements_size_master.yml
+++ b/.github/workflows/monitor_requirements_size_master.yml
@@ -77,7 +77,7 @@ jobs:
           pattern: size-*
 
       - name: Post venv size summary to PR
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -1,0 +1,56 @@
+name: PR guard
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  target-branch:
+    if: github.base_ref == 'master' && !startsWith(github.head_ref, 'release')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment and fail when targeting master from a non-release branch
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: 'PRs need to be open against staging.',
+            });
+            core.setFailed('PRs need to be open against the 'staging' branch.');
+
+  signed-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check that all commits in the PR are signed
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const commits = await github.paginate(
+              github.rest.pulls.listCommits,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+                per_page: 100,
+              }
+            );
+
+            const unsigned = commits.filter(c => !c.commit.verification || !c.commit.verification.verified);
+
+            if (unsigned.length > 0) {
+              const list = unsigned.map(c => `- ${c.sha.substring(0, 7)} ${c.commit.message.split('\n')[0]}`).join('\n');
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: `PRs must use signed commits.\n\nUnsigned commits:\n${list}`,
+              });
+              core.setFailed("PRs must use signed commits.");
+            }


### PR DESCRIPTION
Adds a workflow that prevents accidentally opening against master or having a PR with unsigned commits.

Also bumps the github-script to v9 of the other workflows which use it