### PR TITLE
Support `Conviction v2`

### DIFF
--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -5482,7 +5482,8 @@ class AsyncSubtensor(SubtensorMixin):
         Checks whether a coldkey's lock on a subnet is perpetual (non-decaying).
 
         Locks decay by default. A lock becomes perpetual only when the coldkey explicitly opts in via
-        set_perpetual_lock(enabled=True), which inserts a DecayingLock entry.
+        set_perpetual_lock(enabled=True), which inserts a ``DecayingLock`` entry with value ``false``. When the entry is
+        absent, the lock decays normally.
 
         Parameters:
             coldkey_ss58: The SS58 address of the coldkey to check.
@@ -5492,7 +5493,7 @@ class AsyncSubtensor(SubtensorMixin):
             reuse_block: Whether to reuse the last-used block hash.
 
         Returns:
-            True if the lock is perpetual (does not decay), False if it decays.
+            True if the lock is perpetual (does not decay), False if it decays or no lock exists.
         """
         query = await self.query_subtensor(
             name="DecayingLock",
@@ -5501,7 +5502,7 @@ class AsyncSubtensor(SubtensorMixin):
             block_hash=block_hash,
             reuse_block=reuse_block,
         )
-        return query.value is not None
+        return query.value is False
 
     async def is_subnet_active(
         self,

--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -81,6 +81,11 @@ from bittensor.core.extrinsics.asyncex.liquidity import (
     toggle_user_liquidity_extrinsic,
 )
 from bittensor.core.extrinsics.asyncex.mev_shield import submit_encrypted_extrinsic
+from bittensor.core.extrinsics.asyncex.lock import (
+    lock_stake_extrinsic,
+    move_lock_extrinsic,
+    set_perpetual_lock_extrinsic,
+)
 from bittensor.core.extrinsics.asyncex.move_stake import (
     move_stake_extrinsic,
     swap_stake_extrinsic,
@@ -147,6 +152,7 @@ from bittensor.core.settings import (
 from bittensor.core.types import (
     BlockInfo,
     ExtrinsicResponse,
+    LockState,
     Salt,
     SubtensorMixin,
     UIDs,
@@ -1940,6 +1946,47 @@ class AsyncSubtensor(SubtensorMixin):
             cooldown,
         )
 
+    async def get_coldkey_lock(
+        self,
+        coldkey_ss58: str,
+        netuid: int,
+        block: Optional[int] = None,
+        block_hash: Optional[str] = None,
+        reuse_block: bool = False,
+    ) -> Optional["LockState"]:
+        """
+        Returns the current lock for a coldkey on a subnet, rolled forward to the current block.
+
+        Unlike get_stake_lock which returns the raw stored state, this method applies decay to return the actual current
+        lock values accounting for time elapsed since last update.
+
+        Parameters:
+            coldkey_ss58: The SS58 address of the coldkey.
+            netuid: The subnet UID to query.
+            block: The block number to query. Do not specify if using block_hash or reuse_block.
+            block_hash: The block hash at which to query.
+            reuse_block: Whether to reuse the last-used block hash.
+
+        Returns:
+            LockState with current locked_mass, conviction, and last_update, or None if no lock exists.
+        """
+        result = await self.query_runtime_api(
+            runtime_api="StakeInfoRuntimeApi",
+            method="get_coldkey_lock",
+            params=[coldkey_ss58, netuid],
+            block=block,
+            block_hash=block_hash,
+            reuse_block=reuse_block,
+        )
+        if result is None:
+            return None
+
+        return LockState(
+            locked_mass=Balance.from_rao(result["locked_mass"], netuid),
+            conviction=fixed_to_float(result["conviction"]),
+            last_update=int(result["last_update"]),
+        )
+
     async def get_coldkey_swap_announcement(
         self,
         coldkey_ss58: str,
@@ -2781,6 +2828,39 @@ class AsyncSubtensor(SubtensorMixin):
         # TODO verify this from rao, seems like we're just rounding down
         return block_updated, Balance.from_rao(ema_value)
 
+    async def get_hotkey_conviction(
+        self,
+        hotkey_ss58: str,
+        netuid: int,
+        block: Optional[int] = None,
+        block_hash: Optional[str] = None,
+        reuse_block: bool = False,
+    ) -> float:
+        """
+        Gets the total conviction score for a hotkey on a subnet.
+
+        Parameters:
+            hotkey_ss58: The SS58 address of the hotkey to query.
+            netuid: The subnet UID to query.
+            block: The block number to query. Do not specify if using block_hash or reuse_block.
+            block_hash: The block hash at which to query.
+            reuse_block: Whether to reuse the last-used block hash.
+
+        Returns:
+            The conviction score as a float.
+        """
+        result = await self.query_runtime_api(
+            runtime_api="StakeInfoRuntimeApi",
+            method="get_hotkey_conviction",
+            params=[hotkey_ss58, netuid],
+            block=block,
+            block_hash=block_hash,
+            reuse_block=reuse_block,
+        )
+        if result is None:
+            return 0.0
+        return fixed_to_float(result)
+
     async def get_hotkey_owner(
         self,
         hotkey_ss58: str,
@@ -3358,6 +3438,34 @@ class AsyncSubtensor(SubtensorMixin):
         )
 
         return Balance.from_rao(result.value or 0)
+
+    async def get_most_convicted_hotkey_on_subnet(
+        self,
+        netuid: int,
+        block: Optional[int] = None,
+        block_hash: Optional[str] = None,
+        reuse_block: bool = False,
+    ) -> Optional[str]:
+        """
+        Gets the hotkey with the highest conviction score on a subnet (the "subnet king").
+
+        Parameters:
+            netuid: The subnet UID to query.
+            block: The block number to query. Do not specify if using block_hash or reuse_block.
+            block_hash: The block hash at which to query.
+            reuse_block: Whether to reuse the last-used block hash.
+
+        Returns:
+            The SS58 address of the most convicted hotkey, or None if no locks exist.
+        """
+        return await self.query_runtime_api(
+            runtime_api="StakeInfoRuntimeApi",
+            method="get_most_convicted_hotkey_on_subnet",
+            params=[netuid],
+            block=block,
+            block_hash=block_hash,
+            reuse_block=reuse_block,
+        )
 
     async def get_netuids_for_hotkey(
         self,
@@ -4193,6 +4301,88 @@ class AsyncSubtensor(SubtensorMixin):
             block_hash=block_hash,
         )
         return sim_swap_result.tao_fee
+
+    async def get_stake_lock(
+        self,
+        coldkey_ss58: str,
+        netuid: int,
+        hotkey_ss58: str,
+        block: Optional[int] = None,
+        block_hash: Optional[str] = None,
+        reuse_block: bool = False,
+    ) -> Optional["LockState"]:
+        """
+        Retrieves the lock state for a specific coldkey-netuid-hotkey combination.
+
+        Parameters:
+            coldkey_ss58: The SS58 address of the coldkey that owns the lock.
+            netuid: The subnet UID on which to query.
+            hotkey_ss58: The SS58 address of the hotkey the lock is on.
+            block: The block number to query. Do not specify if using block_hash or reuse_block.
+            block_hash: The block hash at which to query.
+            reuse_block: Whether to reuse the last-used block hash.
+
+        Returns:
+            LockState dict with locked_mass, conviction, last_update, or None if no lock exists.
+        """
+        query = await self.query_subtensor(
+            "Lock",
+            params=[coldkey_ss58, netuid, hotkey_ss58],
+            block=block,
+            block_hash=block_hash,
+            reuse_block=reuse_block,
+        )
+        if query.value is None:
+            return None
+
+        value = cast(dict, query.value)
+        return LockState(
+            locked_mass=Balance.from_rao(value["locked_mass"], netuid),
+            conviction=fixed_to_float(value["conviction"]),
+            last_update=int(value["last_update"]),
+        )
+
+    async def get_stake_locks(
+        self,
+        coldkey_ss58: str,
+        netuid: int,
+        block: Optional[int] = None,
+        block_hash: Optional[str] = None,
+        reuse_block: bool = False,
+    ) -> "list[tuple[str, LockState]]":
+        """
+        Retrieves all lock states for a coldkey on a subnet.
+
+        Parameters:
+            coldkey_ss58: The SS58 address of the coldkey that owns the locks.
+            netuid: The subnet UID on which to query.
+            block: The block number to query. Do not specify if using block_hash or reuse_block.
+            block_hash: The block hash at which to query.
+            reuse_block: Whether to reuse the last-used block hash.
+
+        Returns:
+            List of (hotkey_ss58, LockState) tuples.
+        """
+        query_map = await self.query_map_subtensor(
+            "Lock",
+            params=[coldkey_ss58, netuid],
+            block=block,
+            block_hash=block_hash,
+            reuse_block=reuse_block,
+        )
+        locks = []
+        async for hotkey, lock_state in query_map:
+            locks.append(
+                (
+                    hotkey,
+                    LockState(
+                        locked_mass=Balance.from_rao(lock_state["locked_mass"], netuid),
+                        conviction=fixed_to_float(lock_state["conviction"]),
+                        last_update=int(lock_state["last_update"]),
+                    ),
+                )
+            )
+        return locks
 
     async def get_stake_movement_fee(
         self,
@@ -5279,6 +5469,39 @@ class AsyncSubtensor(SubtensorMixin):
             )
             is not None
         )
+
+    async def is_perpetual_lock(
+        self,
+        coldkey_ss58: str,
+        netuid: int,
+        block: Optional[int] = None,
+        block_hash: Optional[str] = None,
+        reuse_block: bool = False,
+    ) -> bool:
+        """
+        Checks whether a coldkey's lock on a subnet is perpetual (non-decaying).
+
+        Locks decay by default. A lock becomes perpetual only when the coldkey explicitly opts in via
+        set_perpetual_lock(enabled=True), which inserts a DecayingLock entry.
+
+        Parameters:
+            coldkey_ss58: The SS58 address of the coldkey to check.
+            netuid: The subnet UID to check.
+            block: The block number to query. Do not specify if using block_hash or reuse_block.
+            block_hash: The block hash at which to query.
+            reuse_block: Whether to reuse the last-used block hash.
+
+        Returns:
+            True if the lock is perpetual (does not decay), False if it decays.
+        """
+        query = await self.query_subtensor(
+            name="DecayingLock",
+            params=[coldkey_ss58, netuid],
+            block=block,
+            block_hash=block_hash,
+            reuse_block=reuse_block,
+        )
+        return query.value is not None
 
     async def is_subnet_active(
         self,
@@ -7332,6 +7555,53 @@ class AsyncSubtensor(SubtensorMixin):
             wait_for_revealed_execution=wait_for_revealed_execution,
         )
 
+    async def lock_stake(
+        self,
+        wallet: "Wallet",
+        hotkey_ss58: str,
+        netuid: int,
+        amount: Balance,
+        *,
+        mev_protection: bool = DEFAULT_MEV_PROTECTION,
+        period: Optional[int] = DEFAULT_PERIOD,
+        raise_error: bool = False,
+        wait_for_inclusion: bool = True,
+        wait_for_finalization: bool = True,
+        wait_for_revealed_execution: bool = True,
+    ) -> ExtrinsicResponse:
+        """
+        Locks alpha stake on a hotkey within a subnet, building conviction over time.
+
+        Parameters:
+            wallet: The wallet whose coldkey owns the stake to lock.
+            hotkey_ss58: The SS58 address of the hotkey to lock stake on.
+            netuid: The subnet UID on which to lock.
+            amount: Amount of alpha to lock as a Balance object.
+            mev_protection: If `True`, encrypts and submits the transaction through MEV Shield.
+            period: The number of blocks during which the transaction will remain valid after it's submitted.
+            raise_error: Raises exception rather than returning failure response.
+            wait_for_inclusion: Waits for the transaction to be included in a block.
+            wait_for_finalization: Waits for the transaction to be finalized on the blockchain.
+            wait_for_revealed_execution: Whether to wait for the revealed execution of transaction if mev_protection used.
+
+        Returns:
+            ExtrinsicResponse: The result object of the extrinsic execution.
+        """
+        check_balance_amount(amount)
+        return await lock_stake_extrinsic(
+            subtensor=self,
+            wallet=wallet,
+            hotkey_ss58=hotkey_ss58,
+            netuid=netuid,
+            amount=amount,
+            mev_protection=mev_protection,
+            period=period,
+            raise_error=raise_error,
+            wait_for_inclusion=wait_for_inclusion,
+            wait_for_finalization=wait_for_finalization,
+            wait_for_revealed_execution=wait_for_revealed_execution,
+        )
+
     async def mev_submit_encrypted(
         self,
         wallet: "Wallet",
@@ -7473,6 +7743,49 @@ class AsyncSubtensor(SubtensorMixin):
             position_id=position_id,
             liquidity_delta=liquidity_delta,
             hotkey_ss58=hotkey_ss58,
+            mev_protection=mev_protection,
+            period=period,
+            raise_error=raise_error,
+            wait_for_inclusion=wait_for_inclusion,
+            wait_for_finalization=wait_for_finalization,
+            wait_for_revealed_execution=wait_for_revealed_execution,
+        )
+
+    async def move_lock(
+        self,
+        wallet: "Wallet",
+        destination_hotkey_ss58: str,
+        netuid: int,
+        *,
+        mev_protection: bool = DEFAULT_MEV_PROTECTION,
+        period: Optional[int] = DEFAULT_PERIOD,
+        raise_error: bool = False,
+        wait_for_inclusion: bool = True,
+        wait_for_finalization: bool = True,
+        wait_for_revealed_execution: bool = True,
+    ) -> ExtrinsicResponse:
+        """
+        Moves an existing lock from its current hotkey to a different hotkey on the same subnet.
+
+        Parameters:
+            wallet: The wallet whose coldkey owns the lock.
+            destination_hotkey_ss58: The SS58 address of the hotkey to move the lock to.
+            netuid: The subnet UID on which the lock exists.
+            mev_protection: If `True`, encrypts and submits the transaction through MEV Shield.
+            period: The number of blocks during which the transaction will remain valid after it's submitted.
+            raise_error: Raises exception rather than returning failure response.
+            wait_for_inclusion: Waits for the transaction to be included in a block.
+            wait_for_finalization: Waits for the transaction to be finalized on the blockchain.
+            wait_for_revealed_execution: Whether to wait for the revealed execution of transaction if mev_protection used.
+
+        Returns:
+            ExtrinsicResponse: The result object of the extrinsic execution.
+        """
+        return await move_lock_extrinsic(
+            subtensor=self,
+            wallet=wallet,
+            destination_hotkey_ss58=destination_hotkey_ss58,
+            netuid=netuid,
             mev_protection=mev_protection,
             period=period,
             raise_error=raise_error,
@@ -8601,6 +8914,45 @@ class AsyncSubtensor(SubtensorMixin):
 
         logging.error(f"[red]{response.message}[/red]")
         return response
+
+    async def set_perpetual_lock(
+        self,
+        wallet: "Wallet",
+        netuid: int,
+        enabled: bool,
+        *,
+        period: Optional[int] = DEFAULT_PERIOD,
+        raise_error: bool = False,
+        wait_for_inclusion: bool = True,
+        wait_for_finalization: bool = True,
+    ) -> ExtrinsicResponse:
+        """
+        Sets or clears the perpetual lock flag for the caller's lock on a subnet.
+
+        When enabled, the lock does not decay over time. When disabled, normal decay resumes.
+
+        Parameters:
+            wallet: The wallet whose coldkey owns the lock.
+            netuid: The subnet UID for which to set the perpetual lock flag.
+            enabled: If True, the lock will not decay. If False, normal decay resumes.
+            period: The number of blocks during which the transaction will remain valid after it's submitted.
+            raise_error: Raises exception rather than returning failure response.
+            wait_for_inclusion: Waits for the transaction to be included in a block.
+            wait_for_finalization: Waits for the transaction to be finalized on the blockchain.
+
+        Returns:
+            ExtrinsicResponse: The result object of the extrinsic execution.
+        """
+        return await set_perpetual_lock_extrinsic(
+            subtensor=self,
+            wallet=wallet,
+            netuid=netuid,
+            enabled=enabled,
+            period=period,
+            raise_error=raise_error,
+            wait_for_inclusion=wait_for_inclusion,
+            wait_for_finalization=wait_for_finalization,
+        )
 
     async def set_root_claim_type(
         self,

--- a/bittensor/core/extrinsics/asyncex/lock.py
+++ b/bittensor/core/extrinsics/asyncex/lock.py
@@ -1,0 +1,238 @@
+from typing import Optional, TYPE_CHECKING
+
+from bittensor.core.extrinsics.asyncex.mev_shield import submit_encrypted_extrinsic
+from bittensor.core.extrinsics.pallets import SubtensorModule
+from bittensor.core.settings import DEFAULT_MEV_PROTECTION
+from bittensor.core.types import ExtrinsicResponse
+from bittensor.utils.balance import Balance
+from bittensor.utils.btlogging import logging
+
+if TYPE_CHECKING:
+    from bittensor_wallet import Wallet
+    from bittensor.core.async_subtensor import AsyncSubtensor
+
+
+async def lock_stake_extrinsic(
+    subtensor: "AsyncSubtensor",
+    wallet: "Wallet",
+    hotkey_ss58: str,
+    netuid: int,
+    amount: Balance,
+    *,
+    mev_protection: bool = DEFAULT_MEV_PROTECTION,
+    period: Optional[int] = None,
+    raise_error: bool = False,
+    wait_for_inclusion: bool = True,
+    wait_for_finalization: bool = True,
+    wait_for_revealed_execution: bool = True,
+) -> ExtrinsicResponse:
+    """
+    Locks alpha stake on a hotkey within a subnet, building conviction over time.
+
+    Parameters:
+        subtensor: AsyncSubtensor instance.
+        wallet: The wallet whose coldkey owns the stake to lock.
+        hotkey_ss58: The SS58 address of the hotkey to lock stake on.
+        netuid: The subnet UID on which to lock.
+        amount: Amount of alpha to lock.
+        mev_protection: If True, encrypts and submits the transaction through MEV Shield.
+        period: Number of blocks during which the transaction remains valid.
+        raise_error: Raises exception rather than returning failure response.
+        wait_for_inclusion: Whether to wait for inclusion in a block.
+        wait_for_finalization: Whether to wait for finalization.
+        wait_for_revealed_execution: Whether to wait for revealed execution if mev_protection used.
+
+    Returns:
+        ExtrinsicResponse: The result object of the extrinsic execution.
+    """
+    try:
+        if not (
+            unlocked := ExtrinsicResponse.unlock_wallet(wallet, raise_error)
+        ).success:
+            return unlocked
+
+        logging.debug(
+            f"Locking stake on hotkey [blue]{hotkey_ss58}[/blue] "
+            f"on subnet [yellow]{netuid}[/yellow], amount: [green]{amount}[/green]"
+        )
+
+        call = await SubtensorModule(subtensor).lock_stake(
+            hotkey=hotkey_ss58,
+            netuid=netuid,
+            amount=amount.rao,
+        )
+
+        if mev_protection:
+            response = await submit_encrypted_extrinsic(
+                subtensor=subtensor,
+                wallet=wallet,
+                call=call,
+                period=period,
+                raise_error=raise_error,
+                wait_for_inclusion=wait_for_inclusion,
+                wait_for_finalization=wait_for_finalization,
+                wait_for_revealed_execution=wait_for_revealed_execution,
+            )
+        else:
+            response = await subtensor.sign_and_send_extrinsic(
+                call=call,
+                wallet=wallet,
+                wait_for_inclusion=wait_for_inclusion,
+                wait_for_finalization=wait_for_finalization,
+                period=period,
+                raise_error=raise_error,
+            )
+
+        if response.success:
+            logging.debug("[green]Lock stake finalized[/green]")
+        else:
+            logging.error(f"[red]{response.message}[/red]")
+
+        return response
+
+    except Exception as error:
+        return ExtrinsicResponse.from_exception(raise_error=raise_error, error=error)
+
+
+async def move_lock_extrinsic(
+    subtensor: "AsyncSubtensor",
+    wallet: "Wallet",
+    destination_hotkey_ss58: str,
+    netuid: int,
+    *,
+    mev_protection: bool = DEFAULT_MEV_PROTECTION,
+    period: Optional[int] = None,
+    raise_error: bool = False,
+    wait_for_inclusion: bool = True,
+    wait_for_finalization: bool = True,
+    wait_for_revealed_execution: bool = True,
+) -> ExtrinsicResponse:
+    """
+    Moves an existing lock from its current hotkey to a different hotkey on the same subnet.
+
+    Parameters:
+        subtensor: AsyncSubtensor instance.
+        wallet: The wallet whose coldkey owns the lock.
+        destination_hotkey_ss58: The SS58 address of the hotkey to move the lock to.
+        netuid: The subnet UID on which the lock exists.
+        mev_protection: If True, encrypts and submits the transaction through MEV Shield.
+        period: Number of blocks during which the transaction remains valid.
+        raise_error: Raises exception rather than returning failure response.
+        wait_for_inclusion: Whether to wait for inclusion in a block.
+        wait_for_finalization: Whether to wait for finalization.
+        wait_for_revealed_execution: Whether to wait for revealed execution if mev_protection used.
+
+    Returns:
+        ExtrinsicResponse: The result object of the extrinsic execution.
+    """
+    try:
+        if not (
+            unlocked := ExtrinsicResponse.unlock_wallet(wallet, raise_error)
+        ).success:
+            return unlocked
+
+        logging.debug(
+            f"Moving lock to hotkey [blue]{destination_hotkey_ss58}[/blue] "
+            f"on subnet [yellow]{netuid}[/yellow]"
+        )
+
+        call = await SubtensorModule(subtensor).move_lock(
+            destination_hotkey=destination_hotkey_ss58,
+            netuid=netuid,
+        )
+
+        if mev_protection:
+            response = await submit_encrypted_extrinsic(
+                subtensor=subtensor,
+                wallet=wallet,
+                call=call,
+                period=period,
+                raise_error=raise_error,
+                wait_for_inclusion=wait_for_inclusion,
+                wait_for_finalization=wait_for_finalization,
+                wait_for_revealed_execution=wait_for_revealed_execution,
+            )
+        else:
+            response = await subtensor.sign_and_send_extrinsic(
+                call=call,
+                wallet=wallet,
+                wait_for_inclusion=wait_for_inclusion,
+                wait_for_finalization=wait_for_finalization,
+                period=period,
+                raise_error=raise_error,
+            )
+
+        if response.success:
+            logging.debug("[green]Move lock finalized[/green]")
+        else:
+            logging.error(f"[red]{response.message}[/red]")
+
+        return response
+
+    except Exception as error:
+        return ExtrinsicResponse.from_exception(raise_error=raise_error, error=error)
+
+
+async def set_perpetual_lock_extrinsic(
+    subtensor: "AsyncSubtensor",
+    wallet: "Wallet",
+    netuid: int,
+    enabled: bool,
+    *,
+    period: Optional[int] = None,
+    raise_error: bool = False,
+    wait_for_inclusion: bool = True,
+    wait_for_finalization: bool = True,
+) -> ExtrinsicResponse:
+    """
+    Sets or clears the perpetual lock flag for the caller's lock on a subnet.
+
+    When enabled, the lock does not decay over time. When disabled, normal decay resumes.
+
+    Parameters:
+        subtensor: AsyncSubtensor instance.
+        wallet: The wallet whose coldkey owns the lock.
+        netuid: The subnet UID for which to set the perpetual lock flag.
+        enabled: If True, the lock will not decay. If False, normal decay resumes.
+        period: Number of blocks during which the transaction remains valid.
+        raise_error: Raises exception rather than returning failure response.
+        wait_for_inclusion: Whether to wait for inclusion in a block.
+        wait_for_finalization: Whether to wait for finalization.
+
+    Returns:
+        ExtrinsicResponse: The result object of the extrinsic execution.
+    """
+    try:
+        if not (
+            unlocked := ExtrinsicResponse.unlock_wallet(wallet, raise_error)
+        ).success:
+            return unlocked
+
+        logging.debug(
+            f"Setting perpetual lock to [green]{enabled}[/green] "
+            f"on subnet [yellow]{netuid}[/yellow]"
+        )
+
+        call = await SubtensorModule(subtensor).set_perpetual_lock(
+            netuid=netuid,
+            enabled=enabled,
+        )
+
+        response = await subtensor.sign_and_send_extrinsic(
+            call=call,
+            wallet=wallet,
+            wait_for_inclusion=wait_for_inclusion,
+            wait_for_finalization=wait_for_finalization,
+            period=period,
+            raise_error=raise_error,
+        )
+
+        if response.success:
+            logging.debug("[green]Set perpetual lock finalized[/green]")
+        else:
+            logging.error(f"[red]{response.message}[/red]")
+
+        return response
+
+    except Exception as error:
+        return ExtrinsicResponse.from_exception(raise_error=raise_error, error=error)

--- a/bittensor/core/extrinsics/lock.py
+++ b/bittensor/core/extrinsics/lock.py
@@ -1,0 +1,239 @@
+from typing import Optional, TYPE_CHECKING
+
+from bittensor.core.extrinsics.mev_shield import submit_encrypted_extrinsic
+from bittensor.core.extrinsics.pallets import SubtensorModule
+from bittensor.core.settings import DEFAULT_MEV_PROTECTION
+from bittensor.core.types import ExtrinsicResponse
+from bittensor.utils.balance import Balance
+from bittensor.utils.btlogging import logging
+
+
+if TYPE_CHECKING:
+    from bittensor_wallet import Wallet
+    from bittensor.core.subtensor import Subtensor
+
+
+def lock_stake_extrinsic(
+    subtensor: "Subtensor",
+    wallet: "Wallet",
+    hotkey_ss58: str,
+    netuid: int,
+    amount: Balance,
+    *,
+    mev_protection: bool = DEFAULT_MEV_PROTECTION,
+    period: Optional[int] = None,
+    raise_error: bool = False,
+    wait_for_inclusion: bool = True,
+    wait_for_finalization: bool = True,
+    wait_for_revealed_execution: bool = True,
+) -> ExtrinsicResponse:
+    """
+    Locks alpha stake on a hotkey within a subnet, building conviction over time.
+
+    Parameters:
+        subtensor: Subtensor instance.
+        wallet: The wallet whose coldkey owns the stake to lock.
+        hotkey_ss58: The SS58 address of the hotkey to lock stake on.
+        netuid: The subnet UID on which to lock.
+        amount: Amount of alpha to lock.
+        mev_protection: If True, encrypts and submits the transaction through MEV Shield.
+        period: Number of blocks during which the transaction remains valid.
+        raise_error: Raises exception rather than returning failure response.
+        wait_for_inclusion: Whether to wait for inclusion in a block.
+        wait_for_finalization: Whether to wait for finalization.
+        wait_for_revealed_execution: Whether to wait for revealed execution if mev_protection used.
+
+    Returns:
+        ExtrinsicResponse: The result object of the extrinsic execution.
+    """
+    try:
+        if not (
+            unlocked := ExtrinsicResponse.unlock_wallet(wallet, raise_error)
+        ).success:
+            return unlocked
+
+        logging.debug(
+            f"Locking stake on hotkey [blue]{hotkey_ss58}[/blue] "
+            f"on subnet [yellow]{netuid}[/yellow], amount: [green]{amount}[/green]"
+        )
+
+        call = SubtensorModule(subtensor).lock_stake(
+            hotkey=hotkey_ss58,
+            netuid=netuid,
+            amount=amount.rao,
+        )
+
+        if mev_protection:
+            response = submit_encrypted_extrinsic(
+                subtensor=subtensor,
+                wallet=wallet,
+                call=call,
+                period=period,
+                raise_error=raise_error,
+                wait_for_inclusion=wait_for_inclusion,
+                wait_for_finalization=wait_for_finalization,
+                wait_for_revealed_execution=wait_for_revealed_execution,
+            )
+        else:
+            response = subtensor.sign_and_send_extrinsic(
+                call=call,
+                wallet=wallet,
+                wait_for_inclusion=wait_for_inclusion,
+                wait_for_finalization=wait_for_finalization,
+                period=period,
+                raise_error=raise_error,
+            )
+
+        if response.success:
+            logging.debug("[green]Lock stake finalized[/green]")
+        else:
+            logging.error(f"[red]{response.message}[/red]")
+
+        return response
+
+    except Exception as error:
+        return ExtrinsicResponse.from_exception(raise_error=raise_error, error=error)
+
+
+def move_lock_extrinsic(
+    subtensor: "Subtensor",
+    wallet: "Wallet",
+    destination_hotkey_ss58: str,
+    netuid: int,
+    *,
+    mev_protection: bool = DEFAULT_MEV_PROTECTION,
+    period: Optional[int] = None,
+    raise_error: bool = False,
+    wait_for_inclusion: bool = True,
+    wait_for_finalization: bool = True,
+    wait_for_revealed_execution: bool = True,
+) -> ExtrinsicResponse:
+    """
+    Moves an existing lock from its current hotkey to a different hotkey on the same subnet.
+
+    Parameters:
+        subtensor: Subtensor instance.
+        wallet: The wallet whose coldkey owns the lock.
+        destination_hotkey_ss58: The SS58 address of the hotkey to move the lock to.
+        netuid: The subnet UID on which the lock exists.
+        mev_protection: If True, encrypts and submits the transaction through MEV Shield.
+        period: Number of blocks during which the transaction remains valid.
+        raise_error: Raises exception rather than returning failure response.
+        wait_for_inclusion: Whether to wait for inclusion in a block.
+        wait_for_finalization: Whether to wait for finalization.
+        wait_for_revealed_execution: Whether to wait for revealed execution if mev_protection used.
+
+    Returns:
+        ExtrinsicResponse: The result object of the extrinsic execution.
+    """
+    try:
+        if not (
+            unlocked := ExtrinsicResponse.unlock_wallet(wallet, raise_error)
+        ).success:
+            return unlocked
+
+        logging.debug(
+            f"Moving lock to hotkey [blue]{destination_hotkey_ss58}[/blue] "
+            f"on subnet [yellow]{netuid}[/yellow]"
+        )
+
+        call = SubtensorModule(subtensor).move_lock(
+            destination_hotkey=destination_hotkey_ss58,
+            netuid=netuid,
+        )
+
+        if mev_protection:
+            response = submit_encrypted_extrinsic(
+                subtensor=subtensor,
+                wallet=wallet,
+                call=call,
+                period=period,
+                raise_error=raise_error,
+                wait_for_inclusion=wait_for_inclusion,
+                wait_for_finalization=wait_for_finalization,
+                wait_for_revealed_execution=wait_for_revealed_execution,
+            )
+        else:
+            response = subtensor.sign_and_send_extrinsic(
+                call=call,
+                wallet=wallet,
+                wait_for_inclusion=wait_for_inclusion,
+                wait_for_finalization=wait_for_finalization,
+                period=period,
+                raise_error=raise_error,
+            )
+
+        if response.success:
+            logging.debug("[green]Move lock finalized[/green]")
+        else:
+            logging.error(f"[red]{response.message}[/red]")
+
+        return response
+
+    except Exception as error:
+        return ExtrinsicResponse.from_exception(raise_error=raise_error, error=error)
+
+
+def set_perpetual_lock_extrinsic(
+    subtensor: "Subtensor",
+    wallet: "Wallet",
+    netuid: int,
+    enabled: bool,
+    *,
+    period: Optional[int] = None,
+    raise_error: bool = False,
+    wait_for_inclusion: bool = True,
+    wait_for_finalization: bool = True,
+) -> ExtrinsicResponse:
+    """
+    Sets or clears the perpetual lock flag for the caller's lock on a subnet.
+
+    When enabled, the lock does not decay over time. When disabled, normal decay resumes.
+
+    Parameters:
+        subtensor: Subtensor instance.
+        wallet: The wallet whose coldkey owns the lock.
+        netuid: The subnet UID for which to set the perpetual lock flag.
+        enabled: If True, the lock will not decay. If False, normal decay resumes.
+        period: Number of blocks during which the transaction remains valid.
+        raise_error: Raises exception rather than returning failure response.
+        wait_for_inclusion: Whether to wait for inclusion in a block.
+        wait_for_finalization: Whether to wait for finalization.
+
+    Returns:
+        ExtrinsicResponse: The result object of the extrinsic execution.
+    """
+    try:
+        if not (
+            unlocked := ExtrinsicResponse.unlock_wallet(wallet, raise_error)
+        ).success:
+            return unlocked
+
+        logging.debug(
+            f"Setting perpetual lock to [green]{enabled}[/green] "
+            f"on subnet [yellow]{netuid}[/yellow]"
+        )
+
+        call = SubtensorModule(subtensor).set_perpetual_lock(
+            netuid=netuid,
+            enabled=enabled,
+        )
+
+        response = subtensor.sign_and_send_extrinsic(
+            call=call,
+            wallet=wallet,
+            wait_for_inclusion=wait_for_inclusion,
+            wait_for_finalization=wait_for_finalization,
+            period=period,
+            raise_error=raise_error,
+        )
+
+        if response.success:
+            logging.debug("[green]Set perpetual lock finalized[/green]")
+        else:
+            logging.error(f"[red]{response.message}[/red]")
+
+        return response
+
+    except Exception as error:
+        return ExtrinsicResponse.from_exception(raise_error=raise_error, error=error)

--- a/bittensor/core/extrinsics/pallets/subtensor_module.py
+++ b/bittensor/core/extrinsics/pallets/subtensor_module.py
@@ -215,6 +215,47 @@ class SubtensorModule(_BasePallet):
         """
         return self.create_composed_call(hotkey=hotkey, take=take)
 
+    def lock_stake(
+        self,
+        hotkey: str,
+        netuid: int,
+        amount: int,
+    ) -> Call:
+        """Returns GenericCall instance for Subtensor function SubtensorModule.lock_stake.
+
+        Parameters:
+            hotkey: The hotkey SS58 address to lock stake on.
+            netuid: The subnet UID on which to lock.
+            amount: Amount of alpha in RAO to lock.
+
+        Returns:
+            GenericCall instance.
+        """
+        return self.create_composed_call(
+            hotkey=hotkey,
+            netuid=netuid,
+            amount=amount,
+        )
+
+    def move_lock(
+        self,
+        destination_hotkey: str,
+        netuid: int,
+    ) -> Call:
+        """Returns GenericCall instance for Subtensor function SubtensorModule.move_lock.
+
+        Parameters:
+            destination_hotkey: The SS58 address of the hotkey to move the lock to.
+            netuid: The subnet UID on which the lock exists.
+
+        Returns:
+            GenericCall instance.
+        """
+        return self.create_composed_call(
+            destination_hotkey=destination_hotkey,
+            netuid=netuid,
+        )
+
     def move_stake(
         self,
         origin_netuid: int,
@@ -621,6 +662,25 @@ class SubtensorModule(_BasePallet):
             GenericCall instance.
         """
         return self.create_composed_call(cooldown=cooldown)
+
+    def set_perpetual_lock(
+        self,
+        netuid: int,
+        enabled: bool,
+    ) -> Call:
+        """Returns GenericCall instance for Subtensor function SubtensorModule.set_perpetual_lock.
+
+        Parameters:
+            netuid: The subnet UID for which to set the perpetual lock flag.
+            enabled: If True, the lock will not decay. If False, normal decay resumes.
+
+        Returns:
+            GenericCall instance.
+        """
+        return self.create_composed_call(
+            netuid=netuid,
+            enabled=enabled,
+        )
 
     def set_root_claim_type(
         self,

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -77,6 +77,11 @@ from bittensor.core.extrinsics.liquidity import (
     toggle_user_liquidity_extrinsic,
 )
 from bittensor.core.extrinsics.mev_shield import submit_encrypted_extrinsic
+from bittensor.core.extrinsics.lock import (
+    lock_stake_extrinsic,
+    move_lock_extrinsic,
+    set_perpetual_lock_extrinsic,
+)
 from bittensor.core.extrinsics.move_stake import (
     move_stake_extrinsic,
     swap_stake_extrinsic,
@@ -143,6 +148,7 @@ from bittensor.core.settings import (
 from bittensor.core.types import (
     BlockInfo,
     ExtrinsicResponse,
+    LockState,
     Salt,
     SubtensorMixin,
     UIDs,
@@ -1572,6 +1578,41 @@ class Subtensor(SubtensorMixin):
             cooldown,
         )
 
+    def get_coldkey_lock(
+        self,
+        coldkey_ss58: str,
+        netuid: int,
+        block: Optional[int] = None,
+    ) -> Optional["LockState"]:
+        """
+        Returns the current lock for a coldkey on a subnet, rolled forward to the current block.
+
+        Unlike get_stake_lock which returns the raw stored state, this method applies decay to return the actual current
+        lock values accounting for time elapsed since last update.
+
+        Parameters:
+            coldkey_ss58: The SS58 address of the coldkey.
+            netuid: The subnet UID to query.
+            block: The block number to query. If None, queries the current block.
+
+        Returns:
+            LockState with current locked_mass, conviction, and last_update, or None if no lock exists.
+        """
+        result = self.query_runtime_api(
+            runtime_api="StakeInfoRuntimeApi",
+            method="get_coldkey_lock",
+            params=[coldkey_ss58, netuid],
+            block=block,
+        )
+        if result is None:
+            return None
+
+        return LockState(
+            locked_mass=Balance.from_rao(result["locked_mass"], netuid),
+            conviction=fixed_to_float(result["conviction"]),
+            last_update=int(result["last_update"]),
+        )
+
     def get_coldkey_swap_announcement(
         self,
         coldkey_ss58: str,
@@ -2271,6 +2312,33 @@ class Subtensor(SubtensorMixin):
         # TODO verify this from rao, seems like we're just rounding down
         return block_updated, Balance.from_rao(ema_value)
 
+    def get_hotkey_conviction(
+        self,
+        hotkey_ss58: str,
+        netuid: int,
+        block: Optional[int] = None,
+    ) -> float:
+        """
+        Gets the total conviction score for a hotkey on a subnet.
+
+        Parameters:
+            hotkey_ss58: The SS58 address of the hotkey to query.
+            netuid: The subnet UID to query.
+            block: The block number to query. If None, queries the current block.
+
+        Returns:
+            The conviction score as a float.
+        """
+        result = self.query_runtime_api(
+            runtime_api="StakeInfoRuntimeApi",
+            method="get_hotkey_conviction",
+            params=[hotkey_ss58, netuid],
+            block=block,
+        )
+        if result is None:
+            return 0.0
+        return fixed_to_float(result)
+
     def get_hotkey_owner(
         self, hotkey_ss58: str, block: Optional[int] = None
     ) -> Optional[str]:
@@ -2791,6 +2859,28 @@ class Subtensor(SubtensorMixin):
         )
 
         return Balance.from_rao(result.value or 0)
+
+    def get_most_convicted_hotkey_on_subnet(
+        self,
+        netuid: int,
+        block: Optional[int] = None,
+    ) -> Optional[str]:
+        """
+        Gets the hotkey with the highest conviction score on a subnet (the "subnet king").
+
+        Parameters:
+            netuid: The subnet UID to query.
+            block: The block number to query. If None, queries the current block.
+
+        Returns:
+            The SS58 address of the most convicted hotkey, or None if no locks exist.
+        """
+        return self.query_runtime_api(
+            runtime_api="StakeInfoRuntimeApi",
+            method="get_most_convicted_hotkey_on_subnet",
+            params=[netuid],
+            block=block,
+        )
 
     def get_netuids_for_hotkey(
         self, hotkey_ss58: str, block: Optional[int] = None
@@ -3596,6 +3686,72 @@ class Subtensor(SubtensorMixin):
         )
         return sim_swap_result.tao_fee
 
+    def get_stake_lock(
+        self,
+        coldkey_ss58: str,
+        netuid: int,
+        hotkey_ss58: str,
+        block: Optional[int] = None,
+    ) -> Optional["LockState"]:
+        """
+        Retrieves the lock state for a specific coldkey-netuid-hotkey combination.
+
+        Parameters:
+            coldkey_ss58: The SS58 address of the coldkey that owns the lock.
+            netuid: The subnet UID on which to query.
+            hotkey_ss58: The SS58 address of the hotkey the lock is on.
+            block: The block number to query. If None, queries the current block.
+
+        Returns:
+            LockState dict with locked_mass, conviction, last_update, or None if no lock exists.
+        """
+        query = self.query_subtensor(
+            "Lock", params=[coldkey_ss58, netuid, hotkey_ss58], block=block
+        )
+        if query.value is None:
+            return None
+
+        value = cast(dict, query.value)
+        return LockState(
+            locked_mass=Balance.from_rao(value["locked_mass"], netuid),
+            conviction=fixed_to_float(value["conviction"]),
+            last_update=int(value["last_update"]),
+        )
+
+    def get_stake_locks(
+        self,
+        coldkey_ss58: str,
+        netuid: int,
+        block: Optional[int] = None,
+    ) -> "list[tuple[str, LockState]]":
+        """
+        Retrieves all lock states for a coldkey on a subnet.
+
+        Parameters:
+            coldkey_ss58: The SS58 address of the coldkey that owns the locks.
+            netuid: The subnet UID on which to query.
+            block: The block number to query. If None, queries the current block.
+
+        Returns:
+            List of (hotkey_ss58, LockState) tuples.
+        """
+        query_map = self.query_map_subtensor(
+            "Lock", params=[coldkey_ss58, netuid], block=block
+        )
+        locks = []
+        for hotkey, lock_state in query_map:
+            locks.append(
+                (
+                    hotkey,
+                    LockState(
+                        locked_mass=Balance.from_rao(lock_state["locked_mass"], netuid),
+                        conviction=fixed_to_float(lock_state["conviction"]),
+                        last_update=int(lock_state["last_update"]),
+                    ),
+                )
+            )
+        return locks
+
     def get_stake_movement_fee(
         self,
         origin_netuid: int,
@@ -4320,6 +4476,31 @@ class Subtensor(SubtensorMixin):
             is not None
         )
 
+    def is_perpetual_lock(
+        self,
+        coldkey_ss58: str,
+        netuid: int,
+        block: Optional[int] = None,
+    ) -> bool:
+        """
+        Checks whether a coldkey's lock on a subnet is perpetual (non-decaying).
+
+        Locks decay by default. A lock becomes perpetual only when the coldkey explicitly opts in via
+        set_perpetual_lock(enabled=True), which inserts a DecayingLock entry.
+
+        Parameters:
+            coldkey_ss58: The SS58 address of the coldkey to check.
+            netuid: The subnet UID to check.
+            block: The block number to query. If None, queries the current block.
+
+        Returns:
+            True if the lock is perpetual (does not decay), False if it decays.
+        """
+        query = self.query_subtensor(
+            name="DecayingLock", params=[coldkey_ss58, netuid], block=block
+        )
+        return query.value is not None
+
     def is_subnet_active(self, netuid: int, block: Optional[int] = None) -> bool:
         """Verifies if a subnet with the provided netuid is active.
 
@@ -4731,7 +4912,7 @@ class Subtensor(SubtensorMixin):
                 return True
             return None
 
-        current_block = cast(Optional[dict[str, Any]], self.substrate.get_block())
+        current_block = self.substrate.get_block()
         if current_block is None:
             return False
         current_block_hash = current_block.get("header", {}).get("hash")
@@ -6169,6 +6350,53 @@ class Subtensor(SubtensorMixin):
             wait_for_revealed_execution=wait_for_revealed_execution,
         )
 
+    def lock_stake(
+        self,
+        wallet: "Wallet",
+        hotkey_ss58: str,
+        netuid: int,
+        amount: Balance,
+        *,
+        mev_protection: bool = DEFAULT_MEV_PROTECTION,
+        period: Optional[int] = DEFAULT_PERIOD,
+        raise_error: bool = False,
+        wait_for_inclusion: bool = True,
+        wait_for_finalization: bool = True,
+        wait_for_revealed_execution: bool = True,
+    ) -> ExtrinsicResponse:
+        """
+        Locks alpha stake on a hotkey within a subnet, building conviction over time.
+
+        Parameters:
+            wallet: The wallet whose coldkey owns the stake to lock.
+            hotkey_ss58: The SS58 address of the hotkey to lock stake on.
+            netuid: The subnet UID on which to lock.
+            amount: Amount of alpha to lock as a Balance object.
+            mev_protection: If `True`, encrypts and submits the transaction through MEV Shield.
+            period: The number of blocks during which the transaction will remain valid after it's submitted.
+            raise_error: Raises exception rather than returning failure response.
+            wait_for_inclusion: Waits for the transaction to be included in a block.
+            wait_for_finalization: Waits for the transaction to be finalized on the blockchain.
+            wait_for_revealed_execution: Whether to wait for the revealed execution of transaction if mev_protection used.
+
+        Returns:
+            ExtrinsicResponse: The result object of the extrinsic execution.
+        """
+        check_balance_amount(amount)
+        return lock_stake_extrinsic(
+            subtensor=self,
+            wallet=wallet,
+            hotkey_ss58=hotkey_ss58,
+            netuid=netuid,
+            amount=amount,
+            mev_protection=mev_protection,
+            period=period,
+            raise_error=raise_error,
+            wait_for_inclusion=wait_for_inclusion,
+            wait_for_finalization=wait_for_finalization,
+            wait_for_revealed_execution=wait_for_revealed_execution,
+        )
+
     def mev_submit_encrypted(
         self,
         wallet: "Wallet",
@@ -6307,6 +6535,49 @@ class Subtensor(SubtensorMixin):
             position_id=position_id,
             liquidity_delta=liquidity_delta,
             hotkey_ss58=hotkey_ss58,
+            mev_protection=mev_protection,
+            period=period,
+            raise_error=raise_error,
+            wait_for_inclusion=wait_for_inclusion,
+            wait_for_finalization=wait_for_finalization,
+            wait_for_revealed_execution=wait_for_revealed_execution,
+        )
+
+    def move_lock(
+        self,
+        wallet: "Wallet",
+        destination_hotkey_ss58: str,
+        netuid: int,
+        *,
+        mev_protection: bool = DEFAULT_MEV_PROTECTION,
+        period: Optional[int] = DEFAULT_PERIOD,
+        raise_error: bool = False,
+        wait_for_inclusion: bool = True,
+        wait_for_finalization: bool = True,
+        wait_for_revealed_execution: bool = True,
+    ) -> ExtrinsicResponse:
+        """
+        Moves an existing lock from its current hotkey to a different hotkey on the same subnet.
+
+        Parameters:
+            wallet: The wallet whose coldkey owns the lock.
+            destination_hotkey_ss58: The SS58 address of the hotkey to move the lock to.
+            netuid: The subnet UID on which the lock exists.
+            mev_protection: If `True`, encrypts and submits the transaction through MEV Shield.
+            period: The number of blocks during which the transaction will remain valid after it's submitted.
+            raise_error: Raises exception rather than returning failure response.
+            wait_for_inclusion: Waits for the transaction to be included in a block.
+            wait_for_finalization: Waits for the transaction to be finalized on the blockchain.
+            wait_for_revealed_execution: Whether to wait for the revealed execution of transaction if mev_protection used.
+
+        Returns:
+            ExtrinsicResponse: The result object of the extrinsic execution.
+        """
+        return move_lock_extrinsic(
+            subtensor=self,
+            wallet=wallet,
+            destination_hotkey_ss58=destination_hotkey_ss58,
+            netuid=netuid,
             mev_protection=mev_protection,
             period=period,
             raise_error=raise_error,
@@ -7409,6 +7680,45 @@ class Subtensor(SubtensorMixin):
 
         logging.error(f"[red]{response.message}[/red]")
         return response
+
+    def set_perpetual_lock(
+        self,
+        wallet: "Wallet",
+        netuid: int,
+        enabled: bool,
+        *,
+        period: Optional[int] = DEFAULT_PERIOD,
+        raise_error: bool = False,
+        wait_for_inclusion: bool = True,
+        wait_for_finalization: bool = True,
+    ) -> ExtrinsicResponse:
+        """
+        Sets or clears the perpetual lock flag for the caller's lock on a subnet.
+
+        When enabled, the lock does not decay over time. When disabled, normal decay resumes.
+
+        Parameters:
+            wallet: The wallet whose coldkey owns the lock.
+            netuid: The subnet UID for which to set the perpetual lock flag.
+            enabled: If True, the lock will not decay. If False, normal decay resumes.
+            period: The number of blocks during which the transaction will remain valid after it's submitted.
+            raise_error: Raises exception rather than returning failure response.
+            wait_for_inclusion: Waits for the transaction to be included in a block.
+            wait_for_finalization: Waits for the transaction to be finalized on the blockchain.
+
+        Returns:
+            ExtrinsicResponse: The result object of the extrinsic execution.
+        """
+        return set_perpetual_lock_extrinsic(
+            subtensor=self,
+            wallet=wallet,
+            netuid=netuid,
+            enabled=enabled,
+            period=period,
+            raise_error=raise_error,
+            wait_for_inclusion=wait_for_inclusion,
+            wait_for_finalization=wait_for_finalization,
+        )
 
     def set_root_claim_type(
         self,

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -4486,7 +4486,8 @@ class Subtensor(SubtensorMixin):
         Checks whether a coldkey's lock on a subnet is perpetual (non-decaying).
 
         Locks decay by default. A lock becomes perpetual only when the coldkey explicitly opts in via
-        set_perpetual_lock(enabled=True), which inserts a DecayingLock entry.
+        set_perpetual_lock(enabled=True), which inserts a ``DecayingLock`` entry with value ``false``. When the entry is
+        absent, the lock decays normally.
 
         Parameters:
             coldkey_ss58: The SS58 address of the coldkey to check.
@@ -4494,12 +4495,12 @@ class Subtensor(SubtensorMixin):
             block: The block number to query. If None, queries the current block.
 
         Returns:
-            True if the lock is perpetual (does not decay), False if it decays.
+            True if the lock is perpetual (does not decay), False if it decays or no lock exists.
         """
         query = self.query_subtensor(
             name="DecayingLock", params=[coldkey_ss58, netuid], block=block
         )
-        return query.value is not None
+        return query.value is False
 
     def is_subnet_active(self, netuid: int, block: Optional[int] = None) -> bool:
         """Verifies if a subnet with the provided netuid is active.

--- a/bittensor/core/types.py
+++ b/bittensor/core/types.py
@@ -658,3 +658,18 @@ class DynamicInfoResponse(TypedDict):
     subnet_identity: SubnetIdentityResponse
     moving_price: FixedPoint
     price: NotRequired["Balance"]
+
+
+class LockState(TypedDict):
+    """
+    Exponential lock state for a coldkey on a subnet.
+
+    Attributes:
+        locked_mass: Exponentially decaying locked amount (Balance in subnet Alpha).
+        conviction: Matured decaying score (integral of locked_mass over time).
+        last_update: Block number of last roll-forward.
+    """
+
+    locked_mass: "Balance"
+    conviction: float
+    last_update: int

--- a/bittensor/extras/subtensor_api/extrinsics.py
+++ b/bittensor/extras/subtensor_api/extrinsics.py
@@ -13,17 +13,19 @@ class Extrinsics:
         self.add_stake_burn = subtensor.add_stake_burn
         self.add_stake_multiple = subtensor.add_stake_multiple
         self.announce_coldkey_swap = subtensor.announce_coldkey_swap
-        self.clear_coldkey_swap_announcement = subtensor.clear_coldkey_swap_announcement
-        self.dispute_coldkey_swap = subtensor.dispute_coldkey_swap
         self.burned_register = subtensor.burned_register
         self.claim_root = subtensor.claim_root
+        self.clear_coldkey_swap_announcement = subtensor.clear_coldkey_swap_announcement
         self.commit_weights = subtensor.commit_weights
         self.contribute_crowdloan = subtensor.contribute_crowdloan
         self.create_crowdloan = subtensor.create_crowdloan
+        self.dispute_coldkey_swap = subtensor.dispute_coldkey_swap
         self.dissolve_crowdloan = subtensor.dissolve_crowdloan
         self.finalize_crowdloan = subtensor.finalize_crowdloan
         self.get_extrinsic_fee = subtensor.get_extrinsic_fee
+        self.lock_stake = subtensor.lock_stake
         self.modify_liquidity = subtensor.modify_liquidity
+        self.move_lock = subtensor.move_lock
         self.move_stake = subtensor.move_stake
         self.refund_crowdloan = subtensor.refund_crowdloan
         self.register = subtensor.register
@@ -35,12 +37,16 @@ class Extrinsics:
         self.root_set_pending_childkey_cooldown = (
             subtensor.root_set_pending_childkey_cooldown
         )
+        self.serve_axon = subtensor.serve_axon
+        self.set_auto_stake = subtensor.set_auto_stake
         self.set_children = subtensor.set_children
+        self.set_commitment = subtensor.set_commitment
+        self.set_delegate_take = subtensor.set_delegate_take
+        self.set_perpetual_lock = subtensor.set_perpetual_lock
+        self.set_reveal_commitment = subtensor.set_reveal_commitment
+        self.set_root_claim_type = subtensor.set_root_claim_type
         self.set_subnet_identity = subtensor.set_subnet_identity
         self.set_weights = subtensor.set_weights
-        self.serve_axon = subtensor.serve_axon
-        self.set_commitment = subtensor.set_commitment
-        self.set_root_claim_type = subtensor.set_root_claim_type
         self.start_call = subtensor.start_call
         self.swap_coldkey_announced = subtensor.swap_coldkey_announced
         self.swap_stake = subtensor.swap_stake

--- a/bittensor/extras/subtensor_api/staking.py
+++ b/bittensor/extras/subtensor_api/staking.py
@@ -12,8 +12,12 @@ class Staking:
         self.add_stake_multiple = subtensor.add_stake_multiple
         self.claim_root = subtensor.claim_root
         self.get_auto_stakes = subtensor.get_auto_stakes
+        self.get_hotkey_conviction = subtensor.get_hotkey_conviction
         self.get_hotkey_stake = subtensor.get_hotkey_stake
         self.get_minimum_required_stake = subtensor.get_minimum_required_stake
+        self.get_most_convicted_hotkey_on_subnet = (
+            subtensor.get_most_convicted_hotkey_on_subnet
+        )
         self.get_root_alpha_dividends_per_subnet = (
             subtensor.get_root_alpha_dividends_per_subnet
         )
@@ -21,9 +25,12 @@ class Staking:
         self.get_root_claimable_all_rates = subtensor.get_root_claimable_all_rates
         self.get_root_claimable_rate = subtensor.get_root_claimable_rate
         self.get_root_claimable_stake = subtensor.get_root_claimable_stake
+        self.get_coldkey_lock = subtensor.get_coldkey_lock
         self.get_root_claimed = subtensor.get_root_claimed
         self.get_stake = subtensor.get_stake
         self.get_stake_add_fee = subtensor.get_stake_add_fee
+        self.get_stake_lock = subtensor.get_stake_lock
+        self.get_stake_locks = subtensor.get_stake_locks
         self.get_stake_for_coldkey_and_hotkey = (
             subtensor.get_stake_for_coldkey_and_hotkey
         )
@@ -33,8 +40,12 @@ class Staking:
         self.get_stake_weight = subtensor.get_stake_weight
         self.get_staking_hotkeys = subtensor.get_staking_hotkeys
         self.get_unstake_fee = subtensor.get_unstake_fee
+        self.is_perpetual_lock = subtensor.is_perpetual_lock
+        self.lock_stake = subtensor.lock_stake
+        self.move_lock = subtensor.move_lock
         self.move_stake = subtensor.move_stake
         self.set_auto_stake = subtensor.set_auto_stake
+        self.set_perpetual_lock = subtensor.set_perpetual_lock
         self.set_root_claim_type = subtensor.set_root_claim_type
         self.sim_swap = subtensor.sim_swap
         self.swap_stake = subtensor.swap_stake

--- a/bittensor/extras/subtensor_api/staking.py
+++ b/bittensor/extras/subtensor_api/staking.py
@@ -12,6 +12,7 @@ class Staking:
         self.add_stake_multiple = subtensor.add_stake_multiple
         self.claim_root = subtensor.claim_root
         self.get_auto_stakes = subtensor.get_auto_stakes
+        self.get_coldkey_lock = subtensor.get_coldkey_lock
         self.get_hotkey_conviction = subtensor.get_hotkey_conviction
         self.get_hotkey_stake = subtensor.get_hotkey_stake
         self.get_minimum_required_stake = subtensor.get_minimum_required_stake
@@ -25,17 +26,16 @@ class Staking:
         self.get_root_claimable_all_rates = subtensor.get_root_claimable_all_rates
         self.get_root_claimable_rate = subtensor.get_root_claimable_rate
         self.get_root_claimable_stake = subtensor.get_root_claimable_stake
-        self.get_coldkey_lock = subtensor.get_coldkey_lock
         self.get_root_claimed = subtensor.get_root_claimed
         self.get_stake = subtensor.get_stake
         self.get_stake_add_fee = subtensor.get_stake_add_fee
-        self.get_stake_lock = subtensor.get_stake_lock
-        self.get_stake_locks = subtensor.get_stake_locks
         self.get_stake_for_coldkey_and_hotkey = (
             subtensor.get_stake_for_coldkey_and_hotkey
         )
         self.get_stake_info_for_coldkey = subtensor.get_stake_info_for_coldkey
         self.get_stake_info_for_coldkeys = subtensor.get_stake_info_for_coldkeys
+        self.get_stake_lock = subtensor.get_stake_lock
+        self.get_stake_locks = subtensor.get_stake_locks
         self.get_stake_movement_fee = subtensor.get_stake_movement_fee
         self.get_stake_weight = subtensor.get_stake_weight
         self.get_staking_hotkeys = subtensor.get_staking_hotkeys

--- a/tests/e2e_tests/test_lock_stake.py
+++ b/tests/e2e_tests/test_lock_stake.py
@@ -12,14 +12,15 @@ from tests.e2e_tests.utils import (
 
 def test_owner_lock_lifecycle(subtensor, alice_wallet, bob_wallet):
     """
-    Tests owner lock lifecycle including auto-lock from emission.
+    Tests owner lock lifecycle.
 
-    1. After emission, owner already has an auto-lock on their own hotkey
-    2. Query lock state and verify conviction > 0 (owner gets instant conviction)
-    3. Verify get_most_convicted_hotkey_on_subnet returns owner hotkey
-    4. Fail to lock on a different hotkey (LockHotkeyMismatch)
-    5. Top-up the existing lock on the same hotkey
-    6. Unstake within available limit succeeds, lock remains unchanged
+    1. Owner has no locks initially
+    2. Owner adds stake and creates a lock on their own hotkey
+    3. Query lock state and verify conviction > 0 (owner gets instant conviction)
+    4. Verify get_most_convicted_hotkey_on_subnet returns owner hotkey
+    5. Fail to lock on a different hotkey (LockHotkeyMismatch)
+    6. Top-up the existing lock on the same hotkey
+    7. Unstake within available limit succeeds, lock remains unchanged
     """
     alice_sn = TestSubnet(subtensor)
     steps = [
@@ -29,16 +30,38 @@ def test_owner_lock_lifecycle(subtensor, alice_wallet, bob_wallet):
     ]
     alice_sn.execute_steps(steps)
 
-    # Wait for at least one epoch so that emission fires auto_lock_owner_cut
-    next_epoch = subtensor.subnets.get_next_epoch_start_block(alice_sn.netuid)
-    subtensor.wait_for_block(next_epoch + 1)
-
-    # Owner should already have an auto-lock on their own hotkey
+    # Owner has no locks initially (auto_lock_owner_cut is disabled by default)
     locks = subtensor.staking.get_stake_locks(
         coldkey_ss58=alice_wallet.coldkey.ss58_address,
         netuid=alice_sn.netuid,
     )
-    logging.console.info(f"Owner locks after emission: {locks}")
+    assert len(locks) == 0
+
+    # Add stake so owner can create a lock
+    assert subtensor.staking.add_stake(
+        wallet=alice_wallet,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=alice_wallet.hotkey.ss58_address,
+        amount=Balance.from_tao(10),
+    ).success
+
+    # Owner creates a lock on their own hotkey
+    lock_amount = Balance.from_tao(3).set_unit(alice_sn.netuid)
+    response = subtensor.staking.lock_stake(
+        wallet=alice_wallet,
+        hotkey_ss58=alice_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+        amount=lock_amount,
+    )
+    logging.console.info(f"Owner lock response: {response}")
+    assert response.success
+
+    # Verify lock exists
+    locks = subtensor.staking.get_stake_locks(
+        coldkey_ss58=alice_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    logging.console.info(f"Owner locks: {locks}")
     assert len(locks) == 1
     hotkey, lock_state = locks[0]
     assert hotkey == alice_wallet.hotkey.ss58_address
@@ -68,14 +91,6 @@ def test_owner_lock_lifecycle(subtensor, alice_wallet, bob_wallet):
     )
     logging.console.info(f"Lock on different hotkey response: {response}")
     assert response.success is False
-
-    # Add more stake on own hotkey so we have enough to lock
-    assert subtensor.staking.add_stake(
-        wallet=alice_wallet,
-        netuid=alice_sn.netuid,
-        hotkey_ss58=alice_wallet.hotkey.ss58_address,
-        amount=Balance.from_tao(5),
-    ).success
 
     # Record locked_mass before top-up
     lock_before = subtensor.staking.get_stake_lock(
@@ -117,7 +132,7 @@ def test_owner_lock_lifecycle(subtensor, alice_wallet, bob_wallet):
     logging.console.info(f"Unstake small amount response: {response}")
     assert response.success
 
-    # Unstake must not reduce locked_mass (may grow due to auto_lock_owner_cut between blocks)
+    # Unstake must not reduce locked_mass
     lock_unchanged = subtensor.staking.get_stake_lock(
         coldkey_ss58=alice_wallet.coldkey.ss58_address,
         netuid=alice_sn.netuid,
@@ -129,14 +144,15 @@ def test_owner_lock_lifecycle(subtensor, alice_wallet, bob_wallet):
 @pytest.mark.asyncio
 async def test_owner_lock_lifecycle_async(async_subtensor, alice_wallet, bob_wallet):
     """
-    Async version: Tests owner lock lifecycle including auto-lock from emission.
+    Async version: Tests owner lock lifecycle.
 
-    1. After emission, owner already has an auto-lock on their own hotkey
-    2. Query lock state and verify conviction > 0 (owner gets instant conviction)
-    3. Verify get_most_convicted_hotkey_on_subnet returns owner hotkey
-    4. Fail to lock on a different hotkey (LockHotkeyMismatch)
-    5. Top-up the existing lock on the same hotkey
-    6. Unstake within available limit succeeds, lock remains unchanged
+    1. Owner has no locks initially
+    2. Owner adds stake and creates a lock on their own hotkey
+    3. Query lock state and verify conviction > 0 (owner gets instant conviction)
+    4. Verify get_most_convicted_hotkey_on_subnet returns owner hotkey
+    5. Fail to lock on a different hotkey (LockHotkeyMismatch)
+    6. Top-up the existing lock on the same hotkey
+    7. Unstake within available limit succeeds, lock remains unchanged
     """
     alice_sn = TestSubnet(async_subtensor)
     steps = [
@@ -146,18 +162,40 @@ async def test_owner_lock_lifecycle_async(async_subtensor, alice_wallet, bob_wal
     ]
     await alice_sn.async_execute_steps(steps)
 
-    # Wait for at least one epoch so that emission fires auto_lock_owner_cut
-    next_epoch = await async_subtensor.subnets.get_next_epoch_start_block(
-        alice_sn.netuid
-    )
-    await async_subtensor.wait_for_block(next_epoch + 1)
-
-    # Owner should already have an auto-lock on their own hotkey
+    # Owner has no locks initially (auto_lock_owner_cut is disabled by default)
     locks = await async_subtensor.staking.get_stake_locks(
         coldkey_ss58=alice_wallet.coldkey.ss58_address,
         netuid=alice_sn.netuid,
     )
-    logging.console.info(f"Owner locks after emission: {locks}")
+    assert len(locks) == 0
+
+    # Add stake so owner can create a lock
+    assert (
+        await async_subtensor.staking.add_stake(
+            wallet=alice_wallet,
+            netuid=alice_sn.netuid,
+            hotkey_ss58=alice_wallet.hotkey.ss58_address,
+            amount=Balance.from_tao(10),
+        )
+    ).success
+
+    # Owner creates a lock on their own hotkey
+    lock_amount = Balance.from_tao(3).set_unit(alice_sn.netuid)
+    response = await async_subtensor.staking.lock_stake(
+        wallet=alice_wallet,
+        hotkey_ss58=alice_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+        amount=lock_amount,
+    )
+    logging.console.info(f"Owner lock response: {response}")
+    assert response.success
+
+    # Verify lock exists
+    locks = await async_subtensor.staking.get_stake_locks(
+        coldkey_ss58=alice_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    logging.console.info(f"Owner locks: {locks}")
     assert len(locks) == 1
     hotkey, lock_state = locks[0]
     assert hotkey == alice_wallet.hotkey.ss58_address
@@ -187,16 +225,6 @@ async def test_owner_lock_lifecycle_async(async_subtensor, alice_wallet, bob_wal
     )
     logging.console.info(f"Lock on different hotkey response: {response}")
     assert response.success is False
-
-    # Add more stake on own hotkey so we have enough to lock
-    assert (
-        await async_subtensor.staking.add_stake(
-            wallet=alice_wallet,
-            netuid=alice_sn.netuid,
-            hotkey_ss58=alice_wallet.hotkey.ss58_address,
-            amount=Balance.from_tao(5),
-        )
-    ).success
 
     # Record locked_mass before top-up
     lock_before = await async_subtensor.staking.get_stake_lock(
@@ -238,7 +266,7 @@ async def test_owner_lock_lifecycle_async(async_subtensor, alice_wallet, bob_wal
     logging.console.info(f"Unstake small amount response: {response}")
     assert response.success
 
-    # Unstake must not reduce locked_mass (may grow due to auto_lock_owner_cut between blocks)
+    # Unstake must not reduce locked_mass
     lock_unchanged = await async_subtensor.staking.get_stake_lock(
         coldkey_ss58=alice_wallet.coldkey.ss58_address,
         netuid=alice_sn.netuid,
@@ -539,7 +567,7 @@ def test_move_lock(subtensor, alice_wallet, bob_wallet, charlie_wallet):
     1. Fail to move when no lock exists (NoExistingLock)
     2. Create a lock for Bob, then move it to Charlie's hotkey
     3. Verify lock moved: old hotkey has None, new hotkey has lock
-    4. Owner moves their auto-lock to a different hotkey
+    4. Owner creates a lock and moves it to a different hotkey
     5. Verify owner lock moved successfully
     """
     alice_sn = TestSubnet(subtensor)
@@ -613,9 +641,20 @@ def test_move_lock(subtensor, alice_wallet, bob_wallet, charlie_wallet):
     assert new_lock["locked_mass"].rao > lock_amount.rao * 0.99
     logging.console.info(f"Bob lock after move: {new_lock}")
 
-    # Owner move: wait for emission so owner has auto-lock
-    next_epoch = subtensor.subnets.get_next_epoch_start_block(alice_sn.netuid)
-    subtensor.wait_for_block(next_epoch + 1)
+    # Owner creates a lock manually (auto_lock_owner_cut is disabled by default)
+    assert subtensor.staking.add_stake(
+        wallet=alice_wallet,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=alice_wallet.hotkey.ss58_address,
+        amount=Balance.from_tao(5),
+    ).success
+
+    assert subtensor.staking.lock_stake(
+        wallet=alice_wallet,
+        hotkey_ss58=alice_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+        amount=Balance.from_tao(2).set_unit(alice_sn.netuid),
+    ).success
 
     owner_lock = subtensor.staking.get_stake_lock(
         coldkey_ss58=alice_wallet.coldkey.ss58_address,
@@ -662,7 +701,7 @@ async def test_move_lock_async(
     1. Fail to move when no lock exists (NoExistingLock)
     2. Create a lock for Bob, then move it to Charlie's hotkey
     3. Verify lock moved: old hotkey has None, new hotkey has lock
-    4. Owner moves their auto-lock to a different hotkey
+    4. Owner creates a lock and moves it to a different hotkey
     5. Verify owner lock moved successfully
     """
     alice_sn = TestSubnet(async_subtensor)
@@ -740,11 +779,24 @@ async def test_move_lock_async(
     assert new_lock["locked_mass"].rao > lock_amount.rao * 0.99
     logging.console.info(f"Bob lock after move: {new_lock}")
 
-    # Owner move: wait for emission so owner has auto-lock
-    next_epoch = await async_subtensor.subnets.get_next_epoch_start_block(
-        alice_sn.netuid
-    )
-    await async_subtensor.wait_for_block(next_epoch + 1)
+    # Owner creates a lock manually (auto_lock_owner_cut is disabled by default)
+    assert (
+        await async_subtensor.staking.add_stake(
+            wallet=alice_wallet,
+            netuid=alice_sn.netuid,
+            hotkey_ss58=alice_wallet.hotkey.ss58_address,
+            amount=Balance.from_tao(5),
+        )
+    ).success
+
+    assert (
+        await async_subtensor.staking.lock_stake(
+            wallet=alice_wallet,
+            hotkey_ss58=alice_wallet.hotkey.ss58_address,
+            netuid=alice_sn.netuid,
+            amount=Balance.from_tao(2).set_unit(alice_sn.netuid),
+        )
+    ).success
 
     owner_lock = await async_subtensor.staking.get_stake_lock(
         coldkey_ss58=alice_wallet.coldkey.ss58_address,

--- a/tests/e2e_tests/test_lock_stake.py
+++ b/tests/e2e_tests/test_lock_stake.py
@@ -1,0 +1,966 @@
+import pytest
+
+from bittensor import logging
+from bittensor.utils.balance import Balance
+from tests.e2e_tests.utils import (
+    TestSubnet,
+    ACTIVATE_SUBNET,
+    REGISTER_SUBNET,
+    REGISTER_NEURON,
+)
+
+
+def test_owner_lock_lifecycle(subtensor, alice_wallet, bob_wallet):
+    """
+    Tests owner lock lifecycle including auto-lock from emission.
+
+    1. After emission, owner already has an auto-lock on their own hotkey
+    2. Query lock state and verify conviction > 0 (owner gets instant conviction)
+    3. Verify get_most_convicted_hotkey_on_subnet returns owner hotkey
+    4. Fail to lock on a different hotkey (LockHotkeyMismatch)
+    5. Top-up the existing lock on the same hotkey
+    6. Unstake within available limit succeeds, lock remains unchanged
+    """
+    alice_sn = TestSubnet(subtensor)
+    steps = [
+        REGISTER_SUBNET(alice_wallet),
+        ACTIVATE_SUBNET(alice_wallet),
+        REGISTER_NEURON(bob_wallet),
+    ]
+    alice_sn.execute_steps(steps)
+
+    # Wait for at least one epoch so that emission fires auto_lock_owner_cut
+    next_epoch = subtensor.subnets.get_next_epoch_start_block(alice_sn.netuid)
+    subtensor.wait_for_block(next_epoch + 1)
+
+    # Owner should already have an auto-lock on their own hotkey
+    locks = subtensor.staking.get_stake_locks(
+        coldkey_ss58=alice_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    logging.console.info(f"Owner locks after emission: {locks}")
+    assert len(locks) == 1
+    hotkey, lock_state = locks[0]
+    assert hotkey == alice_wallet.hotkey.ss58_address
+    assert lock_state["locked_mass"].rao > 0
+
+    # Owner conviction should be > 0 (owner gets conviction = locked_mass instantly)
+    conviction = subtensor.staking.get_hotkey_conviction(
+        hotkey_ss58=alice_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    logging.console.info(f"Owner hotkey conviction: {conviction}")
+    assert conviction > 0.0
+
+    # Subnet king should be the owner hotkey
+    king = subtensor.staking.get_most_convicted_hotkey_on_subnet(
+        netuid=alice_sn.netuid,
+    )
+    logging.console.info(f"Subnet king: {king}")
+    assert king == alice_wallet.hotkey.ss58_address
+
+    # Trying to lock on a different hotkey should fail (LockHotkeyMismatch)
+    response = subtensor.staking.lock_stake(
+        wallet=alice_wallet,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+        amount=Balance.from_tao(1).set_unit(alice_sn.netuid),
+    )
+    logging.console.info(f"Lock on different hotkey response: {response}")
+    assert response.success is False
+
+    # Add more stake on own hotkey so we have enough to lock
+    assert subtensor.staking.add_stake(
+        wallet=alice_wallet,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=alice_wallet.hotkey.ss58_address,
+        amount=Balance.from_tao(5),
+    ).success
+
+    # Record locked_mass before top-up
+    lock_before = subtensor.staking.get_stake_lock(
+        coldkey_ss58=alice_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=alice_wallet.hotkey.ss58_address,
+    )
+    locked_mass_before = lock_before["locked_mass"].rao
+    logging.console.info(f"Locked mass before top-up: {locked_mass_before}")
+
+    # Top-up lock on own hotkey
+    top_up_amount = Balance.from_tao(2).set_unit(alice_sn.netuid)
+    response = subtensor.staking.lock_stake(
+        wallet=alice_wallet,
+        hotkey_ss58=alice_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+        amount=top_up_amount,
+    )
+    logging.console.info(f"Top-up lock response: {response}")
+    assert response.success
+
+    # Verify locked_mass increased
+    lock_after = subtensor.staking.get_stake_lock(
+        coldkey_ss58=alice_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=alice_wallet.hotkey.ss58_address,
+    )
+    logging.console.info(f"Locked mass after top-up: {lock_after['locked_mass'].rao}")
+    assert lock_after["locked_mass"].rao > locked_mass_before
+
+    # Unstaking within available limit should succeed without affecting the lock
+    small_amount = Balance.from_tao(1).set_unit(alice_sn.netuid)
+    response = subtensor.staking.unstake(
+        wallet=alice_wallet,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=alice_wallet.hotkey.ss58_address,
+        amount=small_amount,
+    )
+    logging.console.info(f"Unstake small amount response: {response}")
+    assert response.success
+
+    # Unstake must not reduce locked_mass (may grow due to auto_lock_owner_cut between blocks)
+    lock_unchanged = subtensor.staking.get_stake_lock(
+        coldkey_ss58=alice_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=alice_wallet.hotkey.ss58_address,
+    )
+    assert lock_unchanged["locked_mass"].rao >= lock_after["locked_mass"].rao
+
+
+@pytest.mark.asyncio
+async def test_owner_lock_lifecycle_async(async_subtensor, alice_wallet, bob_wallet):
+    """
+    Async version: Tests owner lock lifecycle including auto-lock from emission.
+
+    1. After emission, owner already has an auto-lock on their own hotkey
+    2. Query lock state and verify conviction > 0 (owner gets instant conviction)
+    3. Verify get_most_convicted_hotkey_on_subnet returns owner hotkey
+    4. Fail to lock on a different hotkey (LockHotkeyMismatch)
+    5. Top-up the existing lock on the same hotkey
+    6. Unstake within available limit succeeds, lock remains unchanged
+    """
+    alice_sn = TestSubnet(async_subtensor)
+    steps = [
+        REGISTER_SUBNET(alice_wallet),
+        ACTIVATE_SUBNET(alice_wallet),
+        REGISTER_NEURON(bob_wallet),
+    ]
+    await alice_sn.async_execute_steps(steps)
+
+    # Wait for at least one epoch so that emission fires auto_lock_owner_cut
+    next_epoch = await async_subtensor.subnets.get_next_epoch_start_block(
+        alice_sn.netuid
+    )
+    await async_subtensor.wait_for_block(next_epoch + 1)
+
+    # Owner should already have an auto-lock on their own hotkey
+    locks = await async_subtensor.staking.get_stake_locks(
+        coldkey_ss58=alice_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    logging.console.info(f"Owner locks after emission: {locks}")
+    assert len(locks) == 1
+    hotkey, lock_state = locks[0]
+    assert hotkey == alice_wallet.hotkey.ss58_address
+    assert lock_state["locked_mass"].rao > 0
+
+    # Owner conviction should be > 0 (owner gets conviction = locked_mass instantly)
+    conviction = await async_subtensor.staking.get_hotkey_conviction(
+        hotkey_ss58=alice_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    logging.console.info(f"Owner hotkey conviction: {conviction}")
+    assert conviction > 0.0
+
+    # Subnet king should be the owner hotkey
+    king = await async_subtensor.staking.get_most_convicted_hotkey_on_subnet(
+        netuid=alice_sn.netuid,
+    )
+    logging.console.info(f"Subnet king: {king}")
+    assert king == alice_wallet.hotkey.ss58_address
+
+    # Trying to lock on a different hotkey should fail (LockHotkeyMismatch)
+    response = await async_subtensor.staking.lock_stake(
+        wallet=alice_wallet,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+        amount=Balance.from_tao(1).set_unit(alice_sn.netuid),
+    )
+    logging.console.info(f"Lock on different hotkey response: {response}")
+    assert response.success is False
+
+    # Add more stake on own hotkey so we have enough to lock
+    assert (
+        await async_subtensor.staking.add_stake(
+            wallet=alice_wallet,
+            netuid=alice_sn.netuid,
+            hotkey_ss58=alice_wallet.hotkey.ss58_address,
+            amount=Balance.from_tao(5),
+        )
+    ).success
+
+    # Record locked_mass before top-up
+    lock_before = await async_subtensor.staking.get_stake_lock(
+        coldkey_ss58=alice_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=alice_wallet.hotkey.ss58_address,
+    )
+    locked_mass_before = lock_before["locked_mass"].rao
+    logging.console.info(f"Locked mass before top-up: {locked_mass_before}")
+
+    # Top-up lock on own hotkey
+    top_up_amount = Balance.from_tao(2).set_unit(alice_sn.netuid)
+    response = await async_subtensor.staking.lock_stake(
+        wallet=alice_wallet,
+        hotkey_ss58=alice_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+        amount=top_up_amount,
+    )
+    logging.console.info(f"Top-up lock response: {response}")
+    assert response.success
+
+    # Verify locked_mass increased
+    lock_after = await async_subtensor.staking.get_stake_lock(
+        coldkey_ss58=alice_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=alice_wallet.hotkey.ss58_address,
+    )
+    logging.console.info(f"Locked mass after top-up: {lock_after['locked_mass'].rao}")
+    assert lock_after["locked_mass"].rao > locked_mass_before
+
+    # Unstaking within available limit should succeed without affecting the lock
+    small_amount = Balance.from_tao(1).set_unit(alice_sn.netuid)
+    response = await async_subtensor.staking.unstake(
+        wallet=alice_wallet,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=alice_wallet.hotkey.ss58_address,
+        amount=small_amount,
+    )
+    logging.console.info(f"Unstake small amount response: {response}")
+    assert response.success
+
+    # Unstake must not reduce locked_mass (may grow due to auto_lock_owner_cut between blocks)
+    lock_unchanged = await async_subtensor.staking.get_stake_lock(
+        coldkey_ss58=alice_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=alice_wallet.hotkey.ss58_address,
+    )
+    assert lock_unchanged["locked_mass"].rao >= lock_after["locked_mass"].rao
+
+
+def test_non_owner_lock_lifecycle(subtensor, alice_wallet, bob_wallet, charlie_wallet):
+    """
+    Tests non-owner lock lifecycle from scratch.
+
+    1. No locks exist initially for non-owner
+    2. Fail to lock without sufficient stake (InsufficientStakeForLock)
+    3. Add stake and lock successfully
+    4. Verify lock state (locked_mass, conviction near zero)
+    5. Fail to lock on a different hotkey (LockHotkeyMismatch)
+    6. Top-up lock on same hotkey
+    7. Fail to unstake more than available (total - locked_mass)
+    8. Successfully unstake within available limit
+    """
+    alice_sn = TestSubnet(subtensor)
+    steps = [
+        REGISTER_SUBNET(alice_wallet),
+        ACTIVATE_SUBNET(alice_wallet),
+        REGISTER_NEURON(bob_wallet),
+        REGISTER_NEURON(charlie_wallet),
+    ]
+    alice_sn.execute_steps(steps)
+
+    # Bob has no locks initially
+    locks = subtensor.staking.get_stake_locks(
+        coldkey_ss58=bob_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    assert len(locks) == 0
+
+    # Locking without stake should fail
+    lock_amount = Balance.from_tao(1).set_unit(alice_sn.netuid)
+    response = subtensor.staking.lock_stake(
+        wallet=bob_wallet,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+        amount=lock_amount,
+    )
+    logging.console.info(f"Lock without stake response: {response}")
+    assert response.success is False
+
+    # Add stake for Bob
+    assert subtensor.staking.add_stake(
+        wallet=bob_wallet,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        amount=Balance.from_tao(5),
+    ).success
+
+    # Now lock should succeed
+    first_lock = Balance.from_tao(1).set_unit(alice_sn.netuid)
+    response = subtensor.staking.lock_stake(
+        wallet=bob_wallet,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+        amount=first_lock,
+    )
+    logging.console.info(f"First lock response: {response}")
+    assert response.success
+
+    # Verify lock state
+    lock_info = subtensor.staking.get_stake_lock(
+        coldkey_ss58=bob_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+    )
+    logging.console.info(f"Bob lock info: {lock_info}")
+    assert lock_info is not None
+    assert lock_info["locked_mass"].rao == first_lock.rao
+    assert lock_info["conviction"] < 1.0
+    assert lock_info["last_update"] > 0
+
+    # Hotkey conviction should be near zero for a fresh non-owner lock
+    conviction = subtensor.staking.get_hotkey_conviction(
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    logging.console.info(f"Bob hotkey conviction: {conviction}")
+    assert isinstance(conviction, float)
+
+    # Locking on a different hotkey should fail (LockHotkeyMismatch)
+    response = subtensor.staking.lock_stake(
+        wallet=bob_wallet,
+        hotkey_ss58=charlie_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+        amount=Balance.from_tao(1).set_unit(alice_sn.netuid),
+    )
+    logging.console.info(f"Lock on different hotkey response: {response}")
+    assert response.success is False
+
+    # Top-up on same hotkey should succeed
+    second_lock = Balance.from_tao(1).set_unit(alice_sn.netuid)
+    response = subtensor.staking.lock_stake(
+        wallet=bob_wallet,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+        amount=second_lock,
+    )
+    assert response.success
+
+    # Verify locked_mass increased (not exact due to decay between blocks)
+    lock_info = subtensor.staking.get_stake_lock(
+        coldkey_ss58=bob_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+    )
+    logging.console.info(
+        f"Bob locked_mass after top-up: {lock_info['locked_mass'].rao}, "
+        f"first_lock: {first_lock.rao}"
+    )
+    assert lock_info["locked_mass"].rao > first_lock.rao
+
+    # Unstaking more than available should fail
+    total_stake = subtensor.staking.get_stake(
+        coldkey_ss58=bob_wallet.coldkey.ss58_address,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    response = subtensor.staking.unstake(
+        wallet=bob_wallet,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        amount=total_stake,
+    )
+    logging.console.info(f"Unstake all response: {response}")
+    assert response.success is False
+
+    # Unstaking a small amount within available limit should succeed
+    small_amount = Balance.from_tao(1).set_unit(alice_sn.netuid)
+    available = total_stake.rao - lock_info["locked_mass"].rao
+    if available > small_amount.rao:
+        response = subtensor.staking.unstake(
+            wallet=bob_wallet,
+            netuid=alice_sn.netuid,
+            hotkey_ss58=bob_wallet.hotkey.ss58_address,
+            amount=small_amount,
+        )
+        logging.console.info(f"Unstake small amount response: {response}")
+        assert response.success
+
+
+@pytest.mark.asyncio
+async def test_non_owner_lock_lifecycle_async(
+    async_subtensor, alice_wallet, bob_wallet, charlie_wallet
+):
+    """
+    Async version: Tests non-owner lock lifecycle from scratch.
+
+    1. No locks exist initially for non-owner
+    2. Fail to lock without sufficient stake (InsufficientStakeForLock)
+    3. Add stake and lock successfully
+    4. Verify lock state (locked_mass, conviction near zero)
+    5. Fail to lock on a different hotkey (LockHotkeyMismatch)
+    6. Top-up lock on same hotkey
+    7. Fail to unstake more than available (total - locked_mass)
+    8. Successfully unstake within available limit
+    """
+    alice_sn = TestSubnet(async_subtensor)
+    steps = [
+        REGISTER_SUBNET(alice_wallet),
+        ACTIVATE_SUBNET(alice_wallet),
+        REGISTER_NEURON(bob_wallet),
+        REGISTER_NEURON(charlie_wallet),
+    ]
+    await alice_sn.async_execute_steps(steps)
+
+    # Bob has no locks initially
+    locks = await async_subtensor.staking.get_stake_locks(
+        coldkey_ss58=bob_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    assert len(locks) == 0
+
+    # Locking without stake should fail
+    lock_amount = Balance.from_tao(1).set_unit(alice_sn.netuid)
+    response = await async_subtensor.staking.lock_stake(
+        wallet=bob_wallet,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+        amount=lock_amount,
+    )
+    logging.console.info(f"Lock without stake response: {response}")
+    assert response.success is False
+
+    # Add stake for Bob
+    assert (
+        await async_subtensor.staking.add_stake(
+            wallet=bob_wallet,
+            netuid=alice_sn.netuid,
+            hotkey_ss58=bob_wallet.hotkey.ss58_address,
+            amount=Balance.from_tao(5),
+        )
+    ).success
+
+    # Now lock should succeed
+    first_lock = Balance.from_tao(1).set_unit(alice_sn.netuid)
+    response = await async_subtensor.staking.lock_stake(
+        wallet=bob_wallet,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+        amount=first_lock,
+    )
+    logging.console.info(f"First lock response: {response}")
+    assert response.success
+
+    # Verify lock state
+    lock_info = await async_subtensor.staking.get_stake_lock(
+        coldkey_ss58=bob_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+    )
+    logging.console.info(f"Bob lock info: {lock_info}")
+    assert lock_info is not None
+    assert lock_info["locked_mass"].rao == first_lock.rao
+    assert lock_info["conviction"] < 1.0
+    assert lock_info["last_update"] > 0
+
+    # Hotkey conviction should be near zero for a fresh non-owner lock
+    conviction = await async_subtensor.staking.get_hotkey_conviction(
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    logging.console.info(f"Bob hotkey conviction: {conviction}")
+    assert isinstance(conviction, float)
+
+    # Locking on a different hotkey should fail (LockHotkeyMismatch)
+    response = await async_subtensor.staking.lock_stake(
+        wallet=bob_wallet,
+        hotkey_ss58=charlie_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+        amount=Balance.from_tao(1).set_unit(alice_sn.netuid),
+    )
+    logging.console.info(f"Lock on different hotkey response: {response}")
+    assert response.success is False
+
+    # Top-up on same hotkey should succeed
+    second_lock = Balance.from_tao(1).set_unit(alice_sn.netuid)
+    response = await async_subtensor.staking.lock_stake(
+        wallet=bob_wallet,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+        amount=second_lock,
+    )
+    assert response.success
+
+    # Verify locked_mass increased (not exact due to decay between blocks)
+    lock_info = await async_subtensor.staking.get_stake_lock(
+        coldkey_ss58=bob_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+    )
+    logging.console.info(
+        f"Bob locked_mass after top-up: {lock_info['locked_mass'].rao}, "
+        f"first_lock: {first_lock.rao}"
+    )
+    assert lock_info["locked_mass"].rao > first_lock.rao
+
+    # Unstaking more than available should fail
+    total_stake = await async_subtensor.staking.get_stake(
+        coldkey_ss58=bob_wallet.coldkey.ss58_address,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    response = await async_subtensor.staking.unstake(
+        wallet=bob_wallet,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        amount=total_stake,
+    )
+    logging.console.info(f"Unstake all response: {response}")
+    assert response.success is False
+
+    # Unstaking a small amount within available limit should succeed
+    small_amount = Balance.from_tao(1).set_unit(alice_sn.netuid)
+    available = total_stake.rao - lock_info["locked_mass"].rao
+    if available > small_amount.rao:
+        response = await async_subtensor.staking.unstake(
+            wallet=bob_wallet,
+            netuid=alice_sn.netuid,
+            hotkey_ss58=bob_wallet.hotkey.ss58_address,
+            amount=small_amount,
+        )
+        logging.console.info(f"Unstake small amount response: {response}")
+        assert response.success
+
+
+def test_move_lock(subtensor, alice_wallet, bob_wallet, charlie_wallet):
+    """
+    Tests move_lock functionality.
+
+    1. Fail to move when no lock exists (NoExistingLock)
+    2. Create a lock for Bob, then move it to Charlie's hotkey
+    3. Verify lock moved: old hotkey has None, new hotkey has lock
+    4. Owner moves their auto-lock to a different hotkey
+    5. Verify owner lock moved successfully
+    """
+    alice_sn = TestSubnet(subtensor)
+    steps = [
+        REGISTER_SUBNET(alice_wallet),
+        ACTIVATE_SUBNET(alice_wallet),
+        REGISTER_NEURON(bob_wallet),
+        REGISTER_NEURON(charlie_wallet),
+    ]
+    alice_sn.execute_steps(steps)
+
+    # Moving without a lock should fail
+    response = subtensor.staking.move_lock(
+        wallet=bob_wallet,
+        destination_hotkey_ss58=charlie_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    logging.console.info(f"Move lock without existing lock: {response}")
+    assert response.success is False
+
+    # Create a lock for Bob
+    assert subtensor.staking.add_stake(
+        wallet=bob_wallet,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        amount=Balance.from_tao(5),
+    ).success
+
+    lock_amount = Balance.from_tao(2).set_unit(alice_sn.netuid)
+    assert subtensor.staking.lock_stake(
+        wallet=bob_wallet,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+        amount=lock_amount,
+    ).success
+
+    # Verify lock exists on Bob's hotkey
+    lock_before = subtensor.staking.get_stake_lock(
+        coldkey_ss58=bob_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+    )
+    assert lock_before is not None
+    logging.console.info(f"Bob lock before move: {lock_before}")
+
+    # Move lock from Bob's hotkey to Charlie's hotkey
+    response = subtensor.staking.move_lock(
+        wallet=bob_wallet,
+        destination_hotkey_ss58=charlie_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    logging.console.info(f"Move lock response: {response}")
+    assert response.success
+
+    # Old hotkey should have no lock
+    old_lock = subtensor.staking.get_stake_lock(
+        coldkey_ss58=bob_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+    )
+    assert old_lock is None
+
+    # New hotkey should have the lock
+    new_lock = subtensor.staking.get_stake_lock(
+        coldkey_ss58=bob_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=charlie_wallet.hotkey.ss58_address,
+    )
+    assert new_lock is not None
+    assert new_lock["locked_mass"].rao <= lock_amount.rao
+    assert new_lock["locked_mass"].rao > lock_amount.rao * 0.99
+    logging.console.info(f"Bob lock after move: {new_lock}")
+
+    # Owner move: wait for emission so owner has auto-lock
+    next_epoch = subtensor.subnets.get_next_epoch_start_block(alice_sn.netuid)
+    subtensor.wait_for_block(next_epoch + 1)
+
+    owner_lock = subtensor.staking.get_stake_lock(
+        coldkey_ss58=alice_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=alice_wallet.hotkey.ss58_address,
+    )
+    logging.console.info(f"Owner lock before move: {owner_lock}")
+    assert owner_lock is not None
+
+    # Owner moves lock to Bob's hotkey
+    response = subtensor.staking.move_lock(
+        wallet=alice_wallet,
+        destination_hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    logging.console.info(f"Owner move lock response: {response}")
+    assert response.success
+
+    # Owner lock should no longer be on alice's hotkey
+    old_owner_lock = subtensor.staking.get_stake_lock(
+        coldkey_ss58=alice_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=alice_wallet.hotkey.ss58_address,
+    )
+    assert old_owner_lock is None
+
+    # Owner lock should now be on Bob's hotkey
+    new_owner_lock = subtensor.staking.get_stake_lock(
+        coldkey_ss58=alice_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+    )
+    assert new_owner_lock is not None
+    logging.console.info(f"Owner lock after move: {new_owner_lock}")
+
+
+@pytest.mark.asyncio
+async def test_move_lock_async(
+    async_subtensor, alice_wallet, bob_wallet, charlie_wallet
+):
+    """
+    Async version: Tests move_lock functionality.
+
+    1. Fail to move when no lock exists (NoExistingLock)
+    2. Create a lock for Bob, then move it to Charlie's hotkey
+    3. Verify lock moved: old hotkey has None, new hotkey has lock
+    4. Owner moves their auto-lock to a different hotkey
+    5. Verify owner lock moved successfully
+    """
+    alice_sn = TestSubnet(async_subtensor)
+    steps = [
+        REGISTER_SUBNET(alice_wallet),
+        ACTIVATE_SUBNET(alice_wallet),
+        REGISTER_NEURON(bob_wallet),
+        REGISTER_NEURON(charlie_wallet),
+    ]
+    await alice_sn.async_execute_steps(steps)
+
+    # Moving without a lock should fail
+    response = await async_subtensor.staking.move_lock(
+        wallet=bob_wallet,
+        destination_hotkey_ss58=charlie_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    logging.console.info(f"Move lock without existing lock: {response}")
+    assert response.success is False
+
+    # Create a lock for Bob
+    assert (
+        await async_subtensor.staking.add_stake(
+            wallet=bob_wallet,
+            netuid=alice_sn.netuid,
+            hotkey_ss58=bob_wallet.hotkey.ss58_address,
+            amount=Balance.from_tao(5),
+        )
+    ).success
+
+    lock_amount = Balance.from_tao(2).set_unit(alice_sn.netuid)
+    assert (
+        await async_subtensor.staking.lock_stake(
+            wallet=bob_wallet,
+            hotkey_ss58=bob_wallet.hotkey.ss58_address,
+            netuid=alice_sn.netuid,
+            amount=lock_amount,
+        )
+    ).success
+
+    # Verify lock exists on Bob's hotkey
+    lock_before = await async_subtensor.staking.get_stake_lock(
+        coldkey_ss58=bob_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+    )
+    assert lock_before is not None
+    logging.console.info(f"Bob lock before move: {lock_before}")
+
+    # Move lock from Bob's hotkey to Charlie's hotkey
+    response = await async_subtensor.staking.move_lock(
+        wallet=bob_wallet,
+        destination_hotkey_ss58=charlie_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    logging.console.info(f"Move lock response: {response}")
+    assert response.success
+
+    # Old hotkey should have no lock
+    old_lock = await async_subtensor.staking.get_stake_lock(
+        coldkey_ss58=bob_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+    )
+    assert old_lock is None
+
+    # New hotkey should have the lock
+    new_lock = await async_subtensor.staking.get_stake_lock(
+        coldkey_ss58=bob_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=charlie_wallet.hotkey.ss58_address,
+    )
+    assert new_lock is not None
+    assert new_lock["locked_mass"].rao <= lock_amount.rao
+    assert new_lock["locked_mass"].rao > lock_amount.rao * 0.99
+    logging.console.info(f"Bob lock after move: {new_lock}")
+
+    # Owner move: wait for emission so owner has auto-lock
+    next_epoch = await async_subtensor.subnets.get_next_epoch_start_block(
+        alice_sn.netuid
+    )
+    await async_subtensor.wait_for_block(next_epoch + 1)
+
+    owner_lock = await async_subtensor.staking.get_stake_lock(
+        coldkey_ss58=alice_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=alice_wallet.hotkey.ss58_address,
+    )
+    logging.console.info(f"Owner lock before move: {owner_lock}")
+    assert owner_lock is not None
+
+    # Owner moves lock to Bob's hotkey
+    response = await async_subtensor.staking.move_lock(
+        wallet=alice_wallet,
+        destination_hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    logging.console.info(f"Owner move lock response: {response}")
+    assert response.success
+
+    # Owner lock should no longer be on alice's hotkey
+    old_owner_lock = await async_subtensor.staking.get_stake_lock(
+        coldkey_ss58=alice_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=alice_wallet.hotkey.ss58_address,
+    )
+    assert old_owner_lock is None
+
+    # Owner lock should now be on Bob's hotkey
+    new_owner_lock = await async_subtensor.staking.get_stake_lock(
+        coldkey_ss58=alice_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+    )
+    assert new_owner_lock is not None
+    logging.console.info(f"Owner lock after move: {new_owner_lock}")
+
+
+def test_perpetual_lock_toggle(subtensor, alice_wallet, bob_wallet):
+    """
+    Tests set_perpetual_lock toggle for both owner and non-owner.
+
+    1. Locks are decaying by default (is_perpetual_lock returns False)
+    2. Toggle to perpetual via set_perpetual_lock(enabled=True), verify
+    3. Toggle back to decaying via set_perpetual_lock(enabled=False), verify
+    4. Non-owner creates a lock, toggles to perpetual, verify
+    """
+    alice_sn = TestSubnet(subtensor)
+    steps = [
+        REGISTER_SUBNET(alice_wallet),
+        ACTIVATE_SUBNET(alice_wallet),
+        REGISTER_NEURON(bob_wallet),
+    ]
+    alice_sn.execute_steps(steps)
+
+    # Owner lock is decaying by default
+    is_perpetual = subtensor.staking.is_perpetual_lock(
+        coldkey_ss58=alice_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    assert is_perpetual is False
+
+    # Set to perpetual
+    response = subtensor.staking.set_perpetual_lock(
+        wallet=alice_wallet,
+        netuid=alice_sn.netuid,
+        enabled=True,
+    )
+    logging.console.info(f"Set perpetual=True response: {response}")
+    assert response.success
+
+    is_perpetual = subtensor.staking.is_perpetual_lock(
+        coldkey_ss58=alice_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    assert is_perpetual is True
+
+    # Set back to decaying
+    response = subtensor.staking.set_perpetual_lock(
+        wallet=alice_wallet,
+        netuid=alice_sn.netuid,
+        enabled=False,
+    )
+    logging.console.info(f"Set perpetual=False response: {response}")
+    assert response.success
+
+    is_perpetual = subtensor.staking.is_perpetual_lock(
+        coldkey_ss58=alice_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    assert is_perpetual is False
+
+    # Non-owner: Bob is also decaying by default
+    is_perpetual = subtensor.staking.is_perpetual_lock(
+        coldkey_ss58=bob_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    assert is_perpetual is False
+
+    # Bob creates a lock and sets it to perpetual
+    assert subtensor.staking.add_stake(
+        wallet=bob_wallet,
+        netuid=alice_sn.netuid,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        amount=Balance.from_tao(3),
+    ).success
+
+    assert subtensor.staking.lock_stake(
+        wallet=bob_wallet,
+        hotkey_ss58=bob_wallet.hotkey.ss58_address,
+        netuid=alice_sn.netuid,
+        amount=Balance.from_tao(1).set_unit(alice_sn.netuid),
+    ).success
+
+    response = subtensor.staking.set_perpetual_lock(
+        wallet=bob_wallet,
+        netuid=alice_sn.netuid,
+        enabled=True,
+    )
+    assert response.success
+
+    is_perpetual = subtensor.staking.is_perpetual_lock(
+        coldkey_ss58=bob_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    assert is_perpetual is True
+
+
+@pytest.mark.asyncio
+async def test_perpetual_lock_toggle_async(async_subtensor, alice_wallet, bob_wallet):
+    """
+    Async version: Tests set_perpetual_lock toggle for both owner and non-owner.
+
+    1. Locks are decaying by default (is_perpetual_lock returns False)
+    2. Toggle to perpetual via set_perpetual_lock(enabled=True), verify
+    3. Toggle back to decaying via set_perpetual_lock(enabled=False), verify
+    4. Non-owner creates a lock, toggles to perpetual, verify
+    """
+    alice_sn = TestSubnet(async_subtensor)
+    steps = [
+        REGISTER_SUBNET(alice_wallet),
+        ACTIVATE_SUBNET(alice_wallet),
+        REGISTER_NEURON(bob_wallet),
+    ]
+    await alice_sn.async_execute_steps(steps)
+
+    # Owner lock is decaying by default
+    is_perpetual = await async_subtensor.staking.is_perpetual_lock(
+        coldkey_ss58=alice_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    assert is_perpetual is False
+
+    # Set to perpetual
+    response = await async_subtensor.staking.set_perpetual_lock(
+        wallet=alice_wallet,
+        netuid=alice_sn.netuid,
+        enabled=True,
+    )
+    logging.console.info(f"Set perpetual=True response: {response}")
+    assert response.success
+
+    is_perpetual = await async_subtensor.staking.is_perpetual_lock(
+        coldkey_ss58=alice_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    assert is_perpetual is True
+
+    # Set back to decaying
+    response = await async_subtensor.staking.set_perpetual_lock(
+        wallet=alice_wallet,
+        netuid=alice_sn.netuid,
+        enabled=False,
+    )
+    logging.console.info(f"Set perpetual=False response: {response}")
+    assert response.success
+
+    is_perpetual = await async_subtensor.staking.is_perpetual_lock(
+        coldkey_ss58=alice_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    assert is_perpetual is False
+
+    # Non-owner: Bob is also decaying by default
+    is_perpetual = await async_subtensor.staking.is_perpetual_lock(
+        coldkey_ss58=bob_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    assert is_perpetual is False
+
+    # Bob creates a lock and sets it to perpetual
+    assert (
+        await async_subtensor.staking.add_stake(
+            wallet=bob_wallet,
+            netuid=alice_sn.netuid,
+            hotkey_ss58=bob_wallet.hotkey.ss58_address,
+            amount=Balance.from_tao(3),
+        )
+    ).success
+
+    assert (
+        await async_subtensor.staking.lock_stake(
+            wallet=bob_wallet,
+            hotkey_ss58=bob_wallet.hotkey.ss58_address,
+            netuid=alice_sn.netuid,
+            amount=Balance.from_tao(1).set_unit(alice_sn.netuid),
+        )
+    ).success
+
+    response = await async_subtensor.staking.set_perpetual_lock(
+        wallet=bob_wallet,
+        netuid=alice_sn.netuid,
+        enabled=True,
+    )
+    assert response.success
+
+    is_perpetual = await async_subtensor.staking.is_perpetual_lock(
+        coldkey_ss58=bob_wallet.coldkey.ss58_address,
+        netuid=alice_sn.netuid,
+    )
+    assert is_perpetual is True

--- a/tests/unit_tests/extrinsics/asyncex/test_lock.py
+++ b/tests/unit_tests/extrinsics/asyncex/test_lock.py
@@ -1,0 +1,365 @@
+import pytest
+
+from bittensor.core.extrinsics.asyncex import lock
+from bittensor.core.types import ExtrinsicResponse
+from bittensor.utils.balance import Balance
+
+
+@pytest.mark.asyncio
+async def test_lock_stake_extrinsic(mocker):
+    """Verify that async lock_stake_extrinsic composes correct call and submits it."""
+    # Preps
+    fake_subtensor = mocker.AsyncMock(
+        **{
+            "sign_and_send_extrinsic.return_value": ExtrinsicResponse(True, "Success"),
+        }
+    )
+    fake_wallet = mocker.Mock()
+    hotkey_ss58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+    netuid = 1
+    amount = Balance.from_tao(5)
+
+    result = await lock.lock_stake_extrinsic(
+        subtensor=fake_subtensor,
+        wallet=fake_wallet,
+        hotkey_ss58=hotkey_ss58,
+        netuid=netuid,
+        amount=amount,
+        mev_protection=False,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+    )
+
+    # Asserts
+    assert result.success is True
+    fake_subtensor.compose_call.assert_awaited_once_with(
+        call_module="SubtensorModule",
+        call_function="lock_stake",
+        call_params={
+            "hotkey": hotkey_ss58,
+            "netuid": netuid,
+            "amount": amount.rao,
+        },
+    )
+    fake_subtensor.sign_and_send_extrinsic.assert_awaited_once_with(
+        call=fake_subtensor.compose_call.return_value,
+        wallet=fake_wallet,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+        period=None,
+        raise_error=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_lock_stake_extrinsic_mev_protection(mocker):
+    """Verify that async lock_stake_extrinsic uses submit_encrypted_extrinsic when mev_protection=True."""
+    # Preps
+    fake_subtensor = mocker.AsyncMock()
+    fake_wallet = mocker.Mock()
+    hotkey_ss58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+    netuid = 1
+    amount = Balance.from_tao(5)
+
+    mock_submit = mocker.patch(
+        "bittensor.core.extrinsics.asyncex.lock.submit_encrypted_extrinsic",
+        new_callable=mocker.AsyncMock,
+        return_value=ExtrinsicResponse(True, "Success"),
+    )
+
+    result = await lock.lock_stake_extrinsic(
+        subtensor=fake_subtensor,
+        wallet=fake_wallet,
+        hotkey_ss58=hotkey_ss58,
+        netuid=netuid,
+        amount=amount,
+        mev_protection=True,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+        wait_for_revealed_execution=True,
+    )
+
+    # Asserts
+    assert result.success is True
+    mock_submit.assert_awaited_once_with(
+        subtensor=fake_subtensor,
+        wallet=fake_wallet,
+        call=fake_subtensor.compose_call.return_value,
+        period=None,
+        raise_error=False,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+        wait_for_revealed_execution=True,
+    )
+    fake_subtensor.sign_and_send_extrinsic.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_move_lock_extrinsic(mocker):
+    """Verify that async move_lock_extrinsic composes correct call and submits it."""
+    # Preps
+    fake_subtensor = mocker.AsyncMock(
+        **{
+            "sign_and_send_extrinsic.return_value": ExtrinsicResponse(True, "Success"),
+        }
+    )
+    fake_wallet = mocker.Mock()
+    destination_hotkey_ss58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+    netuid = 2
+
+    result = await lock.move_lock_extrinsic(
+        subtensor=fake_subtensor,
+        wallet=fake_wallet,
+        destination_hotkey_ss58=destination_hotkey_ss58,
+        netuid=netuid,
+        mev_protection=False,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+    )
+
+    # Asserts
+    assert result.success is True
+    fake_subtensor.compose_call.assert_awaited_once_with(
+        call_module="SubtensorModule",
+        call_function="move_lock",
+        call_params={
+            "destination_hotkey": destination_hotkey_ss58,
+            "netuid": netuid,
+        },
+    )
+    fake_subtensor.sign_and_send_extrinsic.assert_awaited_once_with(
+        call=fake_subtensor.compose_call.return_value,
+        wallet=fake_wallet,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+        period=None,
+        raise_error=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_move_lock_extrinsic_mev_protection(mocker):
+    """Verify that async move_lock_extrinsic uses submit_encrypted_extrinsic when mev_protection=True."""
+    # Preps
+    fake_subtensor = mocker.AsyncMock()
+    fake_wallet = mocker.Mock()
+    destination_hotkey_ss58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+    netuid = 2
+
+    mock_submit = mocker.patch(
+        "bittensor.core.extrinsics.asyncex.lock.submit_encrypted_extrinsic",
+        new_callable=mocker.AsyncMock,
+        return_value=ExtrinsicResponse(True, "Success"),
+    )
+
+    result = await lock.move_lock_extrinsic(
+        subtensor=fake_subtensor,
+        wallet=fake_wallet,
+        destination_hotkey_ss58=destination_hotkey_ss58,
+        netuid=netuid,
+        mev_protection=True,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+        wait_for_revealed_execution=True,
+    )
+
+    # Asserts
+    assert result.success is True
+    mock_submit.assert_awaited_once_with(
+        subtensor=fake_subtensor,
+        wallet=fake_wallet,
+        call=fake_subtensor.compose_call.return_value,
+        period=None,
+        raise_error=False,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+        wait_for_revealed_execution=True,
+    )
+    fake_subtensor.sign_and_send_extrinsic.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_set_perpetual_lock_extrinsic(mocker):
+    """Verify that async set_perpetual_lock_extrinsic composes correct call and submits it."""
+    # Preps
+    fake_subtensor = mocker.AsyncMock(
+        **{
+            "sign_and_send_extrinsic.return_value": ExtrinsicResponse(True, "Success"),
+        }
+    )
+    fake_wallet = mocker.Mock()
+    netuid = 3
+    enabled = False
+
+    result = await lock.set_perpetual_lock_extrinsic(
+        subtensor=fake_subtensor,
+        wallet=fake_wallet,
+        netuid=netuid,
+        enabled=enabled,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+    )
+
+    # Asserts
+    assert result.success is True
+    fake_subtensor.compose_call.assert_awaited_once_with(
+        call_module="SubtensorModule",
+        call_function="set_perpetual_lock",
+        call_params={
+            "netuid": netuid,
+            "enabled": enabled,
+        },
+    )
+    fake_subtensor.sign_and_send_extrinsic.assert_awaited_once_with(
+        call=fake_subtensor.compose_call.return_value,
+        wallet=fake_wallet,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+        period=None,
+        raise_error=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_lock_stake_wallet_unlock_failure(mocker):
+    """Verify that async lock_stake_extrinsic returns early on wallet unlock failure."""
+    # Preps
+    fake_subtensor = mocker.AsyncMock()
+    fake_wallet = mocker.Mock()
+
+    mocker.patch.object(
+        ExtrinsicResponse,
+        "unlock_wallet",
+        return_value=ExtrinsicResponse(False, "Wallet unlock failed"),
+    )
+
+    result = await lock.lock_stake_extrinsic(
+        subtensor=fake_subtensor,
+        wallet=fake_wallet,
+        hotkey_ss58="hotkey",
+        netuid=1,
+        amount=Balance.from_tao(1),
+    )
+
+    # Asserts
+    assert result.success is False
+    assert "unlock" in result.message.lower()
+    fake_subtensor.compose_call.assert_not_awaited()
+    fake_subtensor.sign_and_send_extrinsic.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_move_lock_wallet_unlock_failure(mocker):
+    """Verify that async move_lock_extrinsic returns early on wallet unlock failure."""
+    # Preps
+    fake_subtensor = mocker.AsyncMock()
+    fake_wallet = mocker.Mock()
+
+    mocker.patch.object(
+        ExtrinsicResponse,
+        "unlock_wallet",
+        return_value=ExtrinsicResponse(False, "Wallet unlock failed"),
+    )
+
+    result = await lock.move_lock_extrinsic(
+        subtensor=fake_subtensor,
+        wallet=fake_wallet,
+        destination_hotkey_ss58="hotkey",
+        netuid=1,
+    )
+
+    # Asserts
+    assert result.success is False
+    assert "unlock" in result.message.lower()
+    fake_subtensor.compose_call.assert_not_awaited()
+    fake_subtensor.sign_and_send_extrinsic.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_set_perpetual_lock_wallet_unlock_failure(mocker):
+    """Verify that async set_perpetual_lock_extrinsic returns early on wallet unlock failure."""
+    # Preps
+    fake_subtensor = mocker.AsyncMock()
+    fake_wallet = mocker.Mock()
+
+    mocker.patch.object(
+        ExtrinsicResponse,
+        "unlock_wallet",
+        return_value=ExtrinsicResponse(False, "Wallet unlock failed"),
+    )
+
+    result = await lock.set_perpetual_lock_extrinsic(
+        subtensor=fake_subtensor,
+        wallet=fake_wallet,
+        netuid=1,
+        enabled=True,
+    )
+
+    # Asserts
+    assert result.success is False
+    assert "unlock" in result.message.lower()
+    fake_subtensor.compose_call.assert_not_awaited()
+    fake_subtensor.sign_and_send_extrinsic.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_lock_stake_extrinsic_exception(mocker):
+    """Verify that async lock_stake_extrinsic handles exceptions gracefully."""
+    # Preps
+    fake_subtensor = mocker.AsyncMock(
+        **{"sign_and_send_extrinsic.side_effect": RuntimeError("chain error")}
+    )
+    fake_wallet = mocker.Mock()
+
+    result = await lock.lock_stake_extrinsic(
+        subtensor=fake_subtensor,
+        wallet=fake_wallet,
+        hotkey_ss58="hotkey",
+        netuid=1,
+        amount=Balance.from_tao(1),
+        mev_protection=False,
+    )
+
+    # Asserts
+    assert result.success is False
+
+
+@pytest.mark.asyncio
+async def test_move_lock_extrinsic_exception(mocker):
+    """Verify that async move_lock_extrinsic handles exceptions gracefully."""
+    # Preps
+    fake_subtensor = mocker.AsyncMock(
+        **{"sign_and_send_extrinsic.side_effect": RuntimeError("chain error")}
+    )
+    fake_wallet = mocker.Mock()
+
+    result = await lock.move_lock_extrinsic(
+        subtensor=fake_subtensor,
+        wallet=fake_wallet,
+        destination_hotkey_ss58="hotkey",
+        netuid=1,
+        mev_protection=False,
+    )
+
+    # Asserts
+    assert result.success is False
+
+
+@pytest.mark.asyncio
+async def test_set_perpetual_lock_extrinsic_exception(mocker):
+    """Verify that async set_perpetual_lock_extrinsic handles exceptions gracefully."""
+    # Preps
+    fake_subtensor = mocker.AsyncMock(
+        **{"sign_and_send_extrinsic.side_effect": RuntimeError("chain error")}
+    )
+    fake_wallet = mocker.Mock()
+
+    result = await lock.set_perpetual_lock_extrinsic(
+        subtensor=fake_subtensor,
+        wallet=fake_wallet,
+        netuid=1,
+        enabled=True,
+    )
+
+    # Asserts
+    assert result.success is False

--- a/tests/unit_tests/extrinsics/test_lock.py
+++ b/tests/unit_tests/extrinsics/test_lock.py
@@ -1,0 +1,329 @@
+from bittensor.core.extrinsics import lock
+from bittensor.core.types import ExtrinsicResponse
+from bittensor.utils.balance import Balance
+
+
+def test_lock_stake_extrinsic(mocker):
+    """Verify that lock_stake_extrinsic composes correct call and submits it."""
+    fake_subtensor = mocker.Mock(
+        **{
+            "sign_and_send_extrinsic.return_value": ExtrinsicResponse(True, "Success"),
+        }
+    )
+    fake_wallet = mocker.Mock()
+    hotkey_ss58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+    netuid = 1
+    amount = Balance.from_tao(5)
+
+    result = lock.lock_stake_extrinsic(
+        subtensor=fake_subtensor,
+        wallet=fake_wallet,
+        hotkey_ss58=hotkey_ss58,
+        netuid=netuid,
+        amount=amount,
+        mev_protection=False,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+    )
+
+    assert result.success is True
+    fake_subtensor.compose_call.assert_called_once_with(
+        call_module="SubtensorModule",
+        call_function="lock_stake",
+        call_params={
+            "hotkey": hotkey_ss58,
+            "netuid": netuid,
+            "amount": amount.rao,
+        },
+    )
+    fake_subtensor.sign_and_send_extrinsic.assert_called_once_with(
+        call=fake_subtensor.compose_call.return_value,
+        wallet=fake_wallet,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+        period=None,
+        raise_error=False,
+    )
+
+
+def test_lock_stake_extrinsic_mev_protection(mocker):
+    """Verify that lock_stake_extrinsic uses submit_encrypted_extrinsic when mev_protection=True."""
+    fake_subtensor = mocker.Mock()
+    fake_wallet = mocker.Mock()
+    hotkey_ss58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+    netuid = 1
+    amount = Balance.from_tao(5)
+
+    mock_submit = mocker.patch(
+        "bittensor.core.extrinsics.lock.submit_encrypted_extrinsic",
+        return_value=ExtrinsicResponse(True, "Success"),
+    )
+
+    result = lock.lock_stake_extrinsic(
+        subtensor=fake_subtensor,
+        wallet=fake_wallet,
+        hotkey_ss58=hotkey_ss58,
+        netuid=netuid,
+        amount=amount,
+        mev_protection=True,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+        wait_for_revealed_execution=True,
+    )
+
+    assert result.success is True
+    mock_submit.assert_called_once_with(
+        subtensor=fake_subtensor,
+        wallet=fake_wallet,
+        call=fake_subtensor.compose_call.return_value,
+        period=None,
+        raise_error=False,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+        wait_for_revealed_execution=True,
+    )
+    fake_subtensor.sign_and_send_extrinsic.assert_not_called()
+
+
+def test_move_lock_extrinsic(mocker):
+    """Verify that move_lock_extrinsic composes correct call and submits it."""
+    fake_subtensor = mocker.Mock(
+        **{
+            "sign_and_send_extrinsic.return_value": ExtrinsicResponse(True, "Success"),
+        }
+    )
+    fake_wallet = mocker.Mock()
+    destination_hotkey_ss58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+    netuid = 2
+
+    result = lock.move_lock_extrinsic(
+        subtensor=fake_subtensor,
+        wallet=fake_wallet,
+        destination_hotkey_ss58=destination_hotkey_ss58,
+        netuid=netuid,
+        mev_protection=False,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+    )
+
+    assert result.success is True
+    fake_subtensor.compose_call.assert_called_once_with(
+        call_module="SubtensorModule",
+        call_function="move_lock",
+        call_params={
+            "destination_hotkey": destination_hotkey_ss58,
+            "netuid": netuid,
+        },
+    )
+    fake_subtensor.sign_and_send_extrinsic.assert_called_once_with(
+        call=fake_subtensor.compose_call.return_value,
+        wallet=fake_wallet,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+        period=None,
+        raise_error=False,
+    )
+
+
+def test_move_lock_extrinsic_mev_protection(mocker):
+    """Verify that move_lock_extrinsic uses submit_encrypted_extrinsic when mev_protection=True."""
+    fake_subtensor = mocker.Mock()
+    fake_wallet = mocker.Mock()
+    destination_hotkey_ss58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+    netuid = 2
+
+    mock_submit = mocker.patch(
+        "bittensor.core.extrinsics.lock.submit_encrypted_extrinsic",
+        return_value=ExtrinsicResponse(True, "Success"),
+    )
+
+    result = lock.move_lock_extrinsic(
+        subtensor=fake_subtensor,
+        wallet=fake_wallet,
+        destination_hotkey_ss58=destination_hotkey_ss58,
+        netuid=netuid,
+        mev_protection=True,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+        wait_for_revealed_execution=True,
+    )
+
+    assert result.success is True
+    mock_submit.assert_called_once_with(
+        subtensor=fake_subtensor,
+        wallet=fake_wallet,
+        call=fake_subtensor.compose_call.return_value,
+        period=None,
+        raise_error=False,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+        wait_for_revealed_execution=True,
+    )
+    fake_subtensor.sign_and_send_extrinsic.assert_not_called()
+
+
+def test_set_perpetual_lock_extrinsic(mocker):
+    """Verify that set_perpetual_lock_extrinsic composes correct call and submits it."""
+    fake_subtensor = mocker.Mock(
+        **{
+            "sign_and_send_extrinsic.return_value": ExtrinsicResponse(True, "Success"),
+        }
+    )
+    fake_wallet = mocker.Mock()
+    netuid = 3
+    enabled = False
+
+    result = lock.set_perpetual_lock_extrinsic(
+        subtensor=fake_subtensor,
+        wallet=fake_wallet,
+        netuid=netuid,
+        enabled=enabled,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+    )
+
+    assert result.success is True
+    fake_subtensor.compose_call.assert_called_once_with(
+        call_module="SubtensorModule",
+        call_function="set_perpetual_lock",
+        call_params={
+            "netuid": netuid,
+            "enabled": enabled,
+        },
+    )
+    fake_subtensor.sign_and_send_extrinsic.assert_called_once_with(
+        call=fake_subtensor.compose_call.return_value,
+        wallet=fake_wallet,
+        wait_for_inclusion=True,
+        wait_for_finalization=True,
+        period=None,
+        raise_error=False,
+    )
+
+
+def test_lock_stake_wallet_unlock_failure(mocker):
+    """Verify that lock_stake_extrinsic returns early on wallet unlock failure."""
+    fake_subtensor = mocker.Mock()
+    fake_wallet = mocker.Mock()
+    amount = Balance.from_tao(1)
+
+    mocker.patch.object(
+        ExtrinsicResponse,
+        "unlock_wallet",
+        return_value=ExtrinsicResponse(False, "Wallet unlock failed"),
+    )
+
+    result = lock.lock_stake_extrinsic(
+        subtensor=fake_subtensor,
+        wallet=fake_wallet,
+        hotkey_ss58="hotkey",
+        netuid=1,
+        amount=amount,
+    )
+
+    assert result.success is False
+    assert "unlock" in result.message.lower()
+    fake_subtensor.compose_call.assert_not_called()
+    fake_subtensor.sign_and_send_extrinsic.assert_not_called()
+
+
+def test_move_lock_wallet_unlock_failure(mocker):
+    """Verify that move_lock_extrinsic returns early on wallet unlock failure."""
+    fake_subtensor = mocker.Mock()
+    fake_wallet = mocker.Mock()
+
+    mocker.patch.object(
+        ExtrinsicResponse,
+        "unlock_wallet",
+        return_value=ExtrinsicResponse(False, "Wallet unlock failed"),
+    )
+
+    result = lock.move_lock_extrinsic(
+        subtensor=fake_subtensor,
+        wallet=fake_wallet,
+        destination_hotkey_ss58="hotkey",
+        netuid=1,
+    )
+
+    assert result.success is False
+    assert "unlock" in result.message.lower()
+    fake_subtensor.compose_call.assert_not_called()
+    fake_subtensor.sign_and_send_extrinsic.assert_not_called()
+
+
+def test_set_perpetual_lock_wallet_unlock_failure(mocker):
+    """Verify that set_perpetual_lock_extrinsic returns early on wallet unlock failure."""
+    fake_subtensor = mocker.Mock()
+    fake_wallet = mocker.Mock()
+
+    mocker.patch.object(
+        ExtrinsicResponse,
+        "unlock_wallet",
+        return_value=ExtrinsicResponse(False, "Wallet unlock failed"),
+    )
+
+    result = lock.set_perpetual_lock_extrinsic(
+        subtensor=fake_subtensor,
+        wallet=fake_wallet,
+        netuid=1,
+        enabled=True,
+    )
+
+    assert result.success is False
+    assert "unlock" in result.message.lower()
+    fake_subtensor.compose_call.assert_not_called()
+    fake_subtensor.sign_and_send_extrinsic.assert_not_called()
+
+
+def test_lock_stake_extrinsic_exception(mocker):
+    """Verify that lock_stake_extrinsic handles exceptions gracefully."""
+    fake_subtensor = mocker.Mock(
+        **{"sign_and_send_extrinsic.side_effect": RuntimeError("chain error")}
+    )
+    fake_wallet = mocker.Mock()
+
+    result = lock.lock_stake_extrinsic(
+        subtensor=fake_subtensor,
+        wallet=fake_wallet,
+        hotkey_ss58="hotkey",
+        netuid=1,
+        amount=Balance.from_tao(1),
+        mev_protection=False,
+    )
+
+    assert result.success is False
+
+
+def test_move_lock_extrinsic_exception(mocker):
+    """Verify that move_lock_extrinsic handles exceptions gracefully."""
+    fake_subtensor = mocker.Mock(
+        **{"sign_and_send_extrinsic.side_effect": RuntimeError("chain error")}
+    )
+    fake_wallet = mocker.Mock()
+
+    result = lock.move_lock_extrinsic(
+        subtensor=fake_subtensor,
+        wallet=fake_wallet,
+        destination_hotkey_ss58="hotkey",
+        netuid=1,
+        mev_protection=False,
+    )
+
+    assert result.success is False
+
+
+def test_set_perpetual_lock_extrinsic_exception(mocker):
+    """Verify that set_perpetual_lock_extrinsic handles exceptions gracefully."""
+    fake_subtensor = mocker.Mock(
+        **{"sign_and_send_extrinsic.side_effect": RuntimeError("chain error")}
+    )
+    fake_wallet = mocker.Mock()
+
+    result = lock.set_perpetual_lock_extrinsic(
+        subtensor=fake_subtensor,
+        wallet=fake_wallet,
+        netuid=1,
+        enabled=True,
+    )
+
+    assert result.success is False

--- a/tests/unit_tests/test_async_subtensor.py
+++ b/tests/unit_tests/test_async_subtensor.py
@@ -3951,6 +3951,240 @@ async def test_get_stake_weight(subtensor, mocker):
     assert result == expected_result
 
 
+# Lock / Conviction tests =====================================================================
+
+
+@pytest.mark.asyncio
+async def test_get_stake_lock_success(subtensor, mocker):
+    """Tests get_stake_lock returns LockState when lock exists."""
+    # Preps
+    coldkey = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+    hotkey = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+    netuid = 1
+    raw_value = {"locked_mass": 1_000_000_000, "conviction": 1 << 64, "last_update": 50}
+    mock_query = mocker.MagicMock(value=raw_value)
+    subtensor.query_subtensor = mocker.AsyncMock(return_value=mock_query)
+
+    # Call
+    result = await subtensor.get_stake_lock(coldkey, netuid, hotkey)
+
+    # Asserts
+    subtensor.query_subtensor.assert_awaited_once_with(
+        "Lock",
+        params=[coldkey, netuid, hotkey],
+        block=None,
+        block_hash=None,
+        reuse_block=False,
+    )
+    assert result is not None
+    assert result["locked_mass"].rao == 1_000_000_000
+    assert isinstance(result["conviction"], float)
+    assert result["last_update"] == 50
+
+
+@pytest.mark.asyncio
+async def test_get_stake_lock_none(subtensor, mocker):
+    """Tests get_stake_lock returns None when no lock exists."""
+    # Preps
+    mock_query = mocker.MagicMock(value=None)
+    subtensor.query_subtensor = mocker.AsyncMock(return_value=mock_query)
+
+    # Call
+    result = await subtensor.get_stake_lock("coldkey", 1, "hotkey")
+
+    # Asserts
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_stake_locks_success(subtensor, mocker):
+    """Tests get_stake_locks returns list of (hotkey, LockState) tuples."""
+    # Preps
+    coldkey = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+    netuid = 1
+    hotkey1 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+    hotkey2 = "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y"
+    raw_locks = [
+        (hotkey1, {"locked_mass": 500, "conviction": 0, "last_update": 10}),
+        (hotkey2, {"locked_mass": 1000, "conviction": 1 << 63, "last_update": 20}),
+    ]
+
+    async def async_iter():
+        for item in raw_locks:
+            yield item
+
+    subtensor.query_map_subtensor = mocker.AsyncMock(return_value=async_iter())
+
+    # Call
+    result = await subtensor.get_stake_locks(coldkey, netuid)
+
+    # Asserts
+    subtensor.query_map_subtensor.assert_awaited_once_with(
+        "Lock",
+        params=[coldkey, netuid],
+        block=None,
+        block_hash=None,
+        reuse_block=False,
+    )
+    assert len(result) == 2
+    assert result[0][0] == hotkey1
+    assert result[0][1]["locked_mass"].rao == 500
+    assert result[1][0] == hotkey2
+    assert result[1][1]["locked_mass"].rao == 1000
+
+
+@pytest.mark.asyncio
+async def test_get_stake_locks_empty(subtensor, mocker):
+    """Tests get_stake_locks returns empty list when no locks exist."""
+
+    # Preps
+    async def async_iter():
+        return
+        yield
+
+    subtensor.query_map_subtensor = mocker.AsyncMock(return_value=async_iter())
+
+    # Call
+    result = await subtensor.get_stake_locks("coldkey", 1)
+
+    # Asserts
+    assert result == []
+
+
+@pytest.mark.parametrize(
+    "query_value, expected",
+    [(False, True), (None, False)],
+    ids=["perpetual-entry-exists", "decaying-no-entry"],
+)
+@pytest.mark.asyncio
+async def test_is_perpetual_lock(subtensor, mocker, query_value, expected):
+    """Tests is_perpetual_lock correctly distinguishes perpetual from decaying."""
+    # Preps
+    mock_query = mocker.MagicMock(value=query_value)
+    subtensor.query_subtensor = mocker.AsyncMock(return_value=mock_query)
+
+    # Call
+    result = await subtensor.is_perpetual_lock("coldkey", 1)
+
+    # Asserts
+    subtensor.query_subtensor.assert_awaited_once_with(
+        name="DecayingLock",
+        params=["coldkey", 1],
+        block=None,
+        block_hash=None,
+        reuse_block=False,
+    )
+    assert result is expected
+
+
+@pytest.mark.asyncio
+async def test_get_coldkey_lock_success(subtensor, mocker):
+    """Tests get_coldkey_lock returns LockState when lock exists."""
+    # Preps
+    raw_result = {"locked_mass": 2000, "conviction": 1 << 64, "last_update": 100}
+    subtensor.query_runtime_api = mocker.AsyncMock(return_value=raw_result)
+
+    # Call
+    result = await subtensor.get_coldkey_lock("coldkey", 1)
+
+    # Asserts
+    subtensor.query_runtime_api.assert_awaited_once_with(
+        runtime_api="StakeInfoRuntimeApi",
+        method="get_coldkey_lock",
+        params=["coldkey", 1],
+        block=None,
+        block_hash=None,
+        reuse_block=False,
+    )
+    assert result is not None
+    assert result["locked_mass"].rao == 2000
+    assert isinstance(result["conviction"], float)
+    assert result["last_update"] == 100
+
+
+@pytest.mark.asyncio
+async def test_get_coldkey_lock_none(subtensor, mocker):
+    """Tests get_coldkey_lock returns None when no lock exists."""
+    # Preps
+    subtensor.query_runtime_api = mocker.AsyncMock(return_value=None)
+
+    # Call
+    result = await subtensor.get_coldkey_lock("coldkey", 1)
+
+    # Asserts
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_hotkey_conviction_success(subtensor, mocker):
+    """Tests get_hotkey_conviction returns float conviction score."""
+    # Preps
+    subtensor.query_runtime_api = mocker.AsyncMock(return_value=(1 << 64))
+
+    # Call
+    result = await subtensor.get_hotkey_conviction("hotkey", 1)
+
+    # Asserts
+    subtensor.query_runtime_api.assert_awaited_once_with(
+        runtime_api="StakeInfoRuntimeApi",
+        method="get_hotkey_conviction",
+        params=["hotkey", 1],
+        block=None,
+        block_hash=None,
+        reuse_block=False,
+    )
+    assert isinstance(result, float)
+    assert result > 0.0
+
+
+@pytest.mark.asyncio
+async def test_get_hotkey_conviction_none(subtensor, mocker):
+    """Tests get_hotkey_conviction returns 0.0 when no data."""
+    # Preps
+    subtensor.query_runtime_api = mocker.AsyncMock(return_value=None)
+
+    # Call
+    result = await subtensor.get_hotkey_conviction("hotkey", 1)
+
+    # Asserts
+    assert result == 0.0
+
+
+@pytest.mark.asyncio
+async def test_get_most_convicted_hotkey_on_subnet_success(subtensor, mocker):
+    """Tests get_most_convicted_hotkey_on_subnet returns hotkey SS58."""
+    # Preps
+    expected_hotkey = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+    subtensor.query_runtime_api = mocker.AsyncMock(return_value=expected_hotkey)
+
+    # Call
+    result = await subtensor.get_most_convicted_hotkey_on_subnet(1)
+
+    # Asserts
+    subtensor.query_runtime_api.assert_awaited_once_with(
+        runtime_api="StakeInfoRuntimeApi",
+        method="get_most_convicted_hotkey_on_subnet",
+        params=[1],
+        block=None,
+        block_hash=None,
+        reuse_block=False,
+    )
+    assert result == expected_hotkey
+
+
+@pytest.mark.asyncio
+async def test_get_most_convicted_hotkey_on_subnet_none(subtensor, mocker):
+    """Tests get_most_convicted_hotkey_on_subnet returns None when no locks."""
+    # Preps
+    subtensor.query_runtime_api = mocker.AsyncMock(return_value=None)
+
+    # Call
+    result = await subtensor.get_most_convicted_hotkey_on_subnet(1)
+
+    # Asserts
+    assert result is None
+
+
 @pytest.mark.asyncio
 async def test_get_timelocked_weight_commits(subtensor, mocker):
     """Verify that `get_timelocked_weight_commits` method calls proper methods and returns the correct value."""

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -4075,6 +4075,201 @@ def test_get_stake_weight(subtensor, mocker):
     assert result == expected_result
 
 
+# Lock / Conviction tests =====================================================================
+
+
+def test_get_stake_lock_success(subtensor, mocker):
+    """Tests get_stake_lock returns LockState when lock exists."""
+    # Preps
+    coldkey = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+    hotkey = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+    netuid = 1
+    raw_value = {"locked_mass": 1_000_000_000, "conviction": 1 << 64, "last_update": 50}
+    mock_query = mocker.MagicMock(value=raw_value)
+    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_query)
+
+    # Call
+    result = subtensor.get_stake_lock(coldkey, netuid, hotkey)
+
+    # Asserts
+    subtensor.query_subtensor.assert_called_once_with(
+        "Lock", params=[coldkey, netuid, hotkey], block=None
+    )
+    assert result is not None
+    assert result["locked_mass"].rao == 1_000_000_000
+    assert isinstance(result["conviction"], float)
+    assert result["last_update"] == 50
+
+
+def test_get_stake_lock_none(subtensor, mocker):
+    """Tests get_stake_lock returns None when no lock exists."""
+    # Preps
+    mock_query = mocker.MagicMock(value=None)
+    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_query)
+
+    # Call
+    result = subtensor.get_stake_lock("coldkey", 1, "hotkey")
+
+    # Asserts
+    assert result is None
+
+
+def test_get_stake_locks_success(subtensor, mocker):
+    """Tests get_stake_locks returns list of (hotkey, LockState) tuples."""
+    # Preps
+    coldkey = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+    netuid = 1
+    hotkey1 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+    hotkey2 = "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y"
+    raw_locks = [
+        (hotkey1, {"locked_mass": 500, "conviction": 0, "last_update": 10}),
+        (hotkey2, {"locked_mass": 1000, "conviction": 1 << 63, "last_update": 20}),
+    ]
+    mocker.patch.object(subtensor, "query_map_subtensor", return_value=iter(raw_locks))
+
+    # Call
+    result = subtensor.get_stake_locks(coldkey, netuid)
+
+    # Asserts
+    subtensor.query_map_subtensor.assert_called_once_with(
+        "Lock", params=[coldkey, netuid], block=None
+    )
+    assert len(result) == 2
+    assert result[0][0] == hotkey1
+    assert result[0][1]["locked_mass"].rao == 500
+    assert result[1][0] == hotkey2
+    assert result[1][1]["locked_mass"].rao == 1000
+
+
+def test_get_stake_locks_empty(subtensor, mocker):
+    """Tests get_stake_locks returns empty list when no locks exist."""
+    # Preps
+    mocker.patch.object(subtensor, "query_map_subtensor", return_value=iter([]))
+
+    # Call
+    result = subtensor.get_stake_locks("coldkey", 1)
+
+    # Asserts
+    assert result == []
+
+
+@pytest.mark.parametrize(
+    "query_value, expected",
+    [(False, True), (None, False)],
+    ids=["perpetual-entry-exists", "decaying-no-entry"],
+)
+def test_is_perpetual_lock(subtensor, mocker, query_value, expected):
+    """Tests is_perpetual_lock correctly distinguishes perpetual from decaying."""
+    # Preps
+    mock_query = mocker.MagicMock(value=query_value)
+    mocker.patch.object(subtensor, "query_subtensor", return_value=mock_query)
+
+    # Call
+    result = subtensor.is_perpetual_lock("coldkey", 1)
+
+    # Asserts
+    subtensor.query_subtensor.assert_called_once_with(
+        name="DecayingLock", params=["coldkey", 1], block=None
+    )
+    assert result is expected
+
+
+def test_get_coldkey_lock_success(subtensor, mocker):
+    """Tests get_coldkey_lock returns LockState when lock exists."""
+    # Preps
+    raw_result = {"locked_mass": 2000, "conviction": 1 << 64, "last_update": 100}
+    mocker.patch.object(subtensor, "query_runtime_api", return_value=raw_result)
+
+    # Call
+    result = subtensor.get_coldkey_lock("coldkey", 1)
+
+    # Asserts
+    subtensor.query_runtime_api.assert_called_once_with(
+        runtime_api="StakeInfoRuntimeApi",
+        method="get_coldkey_lock",
+        params=["coldkey", 1],
+        block=None,
+    )
+    assert result is not None
+    assert result["locked_mass"].rao == 2000
+    assert isinstance(result["conviction"], float)
+    assert result["last_update"] == 100
+
+
+def test_get_coldkey_lock_none(subtensor, mocker):
+    """Tests get_coldkey_lock returns None when no lock exists."""
+    # Preps
+    mocker.patch.object(subtensor, "query_runtime_api", return_value=None)
+
+    # Call
+    result = subtensor.get_coldkey_lock("coldkey", 1)
+
+    # Asserts
+    assert result is None
+
+
+def test_get_hotkey_conviction_success(subtensor, mocker):
+    """Tests get_hotkey_conviction returns float conviction score."""
+    # Preps
+    mocker.patch.object(subtensor, "query_runtime_api", return_value=(1 << 64))
+
+    # Call
+    result = subtensor.get_hotkey_conviction("hotkey", 1)
+
+    # Asserts
+    subtensor.query_runtime_api.assert_called_once_with(
+        runtime_api="StakeInfoRuntimeApi",
+        method="get_hotkey_conviction",
+        params=["hotkey", 1],
+        block=None,
+    )
+    assert isinstance(result, float)
+    assert result > 0.0
+
+
+def test_get_hotkey_conviction_none(subtensor, mocker):
+    """Tests get_hotkey_conviction returns 0.0 when no data."""
+    # Preps
+    mocker.patch.object(subtensor, "query_runtime_api", return_value=None)
+
+    # Call
+    result = subtensor.get_hotkey_conviction("hotkey", 1)
+
+    # Asserts
+    assert result == 0.0
+
+
+def test_get_most_convicted_hotkey_on_subnet_success(subtensor, mocker):
+    """Tests get_most_convicted_hotkey_on_subnet returns hotkey SS58."""
+    # Preps
+    expected_hotkey = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+    mocker.patch.object(subtensor, "query_runtime_api", return_value=expected_hotkey)
+
+    # Call
+    result = subtensor.get_most_convicted_hotkey_on_subnet(1)
+
+    # Asserts
+    subtensor.query_runtime_api.assert_called_once_with(
+        runtime_api="StakeInfoRuntimeApi",
+        method="get_most_convicted_hotkey_on_subnet",
+        params=[1],
+        block=None,
+    )
+    assert result == expected_hotkey
+
+
+def test_get_most_convicted_hotkey_on_subnet_none(subtensor, mocker):
+    """Tests get_most_convicted_hotkey_on_subnet returns None when no locks."""
+    # Preps
+    mocker.patch.object(subtensor, "query_runtime_api", return_value=None)
+
+    # Call
+    result = subtensor.get_most_convicted_hotkey_on_subnet(1)
+
+    # Asserts
+    assert result is None
+
+
 def test_get_timelocked_weight_commits(subtensor, mocker):
     """Verify that `get_timelocked_weight_commits` method calls proper methods and returns the correct value."""
     # Preps


### PR DESCRIPTION
SDK wrapper for the Conviction V2 mechanism ([Subtensor PR #2687](https://github.com/opentensor/subtensor/pull/2658)). Allows a coldkey to lock alpha-stake on a hotkey within a subnet to accumulate conviction (influence). One lock per coldkey per subnet.

### Includes

**Extrinsics:**
- `lock_stake` - lock alpha-stake on a hotkey, with MEV Shield support
- `move_lock` - move lock to a different hotkey on the same subnet (resets conviction)
- `set_perpetual_lock` - freeze lock (disable decay)

**Query methods:**
- `get_stake_lock` - lock state for a specific coldkey/hotkey/netuid
- `get_stake_locks` - all locks for a coldkey on a subnet
- `is_perpetual_lock` - check if lock is frozen (non-decaying)
- `get_coldkey_lock` - lock state rolled forward accounting for decay
- `get_hotkey_conviction` - total conviction score of a hotkey on a subnet
- `get_most_convicted_hotkey_on_subnet` - hotkey with the highest conviction

**Types:**
- `LockState` TypedDict: locked_mass, conviction, last_update

### Logic

- Locks decay by default (exponential decay via UnlockRate/MaturityRate)
- Subnet owner gets an automatic lock via auto_lock_owner_cut on each emission
- `set_perpetual_lock(enabled=True)` freezes the lock (inserts entry into DecayingLock storage)
- `is_perpetual_lock` detects entry existence via `query.value is not None`
- `get_stake_lock` reads raw storage (no decay applied), `get_coldkey_lock` returns rolled-forward values

### Tests

- Unit tests: sync and async for all query methods and extrinsics
- E2E tests: sync and async for owner/non-owner lifecycle, move_lock, perpetual toggle

@latent-to/docs pls take a look this PR related with `Conviction v2` logic.