### PR TITLE
Changelog/10.4.0 + bumping version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 10.4.0 /2026-05-28
+
+## What's Changed
+* Fixes tests in subtensor 2569 by @thewhaleking in https://github.com/latent-to/bittensor/pull/3355
+* Improves monitor_requirements_size_master workflow by @thewhaleking in https://github.com/latent-to/bittensor/pull/3357
+* PR guard workflow by @thewhaleking in https://github.com/latent-to/bittensor/pull/3358
+* Support `Conviction v2` by @basfroman in https://github.com/latent-to/bittensor/pull/3361
+
+**Full Changelog**: https://github.com/latent-to/bittensor/compare/v10.3.2...v10.4.0
+
 ## 10.3.2 /2026-05-15
 
 ## What's Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bittensor"
-version = "10.3.2"
+version = "10.4.0"
 description = "Bittensor SDK"
 readme = "README.md"
 authors = [
@@ -32,7 +32,7 @@ dependencies = [
     "cyscale>=0.3.3,<1.0.0",
     "uvicorn",
     "bittensor-drand>=1.3.0,<2.0.0",
-    "bittensor-wallet==4.0.1",
+    "bittensor-wallet>=4.1.0",
     "async-substrate-interface>=2.0.4,<3.0.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ torch = [
     "torch>=1.13.1,<3.0"
 ]
 cli = [
-    "bittensor-cli>=9.21.1"
+    "bittensor-cli>=9.22.0"
 ]
 
 


### PR DESCRIPTION
## 10.4.0 /2026-05-28

## What's Changed
* Fixes tests in subtensor 2569 by @thewhaleking in https://github.com/latent-to/bittensor/pull/3355
* Improves monitor_requirements_size_master workflow by @thewhaleking in https://github.com/latent-to/bittensor/pull/3357
* PR guard workflow by @thewhaleking in https://github.com/latent-to/bittensor/pull/3358
* Support `Conviction v2` by @basfroman in https://github.com/latent-to/bittensor/pull/3361

**Full Changelog**: https://github.com/latent-to/bittensor/compare/v10.3.2...v10.4.0