### PR TITLE
Forward version_key from commit_weights

### DIFF
--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -7041,6 +7041,7 @@ class AsyncSubtensor(SubtensorMixin):
                     uids=uids,
                     weights=weights,
                     salt=salt,
+                    version_key=version_key,
                     mev_protection=mev_protection,
                     period=period,
                     raise_error=raise_error,

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -5846,6 +5846,7 @@ class Subtensor(SubtensorMixin):
                     uids=uids,
                     weights=weights,
                     salt=salt,
+                    version_key=version_key,
                     mev_protection=mev_protection,
                     period=period,
                     raise_error=raise_error,

--- a/tests/unit_tests/test_async_subtensor.py
+++ b/tests/unit_tests/test_async_subtensor.py
@@ -4885,6 +4885,104 @@ async def test_get_crowdloans(mocker, subtensor):
     assert result == [mocked_decode_crowdloan_entry.return_value]
 
 
+@pytest.mark.asyncio
+async def test_commit_weights_forwards_version_key(subtensor, fake_wallet, mocker):
+    """Regression: async commit_weights must forward the caller's version_key to the
+    extrinsic. If dropped, the commit hash is built with the default version_key and
+    a reveal made with the intended version_key mismatches on-chain."""
+    # Preps
+    netuid = 1
+    uids = [1, 2, 3, 4]
+    weights = [10, 20, 30, 40]
+    salt = [4, 2, 2, 1]
+    custom_version_key = settings.version_as_int + 1
+    mocked_extrinsic = mocker.AsyncMock(return_value=ExtrinsicResponse(True, None))
+    mocker.patch.object(async_subtensor, "commit_weights_extrinsic", mocked_extrinsic)
+
+    # Call
+    await subtensor.commit_weights(
+        wallet=fake_wallet,
+        netuid=netuid,
+        uids=uids,
+        weights=weights,
+        salt=salt,
+        version_key=custom_version_key,
+    )
+
+    # Assertions
+    assert mocked_extrinsic.await_count == 1
+    assert mocked_extrinsic.call_args.kwargs["version_key"] == custom_version_key
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "version_key",
+    [settings.version_as_int, settings.version_as_int + 7],
+    ids=["default_version_key", "custom_version_key"],
+)
+async def test_commit_weights_hash_matches_reveal(
+    subtensor, fake_wallet, mocker, version_key
+):
+    """Symptom-level (async): the commit hash built by AsyncSubtensor.commit_weights
+    (version_key=X) must equal the hash the chain recomputes at reveal for the same
+    inputs and X (reveal_weights forwards version_key). Pre-fix the async wrapper
+    dropped X and hashed with the default, so a custom X produced a mismatching commit
+    hash that a reveal would be rejected against. Drives the REAL async extrinsic
+    (commit_weights_extrinsic is NOT mocked) so it guards asyncex/weights.py's hashing."""
+    from bittensor.utils.weight_utils import generate_weight_hash as real_ghash
+
+    fake_wallet.hotkey.ss58_address = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+    uids = [1, 2, 3]
+    weights = [10, 20, 30]
+    salt = [4, 2, 2, 1]
+
+    captured = {}
+
+    def spy(**kwargs):
+        result = real_ghash(**kwargs)
+        captured.update(kwargs)
+        captured["result"] = result
+        return result
+
+    mocker.patch(
+        "bittensor.core.extrinsics.asyncex.weights.generate_weight_hash",
+        side_effect=spy,
+    )
+    # Neutralize wallet unlock + chain submission so the extrinsic runs through hashing.
+    mocker.patch.object(
+        ExtrinsicResponse, "unlock_wallet", return_value=mocker.Mock(success=True)
+    )
+    mock_sm = mocker.patch("bittensor.core.extrinsics.asyncex.weights.SubtensorModule")
+    mock_sm.return_value.commit_mechanism_weights = mocker.AsyncMock()
+    mocker.patch.object(
+        subtensor,
+        "sign_and_send_extrinsic",
+        mocker.AsyncMock(return_value=ExtrinsicResponse(True, None)),
+    )
+
+    # Call (force the non-MEV path).
+    await subtensor.commit_weights(
+        wallet=fake_wallet,
+        netuid=1,
+        uids=uids,
+        weights=weights,
+        salt=salt,
+        version_key=version_key,
+        mev_protection=False,
+    )
+
+    # Hash actually committed by commit_weights ...
+    commit_hash = captured["result"]
+    # ... vs the hash the chain recomputes at reveal for the same inputs + intended
+    # version_key (reusing the exact non-version_key args the commit path passed).
+    reveal_args = {
+        k: v for k, v in captured.items() if k not in ("version_key", "result")
+    }
+    reveal_hash = real_ghash(**reveal_args, version_key=version_key)
+
+    assert commit_hash == reveal_hash
+
+
 @pytest.mark.parametrize(
     "method, add_salt",
     [

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -1711,6 +1711,99 @@ def test_reveal_weights(subtensor, fake_wallet, mocker):
     )
 
 
+def test_commit_weights_forwards_version_key(subtensor, fake_wallet, mocker):
+    """Regression: commit_weights must forward the caller's version_key to the
+    extrinsic. If dropped, the commit hash is built with the default version_key
+    and a reveal made with the intended version_key mismatches on-chain."""
+    # Preps
+    netuid = 1
+    uids = [1, 2, 3, 4]
+    weights = [10, 20, 30, 40]
+    salt = [4, 2, 2, 1]
+    custom_version_key = version_as_int + 1
+    mocked_extrinsic = mocker.patch.object(
+        subtensor_module,
+        "commit_weights_extrinsic",
+        return_value=ExtrinsicResponse(True, None),
+    )
+
+    # Call
+    subtensor.commit_weights(
+        wallet=fake_wallet,
+        netuid=netuid,
+        uids=uids,
+        weights=weights,
+        salt=salt,
+        version_key=custom_version_key,
+    )
+
+    # Assertions
+    assert mocked_extrinsic.call_count == 1
+    assert mocked_extrinsic.call_args.kwargs["version_key"] == custom_version_key
+
+
+@pytest.mark.parametrize(
+    "version_key",
+    [version_as_int, version_as_int + 7],
+    ids=["default_version_key", "custom_version_key"],
+)
+def test_commit_weights_hash_matches_reveal(
+    subtensor, fake_wallet, mocker, version_key
+):
+    """Symptom-level: the commit hash built by commit_weights(version_key=X) must equal
+    the hash the chain recomputes at reveal for the same inputs and X (reveal_weights
+    forwards version_key). Pre-fix, commit dropped X and hashed with the default, so a
+    custom X produced a mismatching commit hash that a reveal would be rejected against."""
+    from bittensor.utils.weight_utils import generate_weight_hash as real_ghash
+
+    fake_wallet.hotkey.ss58_address = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+    uids = [1, 2, 3]
+    weights = [10, 20, 30]
+    salt = [4, 2, 2, 1]
+
+    captured = {}
+
+    def spy(**kwargs):
+        result = real_ghash(**kwargs)
+        captured.update(kwargs)
+        captured["result"] = result
+        return result
+
+    mocker.patch(
+        "bittensor.core.extrinsics.weights.generate_weight_hash", side_effect=spy
+    )
+    # Neutralize wallet unlock + chain submission so the extrinsic runs through hashing.
+    mocker.patch.object(
+        ExtrinsicResponse, "unlock_wallet", return_value=mocker.Mock(success=True)
+    )
+    mocker.patch("bittensor.core.extrinsics.weights.SubtensorModule")
+    mocker.patch.object(
+        subtensor, "sign_and_send_extrinsic", return_value=ExtrinsicResponse(True, None)
+    )
+
+    # Call (force the non-MEV path).
+    subtensor.commit_weights(
+        wallet=fake_wallet,
+        netuid=1,
+        uids=uids,
+        weights=weights,
+        salt=salt,
+        version_key=version_key,
+        mev_protection=False,
+    )
+
+    # Hash actually committed by commit_weights ...
+    commit_hash = captured["result"]
+    # ... vs the hash the chain recomputes at reveal for the same inputs + intended
+    # version_key (reusing the exact non-version_key args the commit path passed).
+    reveal_args = {
+        k: v for k, v in captured.items() if k not in ("version_key", "result")
+    }
+    reveal_hash = real_ghash(**reveal_args, version_key=version_key)
+
+    assert commit_hash == reveal_hash
+
+
 def test_reveal_weights_false(subtensor, fake_wallet, mocker):
     """Failed test_reveal_weights call."""
     # Preps


### PR DESCRIPTION
# Fix commit_weights dropping the caller's version_key

> Base branch: `staging`. No separate issue — the bug is described in full below
> (per maintainer guidance that a detailed PR description suffices).

### Bug

`commit_weights` (sync + async) ignores a caller-supplied `version_key`,
producing a commit hash that a matching `reveal_weights` cannot satisfy. No
separate issue was filed; the full reproduction, root cause, and fix are
described below.

### Description of the Change

`Subtensor.commit_weights` / `AsyncSubtensor.commit_weights` accept `version_key`
but never forwarded it to `commit_weights_extrinsic`, which uses it in
`generate_weight_hash` to build the commit hash. The extrinsic therefore fell
back to its default (`version_as_int`), so a custom `version_key` was silently
ignored. Because `reveal_weights` *does* forward `version_key`, the commit and
reveal hashes disagreed and the reveal was rejected on-chain.

The fix forwards `version_key=version_key` in both wrappers (one line each),
matching how `reveal_weights` and `set_weights` already forward it.

### Alternate Designs

None needed — the parameter simply has to be threaded through, exactly as the
sibling weights wrappers already do.

### Possible Drawbacks

Behavior-preserving for default callers: the wrapper default and the extrinsic
default are both `version_as_int` (10004000, runtime-verified), so the default
commit hash is unchanged. Only callers passing a custom `version_key` change
behavior — which is the fix. Scope is `commit_weights` only: `generate_weight_hash`
is used solely by `commit_weights_extrinsic`, and `reveal_weights`/`set_weights`
(both `commit_timelocked_weights_extrinsic` and `set_weights_extrinsic`) already
forward `version_key`.

### Verification Process

- Repro-first: `test_commit_weights_forwards_version_key` (sync + async) fails on
  `staging` with `KeyError: 'version_key'`; passes with the fix.
- Symptom-level `test_commit_weights_hash_matches_reveal` (**sync and async**,
  each parametrized default + custom) runs `commit_weights` through the real
  extrinsic (chain submission mocked), captures the actual committed hash, and
  asserts it equals the hash the chain recomputes at reveal for the same inputs
  and `version_key`. The **custom** case fails on `staging` (hashes differ) while
  the **default** case passes, confirming default callers are unaffected and the
  test is precise. The async variant exercises the real `asyncex/weights.py`
  hashing (extrinsic not mocked) and is verified to fail under a
  `version_key=version_as_int` hardcode mutation.
- Python 3.12, async-substrate-interface 2.1.0:
  `-k "commit_weights or reveal_weights or set_weights"` → **15 passed**; full
  `test_subtensor.py` + `test_async_subtensor.py` → **510 passed**;
  `ruff format --check`, `ruff check`, `mypy` clean.

### Release Notes

Fixed `commit_weights` ignoring a custom `version_key`, which caused the
subsequent `reveal_weights` to be rejected on-chain.

### Branch Acknowledgement
[x] I am acknowledging that I am opening this branch against `staging`
