### PR TITLE
Fix after aiohttp latest release

### DIFF
--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -11,7 +11,19 @@ def force_legacy_torch_compatible_api(monkeypatch):
 
 
 @pytest.fixture
-def mock_aio_response():
+def mock_aio_response(monkeypatch):
+    import aiohttp
+    from unittest.mock import Mock
+    from aioresponses import aioresponses
+
+    original_init = aiohttp.ClientResponse.__init__
+
+    def patched_init(self, *args, **kwargs):
+        if "stream_writer" not in kwargs:
+            kwargs["stream_writer"] = Mock()
+        original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(aiohttp.ClientResponse, "__init__", patched_init)
     with aioresponses() as m:
         yield m
 

--- a/tests/unit_tests/test_dendrite.py
+++ b/tests/unit_tests/test_dendrite.py
@@ -3,7 +3,6 @@ import typing
 from unittest.mock import MagicMock, Mock
 
 import aiohttp
-from bittensor_wallet.mock import get_mock_wallet
 import pytest
 
 from bittensor.core.axon import Axon


### PR DESCRIPTION
Patch mock_aio_response fixture to inject the stream_writer kwarg that [aiohttp 3.14](https://pypi.org/project/aiohttp/3.14.0/) requires in ClientResponse.init but aioresponses doesn't provide. Fixes test_dendrite failures on staging without restricting aiohttp version.