### PR TITLE
[Security] `kill_pure_proxy_extrinsic` authorization bypass: non-spawner can destroy pure proxy and permanently lock all funds

### DIFF
--- a/bittensor/core/extrinsics/proxy.py
+++ b/bittensor/core/extrinsics/proxy.py
@@ -546,6 +546,11 @@ def kill_pure_proxy_extrinsic(
             unlocked := ExtrinsicResponse.unlock_wallet(wallet, raise_error)
         ).success:
             return unlocked
+        if wallet.coldkey.ss58_address != spawner:
+            raise ValueError(
+                f"Only the spawner ({spawner}) can kill this pure proxy. "
+                f"Provided wallet belongs to {wallet.coldkey.ss58_address}."
+        )
 
         proxy_type_str = ProxyType.normalize(proxy_type)
 


### PR DESCRIPTION
## Description

The `kill_pure_proxy_extrinsic` function's **documentation explicitly states** that `wallet.coldkey.ss58_address` must be the spawner of the pure proxy. However, the code **never enforces this check**. The only authorization is the chain-level proxy rights check — which permits **any account** holding `Any` proxy rights over the pure proxy to destroy it, not just the spawner.

This means: if the spawner grants `Any` proxy over a pure proxy to a third party (for operational convenience, or by mistake), that third party can call `kill_pure_proxy_extrinsic` and **permanently destroy the pure proxy with all its funds**, even though the documentation guarantees this is impossible.

---

## Affected Component

- **Package**: `bittensor` (SDK)
- **Version**: 10.4.0
- **File**: `bittensor/core/extrinsics/proxy.py`
- **Function**: `kill_pure_proxy_extrinsic()` (line 439–589)

---

## Documentation vs Code

**Documentation** (proxy.py line 466-468):

> `wallet: Bittensor wallet object. The wallet.coldkey.ss58_address must be the spawner of the pure proxy (the account that created it via create_pure_proxy_extrinsic).`

**Documentation** (proxy.py line 471-472):

> `spawner: The SS58 address of the spawner account ... This should match wallet.coldkey.ss58_address.`

**Code** (proxy.py line 544-548):

```python
try:
    if not (
        unlocked := ExtrinsicResponse.unlock_wallet(wallet, raise_error)
    ).success:
        return unlocked

    # <-- NO CHECK: wallet.coldkey.ss58_address == spawner ? -->

    proxy_type_str = ProxyType.normalize(proxy_type)
    # ... proceeds to destroy the pure proxy
```

The only authorization gate is `unlock_wallet(wallet)` — which merely verifies the wallet is unlocked, **not** that it belongs to the spawner.

---

## Call Chain

```
kill_pure_proxy_extrinsic(wallet, pure_proxy_ss58, spawner, ...)
  │
  ├─ proxy.py:545   unlock_wallet(wallet)        ← ONLY checks wallet is unlocked
  │
  ├─ proxy.py:560   Proxy.kill_pure(spawner=...)  ← spawner is just an identifier, not an auth check
  │
  └─ proxy.py:572   proxy_extrinsic(
                        wallet=wallet,             ← any unlocked wallet accepted
                        real_account_ss58=pure_proxy_ss58,
                        force_proxy_type=Any,      ← default
                        call=kill_pure_call
                    )
      │
      └─ [Chain] Does signer have proxy rights over pure_proxy_ss58?
           → Has Any proxy → PASS
           → Chain NEVER checks: is signer == spawner?
```

---

## Exploit Scenario

1. **Alice** (spawner) creates a pure proxy `P` and deposits significant TAO/Alpha into it
2. **Alice** grants **Bob** `Any` proxy rights over `P` — perhaps for temporary operational delegation, or by mistake
3. **Bob** (attacker) calls:

```python
kill_pure_proxy_extrinsic(
    wallet=bob_wallet,              # Bob's wallet — NOT the spawner!
    pure_proxy_ss58=P,
    spawner=alice_address,          # identifies which pure proxy to kill
    proxy_type="Any",
    index=0,
    height=creation_height,
    ext_index=creation_ext_index,
    # force_proxy_type defaults to ProxyType.Any
)
```

4. **Result**: Pure proxy `P` is destroyed. **All funds permanently inaccessible.**
5. Bob was never the spawner. The documentation's "only spawner can kill" guarantee was void.

---

## Impact

- **Type**: Authorization bypass
- **Severity**: High
- **Financial impact**: Permanent, irreversible loss of all funds held in the pure proxy
- **Exploitability**: Requires the attacker to hold `Any` proxy rights over the target pure proxy (granted by spawner or another proxy holder). No private key compromise needed.

---

## Recommended Fix

Add a spawner identity check in `kill_pure_proxy_extrinsic()` immediately after the wallet unlock check, at **proxy.py line 549**:

```python
try:
    if not (
        unlocked := ExtrinsicResponse.unlock_wallet(wallet, raise_error)
    ).success:
        return unlocked

    # === FIX: verify the caller is the spawner ===
    if wallet.coldkey.ss58_address != spawner:
        raise ValueError(
            f"Only the spawner ({spawner}) can kill this pure proxy. "
            f"Provided wallet belongs to {wallet.coldkey.ss58_address}."
        )

    proxy_type_str = ProxyType.normalize(proxy_type)
    # ...
```

This is a 3-line defensive check. The chain already enforces proxy rights; the SDK should additionally enforce that the signer is the spawner, as documented.
