### PR TITLE
[Security] `kill_pure_proxy_extrinsic` authorization bypass: non-spawner can destroy pure proxy and permanently lock all funds

### DIFF
--- a/bittensor/core/extrinsics/proxy.py
+++ b/bittensor/core/extrinsics/proxy.py
@@ -547,6 +547,12 @@ def kill_pure_proxy_extrinsic(
         ).success:
             return unlocked
 
+        if wallet.coldkey.ss58_address != spawner:
+            raise ValueError(
+                f"Only the spawner ({spawner}) can kill this pure proxy. "
+                f"Provided wallet belongs to {wallet.coldkey.ss58_address}."
+            )
+
         proxy_type_str = ProxyType.normalize(proxy_type)
 
         logging.debug(


### PR DESCRIPTION
## Bug

`kill_pure_proxy_extrinsic` in `bittensor/core/extrinsics/proxy.py` has an authorization bypass: any account holding `Any` proxy rights over a pure proxy can destroy it, even if that account is not the spawner. The documentation explicitly states that only the spawner can kill the pure proxy, but the code never enforces this check.

**Affected Component**
- **Package**: `bittensor` (SDK)
- **Version**: 10.4.0
- **File**: `bittensor/core/extrinsics/proxy.py`
- **Function**: `kill_pure_proxy_extrinsic()` (line 439–589)

**Authorization Flow (current)**
```
kill_pure_proxy_extrinsic(wallet, pure_proxy_ss58, spawner, ...)
  │
  ├─ proxy.py:545   unlock_wallet(wallet)        ← ONLY checks wallet is unlocked
  │
  ├─ proxy.py:560   Proxy.kill_pure(spawner=...)  ← spawner is just an identifier, not an auth check
  │
  └─ proxy.py:572   proxy_extrinsic(
                        wallet=wallet,             ← any unlocked wallet accepted
                        real_account_ss58=pure_proxy_ss58,
                        force_proxy_type=Any,      ← default
                        call=kill_pure_call
                    )
      │
      └─ [Chain] Does signer have proxy rights over pure_proxy_ss58?
           → Has Any proxy → PASS
           → Chain NEVER checks: is signer == spawner?
```

**Exploit Scenario**
1. **Alice** (spawner) creates a pure proxy `P` and deposits significant TAO/Alpha into it
2. **Alice** grants **Bob** `Any` proxy rights over `P` — for temporary operational delegation, or by mistake
3. **Bob** (attacker) calls `kill_pure_proxy_extrinsic` with his own wallet (not the spawner)
4. **Result**: Pure proxy `P` is destroyed. All funds permanently inaccessible.
5. Bob was never the spawner. The documentation's "only spawner can kill" guarantee was void.

**Impact**
- **Type**: Authorization bypass
- **Severity**: High
- **Financial impact**: Permanent, irreversible loss of all funds held in the pure proxy
- **Exploitability**: Requires the attacker to hold `Any` proxy rights over the target pure proxy (granted by spawner or another proxy holder). No private key compromise needed.

---

## Description of the Change

Add a spawner identity check in `kill_pure_proxy_extrinsic()` immediately after the wallet unlock check, at **proxy.py line 549**:

```python
try:
    if not (
        unlocked := ExtrinsicResponse.unlock_wallet(wallet, raise_error)
    ).success:
        return unlocked

    # === FIX: verify the caller is the spawner ===
    if wallet.coldkey.ss58_address != spawner:
        raise ValueError(
            f"Only the spawner ({spawner}) can kill this pure proxy. "
            f"Provided wallet belongs to {wallet.coldkey.ss58_address}."
        )

    proxy_type_str = ProxyType.normalize(proxy_type)
    # ...
```

This is a 3-line defensive check. The chain already enforces proxy rights; the SDK should additionally enforce that the signer is the spawner, as documented.

---

## Alternate Designs

1. **Chain-level enforcement**: Modify the Substrate pallet so that `kill_pure_proxy` requires the signer to be the spawner. This would be a stronger guarantee but requires a runtime upgrade and governance approval, making it a longer-term fix.
2. **Dedicated extrinsic for spawner-only kill**: Introduce a new extrinsic that bakes the spawner check into the runtime. Similar trade-offs as above.
3. **Remove the documentation guarantee instead**: Alter the docstring to warn that any `Any` proxy holder can destroy the pure proxy. This eliminates the false sense of security but does not address the underlying risk.

The SDK-level check (proposed above) is the fastest, lowest-risk fix and aligns the code with the existing documentation.

---

## Possible Drawbacks

- **Breaking change for legitimate non-spawner killers**: If any user currently relies on the ability for a non-spawner `Any` proxy holder to kill a pure proxy, this fix would break that workflow. However, this workflow contradicts the documented behavior and is unlikely to be intentional.
- **SDK-only enforcement**: The check lives in the SDK, not on-chain. A determined attacker could bypass it by crafting the extrinsic directly (e.g., via Polkadot.js or a modified SDK). This is acceptable as a first line of defense; chain-level enforcement can follow separately.

---

## Verification Process

1. **Unit test**: Add a test where a non-spawner wallet with `Any` proxy rights calls `kill_pure_proxy_extrinsic` and verify it raises `ValueError`.
2. **Unit test**: Add a test where the spawner wallet calls `kill_pure_proxy_extrinsic` and verify it succeeds.
3. **Manual verification**: On a testnet:
   - Create a pure proxy with wallet A (spawner)
   - Grant `Any` proxy rights to wallet B
   - Attempt `kill_pure_proxy_extrinsic` with wallet B → must fail with `ValueError`
   - Attempt `kill_pure_proxy_extrinsic` with wallet A → must succeed and destroy the pure proxy

---

## Release Notes

**Security Fix**: `kill_pure_proxy_extrinsic` now verifies that the calling wallet's coldkey matches the spawner address before destroying a pure proxy. Previously, any account with `Any` proxy rights could destroy the pure proxy, contrary to the documented guarantee that only the spawner can do so. This fix prevents permanent fund loss when `Any` proxy rights have been delegated to a third party.

---

## Branch Acknowledgement

- [ ] I am acknowledging that I am opening this branch against staging
