### PR TITLE
fix(pyproject): de-dupe build-system deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=70.0.0", "wheel"]
+requires = ["setuptools>=78.1.1"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -13,8 +13,6 @@ authors = [
 license = { file = "LICENSE" }
 requires-python = ">=3.10,<3.15"
 dependencies = [
-    "wheel>0.46.1",
-    "setuptools>=78.1.1",
     "aiohttp>=3.13.4,<4.0",
     "asyncstdlib~=3.13.0",
     "colorama~=0.4.6",


### PR DESCRIPTION

### Bug

Fixes https://github.com/latent-to/bittensor/issues/3376
TL;DR: `wheel` and `setuptools` don't need to be in `dependencies`.

### Description of the Change

- Drops the `wheel` and `setuptools` dependencies.
- Also drops `wheel` from `build-system`; afaict this is also no longer needed.
- Bumps the `setuptools` in `build-system`. Previously this should've gotten coalesced to the newer of the two; with the drop an explicit set is needed

### Alternate Designs

n/a

### Possible Drawbacks

To my knowledge, none.

### Verification Process

Built the package and ran the test suite.

### Release Notes

n/a


### Branch Acknowledgement
- [x] I am acknowledging that I am opening this branch against `staging`