### PR TITLE
Handle cyscale 0.5.0

### DIFF
--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -3972,14 +3972,15 @@ class AsyncSubtensor(SubtensorMixin):
             - See: <https://docs.learnbittensor.org/staking-and-delegation/root-claims/managing-root-claims>
         """
         block_hash = await self.determine_block_hash(block, block_hash, reuse_block)
-        query: ScaleType[list[tuple[int, FixedPoint]]] = await self.substrate.query(
+        query: ScaleType[dict[int, FixedPoint]] = await self.substrate.query(
             module="SubtensorModule",
             storage_function="RootClaimable",
             params=[hotkey_ss58],
             block_hash=block_hash,
         )
         return {
-            netuid: fixed_to_float(bits, frac_bits=32) for (netuid, bits) in query.value
+            netuid: fixed_to_float(bits, frac_bits=32)
+            for (netuid, bits) in query.value.items()
         }
 
     async def get_root_claimable_stake(

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -3286,14 +3286,14 @@ class Subtensor(SubtensorMixin):
         Notes:
             - See: <https://docs.learnbittensor.org/staking-and-delegation/root-claims/managing-root-claims>
         """
-        query: ScaleType[list[tuple[int, FixedPoint]]] = self.substrate.query(
+        query: ScaleType[dict[int, FixedPoint]] = self.substrate.query(
             module="SubtensorModule",
             storage_function="RootClaimable",
             params=[hotkey_ss58],
             block_hash=self.determine_block_hash(block),
         )
         return {
-            netuid: fixed_to_float(bits, frac_bits=32) for (netuid, bits) in query.value
+            netuid: fixed_to_float(bits, frac_bits=32) for (netuid, bits) in query.value.items()
         }
 
     def get_root_claimable_stake(

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -3293,7 +3293,8 @@ class Subtensor(SubtensorMixin):
             block_hash=self.determine_block_hash(block),
         )
         return {
-            netuid: fixed_to_float(bits, frac_bits=32) for (netuid, bits) in query.value.items()
+            netuid: fixed_to_float(bits, frac_bits=32)
+            for (netuid, bits) in query.value.items()
         }
 
     def get_root_claimable_stake(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "retry==0.9.2",
     "requests>=2.33.0,<3.0",
     "pydantic>=2.3,<3",
-    "cyscale>=0.3.3,<1.0.0",
+    "cyscale==0.5.0",
     "uvicorn",
     "bittensor-drand>=1.3.0,<2.0.0",
     "bittensor-wallet>=4.1.0",

--- a/tests/e2e_tests/test_lock_stake.py
+++ b/tests/e2e_tests/test_lock_stake.py
@@ -132,13 +132,13 @@ def test_owner_lock_lifecycle(subtensor, alice_wallet, bob_wallet):
     logging.console.info(f"Unstake small amount response: {response}")
     assert response.success
 
-    # Unstake must not reduce locked_mass
+    # Unstake must not slash locked_mass (decaying locks lose a tiny amount per block)
     lock_unchanged = subtensor.staking.get_stake_lock(
         coldkey_ss58=alice_wallet.coldkey.ss58_address,
         netuid=alice_sn.netuid,
         hotkey_ss58=alice_wallet.hotkey.ss58_address,
     )
-    assert lock_unchanged["locked_mass"].rao >= lock_after["locked_mass"].rao
+    assert lock_unchanged["locked_mass"].rao > lock_after["locked_mass"].rao * 0.99
 
 
 @pytest.mark.asyncio
@@ -266,13 +266,13 @@ async def test_owner_lock_lifecycle_async(async_subtensor, alice_wallet, bob_wal
     logging.console.info(f"Unstake small amount response: {response}")
     assert response.success
 
-    # Unstake must not reduce locked_mass
+    # Unstake must not slash locked_mass (decaying locks lose a tiny amount per block)
     lock_unchanged = await async_subtensor.staking.get_stake_lock(
         coldkey_ss58=alice_wallet.coldkey.ss58_address,
         netuid=alice_sn.netuid,
         hotkey_ss58=alice_wallet.hotkey.ss58_address,
     )
-    assert lock_unchanged["locked_mass"].rao >= lock_after["locked_mass"].rao
+    assert lock_unchanged["locked_mass"].rao > lock_after["locked_mass"].rao * 0.99
 
 
 def test_non_owner_lock_lifecycle(subtensor, alice_wallet, bob_wallet, charlie_wallet):

--- a/tests/unit_tests/test_async_subtensor.py
+++ b/tests/unit_tests/test_async_subtensor.py
@@ -4988,7 +4988,7 @@ async def test_get_root_claimable_all_rates(mocker, subtensor):
     # Preps
     hotkey_ss58 = mocker.Mock(spec=str)
     mocked_determine_block_hash = mocker.patch.object(subtensor, "determine_block_hash")
-    fake_value = [(14, {"bits": 6520190})]
+    fake_value = {14: {"bits": 6520190}}
     fake_result = mocker.MagicMock(spec=ScaleType, value=fake_value)
     fake_result.__iter__ = fake_value
     mocked_query = mocker.patch.object(

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -5036,7 +5036,7 @@ def test_get_root_claimable_all_rates(mocker, subtensor):
     # Preps
     hotkey_ss58 = mocker.Mock(spec=str)
     mocked_determine_block_hash = mocker.patch.object(subtensor, "determine_block_hash")
-    fake_value = [(14, {"bits": 6520190})]
+    fake_value = {14: {"bits": 6520190}}
     fake_result = mocker.MagicMock(value=fake_value)
     fake_result.__iter__ = fake_value
     mocked_query = mocker.patch.object(


### PR DESCRIPTION
pyproject listed cyscale >= 0.3.3<1.0.0 which caused the e2e tests to install the new 0.5.0 which has a different return type for BMaps.


Will fix the broken tests from https://github.com/latent-to/bittensor/pull/3377 (unrelated to that PR)

Note: the broken test_owner_lock_lifecycle is unrelated to cyscale 0.5.0, as it also fails on 0.4.0 (likely from https://github.com/opentensor/subtensor/pull/2731). That test is fixed in https://github.com/latent-to/bittensor/pull/3379