### PR TITLE
Separate find-tests for 2 jobs

### DIFF
--- a/.github/workflows/nightly-e2e-tests-subtensor-main.yml
+++ b/.github/workflows/nightly-e2e-tests-subtensor-main.yml
@@ -25,8 +25,8 @@ env:
 
 # job to run tests in parallel
 jobs:
-  # Looking for e2e tests
-  find-tests:
+  # Looking for e2e tests on master
+  find-tests-master:
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     outputs:
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Check-out repository under $GITHUB_WORKSPACE
         uses: actions/checkout@v6
+        with:
+          ref: master
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -53,8 +55,62 @@ jobs:
           path: |
             ~/.cache/uv
             .venv
-          key: uv-${{ runner.os }}-py3.10-${{ hashFiles('pyproject.toml') }}
-          restore-keys: uv-${{ runner.os }}-py3.10-
+          key: uv-${{ runner.os }}-py3.10-master-${{ hashFiles('pyproject.toml') }}
+          restore-keys: uv-${{ runner.os }}-py3.10-master-
+
+      - name: Install dependencies (faster if cache hit)
+        run: uv sync --extra dev --dev
+
+      - name: Find test files
+        id: get-tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          test_matrix=$(
+            uv run pytest -q --collect-only tests/e2e_tests \
+            | sed -n '/^e2e_tests\//p' \
+            | sed 's|^|tests/|' \
+            | jq -R -s -c '
+                split("\n")
+                | map(select(. != ""))
+                | map({nodeid: ., label: (sub("^tests/e2e_tests/"; ""))})
+              '
+          )
+          echo "Found tests: $test_matrix"
+          echo "test-files=$test_matrix" >> "$GITHUB_OUTPUT"
+
+  # Looking for e2e tests on staging
+  find-tests-staging:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    outputs:
+      test-files: ${{ steps.get-tests.outputs.test-files }}
+    steps:
+      - name: Check-out repository under $GITHUB_WORKSPACE
+        uses: actions/checkout@v6
+        with:
+          ref: staging
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.0.0
+        with:
+          enable-cache: false
+          cache-dependency-glob: '**/pyproject.toml'
+          ignore-nothing-to-cache: true
+
+      - name: Cache uv and venv
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/uv
+            .venv
+          key: uv-${{ runner.os }}-py3.10-staging-${{ hashFiles('pyproject.toml') }}
+          restore-keys: uv-${{ runner.os }}-py3.10-staging-
 
       - name: Install dependencies (faster if cache hit)
         run: uv sync --extra dev --dev
@@ -125,14 +181,14 @@ jobs:
   run-fast-blocks-e2e-test-master:
     name: "master: ${{ matrix.label }}"
     needs:
-      - find-tests
+      - find-tests-master
       - pull-docker-images
       - read-python-versions
     strategy:
       fail-fast: false
       max-parallel: 64
       matrix:
-        include: ${{ fromJson(needs.find-tests.outputs.test-files) }}
+        include: ${{ fromJson(needs.find-tests-master.outputs.test-files) }}
     uses: ./.github/workflows/_run-e2e-single.yaml
     with:
       nodeid: ${{ matrix.nodeid }}
@@ -146,14 +202,14 @@ jobs:
   run-fast-blocks-e2e-test-staging:
     name: "staging: ${{ matrix.label }}"
     needs:
-      - find-tests
+      - find-tests-staging
       - pull-docker-images
       - read-python-versions
     strategy:
       fail-fast: false
       max-parallel: 64
       matrix:
-        include: ${{ fromJson(needs.find-tests.outputs.test-files) }}
+        include: ${{ fromJson(needs.find-tests-staging.outputs.test-files) }}
     uses: ./.github/workflows/_run-e2e-single.yaml
     with:
       nodeid: ${{ matrix.nodeid }}


### PR DESCRIPTION
Sometimes, the staging and master environments use different test suites. This leads to false error triggers. 
<img width="878" height="160" alt="image" src="https://github.com/user-attachments/assets/dc179ea1-35d7-4dc6-b91e-8a7c92361614" />


Fixed and updated `Nightly E2E Subtensor ` workflow based on this PR https://github.com/latent-to/bittensor/actions/runs/27580249390