### PR TITLE
Fix MEV Shield era anchoring

### DIFF
--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -6600,6 +6600,7 @@ class AsyncSubtensor(SubtensorMixin):
         nonce: Optional[int] = None,
         *,
         period: Optional[int] = DEFAULT_PERIOD,
+        era_current: Optional[int] = None,
         raise_error: bool = False,
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
@@ -6619,6 +6620,8 @@ class AsyncSubtensor(SubtensorMixin):
             period: The number of blocks during which the transaction will remain valid after it's submitted. If the
                 transaction is not included in a block within that number of blocks, it will expire and be rejected. You
                 can think of it as an expiration date for the transaction.
+            era_current: The block number to anchor the mortal era to. If not provided, the substrate interface chooses
+                the anchor.
             raise_error: Raises the relevant exception rather than returning `False` if unsuccessful.
             wait_for_inclusion: Whether to wait until the extrinsic call is included on the chain
             wait_for_finalization: Whether to wait until the extrinsic call is finalized on the chain
@@ -6657,6 +6660,8 @@ class AsyncSubtensor(SubtensorMixin):
 
         if period is not None:
             extrinsic_data["era"] = {"period": period}
+            if era_current is not None:
+                extrinsic_data["era"]["current"] = era_current
 
         extrinsic_response.extrinsic = await self.substrate.create_signed_extrinsic(
             **extrinsic_data

--- a/bittensor/core/extrinsics/asyncex/mev_shield.py
+++ b/bittensor/core/extrinsics/asyncex/mev_shield.py
@@ -148,7 +148,8 @@ async def submit_encrypted_extrinsic(
         inner_signing_keypair = getattr(wallet, sign_with)
 
         effective_period = resolve_mev_shield_period(period)
-        era = {"period": effective_period}
+        current_block = await subtensor.substrate.get_block_number()
+        era = {"period": effective_period, "current": current_block}
 
         current_nonce = await subtensor.substrate.get_account_next_index(
             account_address=inner_signing_keypair.ss58_address
@@ -175,6 +176,7 @@ async def submit_encrypted_extrinsic(
             call=extrinsic_call,
             nonce=current_nonce,
             period=effective_period,
+            era_current=current_block,
             raise_error=raise_error,
             wait_for_inclusion=wait_for_inclusion,
             wait_for_finalization=wait_for_finalization,

--- a/bittensor/core/extrinsics/mev_shield.py
+++ b/bittensor/core/extrinsics/mev_shield.py
@@ -148,7 +148,8 @@ def submit_encrypted_extrinsic(
         inner_signing_keypair = getattr(wallet, sign_with)
 
         effective_period = resolve_mev_shield_period(period)
-        era = {"period": effective_period}
+        current_block = subtensor.substrate.get_block_number()
+        era = {"period": effective_period, "current": current_block}
 
         current_nonce = subtensor.substrate.get_account_next_index(
             account_address=inner_signing_keypair.ss58_address
@@ -173,6 +174,7 @@ def submit_encrypted_extrinsic(
             call=extrinsic_call,
             nonce=current_nonce,
             period=effective_period,
+            era_current=current_block,
             raise_error=raise_error,
             wait_for_inclusion=wait_for_inclusion,
             wait_for_finalization=wait_for_finalization,

--- a/bittensor/core/subtensor.py
+++ b/bittensor/core/subtensor.py
@@ -5267,6 +5267,7 @@ class Subtensor(SubtensorMixin):
         nonce: Optional[int] = None,
         *,
         period: Optional[int] = DEFAULT_PERIOD,
+        era_current: Optional[int] = None,
         raise_error: bool = False,
         wait_for_inclusion: bool = True,
         wait_for_finalization: bool = False,
@@ -5285,6 +5286,8 @@ class Subtensor(SubtensorMixin):
             period: The number of blocks during which the transaction will remain valid after it's submitted. If the
                 transaction is not included in a block within that number of blocks, it will expire and be rejected. You
                 can think of it as an expiration date for the transaction.
+            era_current: The block number to anchor the mortal era to. If not provided, the substrate interface chooses
+                the anchor.
             raise_error: Raises the relevant exception rather than returning `False` if unsuccessful.
             wait_for_inclusion: Whether to wait until the extrinsic call is included on the chain
             wait_for_finalization: Whether to wait until the extrinsic call is finalized on the chain
@@ -5324,6 +5327,8 @@ class Subtensor(SubtensorMixin):
 
         if period is not None:
             extrinsic_data["era"] = {"period": period}
+            if era_current is not None:
+                extrinsic_data["era"]["current"] = era_current
 
         extrinsic_response.extrinsic = self.substrate.create_signed_extrinsic(
             **extrinsic_data

--- a/tests/unit_tests/extrinsics/asyncex/test_mev_shield.py
+++ b/tests/unit_tests/extrinsics/asyncex/test_mev_shield.py
@@ -127,6 +127,7 @@ async def test_submit_encrypted_extrinsic_success_with_revealed_execution(
     signed_extrinsic_hash = f"0x{signed_extrinsic_hash_hex}"
     current_nonce = 5
     next_nonce = 6
+    current_block = 12345
     block_hash = "0xblockhash"
 
     mocked_unlock_wallet = mocker.patch.object(
@@ -143,6 +144,11 @@ async def test_submit_encrypted_extrinsic_success_with_revealed_execution(
         subtensor.substrate,
         "get_account_next_index",
         new=mocker.AsyncMock(side_effect=[current_nonce, next_nonce]),
+    )
+    mocker.patch.object(
+        subtensor.substrate,
+        "get_block_number",
+        new=mocker.AsyncMock(return_value=current_block),
     )
     mock_signed_extrinsic = mocker.MagicMock()
     mock_signed_extrinsic.extrinsic_hash.hex.return_value = signed_extrinsic_hash_hex
@@ -221,7 +227,7 @@ async def test_submit_encrypted_extrinsic_success_with_revealed_execution(
         call=call,
         keypair=fake_wallet.coldkey,
         nonce=next_nonce,
-        era={"period": 8},
+        era={"period": 8, "current": current_block},
     )
     mocked_get_mev_shielded_ciphertext.assert_called_once_with(
         signed_ext=mock_signed_extrinsic,
@@ -237,6 +243,7 @@ async def test_submit_encrypted_extrinsic_success_with_revealed_execution(
         call=mock_extrinsic_call,
         nonce=current_nonce,
         period=8,
+        era_current=current_block,
         raise_error=False,
         wait_for_inclusion=True,
         wait_for_finalization=False,
@@ -272,6 +279,7 @@ async def test_submit_encrypted_extrinsic_success_without_revealed_execution(
     signed_extrinsic_hash = f"0x{signed_extrinsic_hash_hex}"
     current_nonce = 5
     next_nonce = 6
+    current_block = 12345
 
     mocked_unlock_wallet = mocker.patch.object(
         ExtrinsicResponse,
@@ -287,6 +295,11 @@ async def test_submit_encrypted_extrinsic_success_without_revealed_execution(
         subtensor.substrate,
         "get_account_next_index",
         new=mocker.AsyncMock(side_effect=[current_nonce, next_nonce]),
+    )
+    mocker.patch.object(
+        subtensor.substrate,
+        "get_block_number",
+        new=mocker.AsyncMock(return_value=current_block),
     )
     mock_signed_extrinsic = mocker.MagicMock()
     mock_signed_extrinsic.extrinsic_hash.hex.return_value = signed_extrinsic_hash_hex
@@ -338,7 +351,7 @@ async def test_submit_encrypted_extrinsic_success_without_revealed_execution(
         call=call,
         keypair=fake_wallet.coldkey,
         nonce=next_nonce,
-        era={"period": 8},
+        era={"period": 8, "current": current_block},
     )
     mocked_get_mev_shielded_ciphertext.assert_called_once_with(
         signed_ext=mock_signed_extrinsic,
@@ -354,6 +367,7 @@ async def test_submit_encrypted_extrinsic_success_without_revealed_execution(
         call=mock_extrinsic_call,
         nonce=current_nonce,
         period=8,
+        era_current=current_block,
         raise_error=False,
         wait_for_inclusion=True,
         wait_for_finalization=False,
@@ -484,6 +498,7 @@ async def test_submit_encrypted_extrinsic_encrypted_submitted_event_not_found(
     mev_ciphertext = b"fake_ciphertext"
     current_nonce = 5
     next_nonce = 6
+    current_block = 12345
 
     mocked_unlock_wallet = mocker.patch.object(
         ExtrinsicResponse,
@@ -499,6 +514,11 @@ async def test_submit_encrypted_extrinsic_encrypted_submitted_event_not_found(
         subtensor.substrate,
         "get_account_next_index",
         new=mocker.AsyncMock(side_effect=[current_nonce, next_nonce]),
+    )
+    mocker.patch.object(
+        subtensor.substrate,
+        "get_block_number",
+        new=mocker.AsyncMock(return_value=current_block),
     )
     mock_signed_extrinsic = mocker.MagicMock()
     mock_signed_extrinsic.extrinsic_hash.hex.return_value = "abcdef123456"
@@ -558,7 +578,7 @@ async def test_submit_encrypted_extrinsic_encrypted_submitted_event_not_found(
         call=call,
         keypair=fake_wallet.coldkey,
         nonce=next_nonce,
-        era={"period": 8},
+        era={"period": 8, "current": current_block},
     )
     mocked_get_mev_shielded_ciphertext.assert_called_once_with(
         signed_ext=mock_signed_extrinsic,
@@ -574,6 +594,7 @@ async def test_submit_encrypted_extrinsic_encrypted_submitted_event_not_found(
         call=mock_extrinsic_call,
         nonce=current_nonce,
         period=8,
+        era_current=current_block,
         raise_error=False,
         wait_for_inclusion=True,
         wait_for_finalization=False,
@@ -604,6 +625,7 @@ async def test_submit_encrypted_extrinsic_failed_to_find_outcome(
     signed_extrinsic_hash = f"0x{signed_extrinsic_hash_hex}"
     current_nonce = 5
     next_nonce = 6
+    current_block = 12345
     block_hash = "0xblockhash"
 
     mocked_unlock_wallet = mocker.patch.object(
@@ -620,6 +642,11 @@ async def test_submit_encrypted_extrinsic_failed_to_find_outcome(
         subtensor.substrate,
         "get_account_next_index",
         new=mocker.AsyncMock(side_effect=[current_nonce, next_nonce]),
+    )
+    mocker.patch.object(
+        subtensor.substrate,
+        "get_block_number",
+        new=mocker.AsyncMock(return_value=current_block),
     )
     mock_signed_extrinsic = mocker.MagicMock()
     mock_signed_extrinsic.extrinsic_hash.hex.return_value = signed_extrinsic_hash_hex
@@ -695,7 +722,7 @@ async def test_submit_encrypted_extrinsic_failed_to_find_outcome(
         call=call,
         keypair=fake_wallet.coldkey,
         nonce=next_nonce,
-        era={"period": 8},
+        era={"period": 8, "current": current_block},
     )
     mocked_get_mev_shielded_ciphertext.assert_called_once_with(
         signed_ext=mock_signed_extrinsic,
@@ -711,6 +738,7 @@ async def test_submit_encrypted_extrinsic_failed_to_find_outcome(
         call=mock_extrinsic_call,
         nonce=current_nonce,
         period=8,
+        era_current=current_block,
         raise_error=False,
         wait_for_inclusion=True,
         wait_for_finalization=False,
@@ -747,6 +775,7 @@ async def test_submit_encrypted_extrinsic_execution_failure(
     signed_extrinsic_hash = f"0x{signed_extrinsic_hash_hex}"
     current_nonce = 5
     next_nonce = 6
+    current_block = 12345
     block_hash = "0xblockhash"
     error_message = "Execution failed"
     formatted_error = "Formatted error: Execution failed"
@@ -765,6 +794,11 @@ async def test_submit_encrypted_extrinsic_execution_failure(
         subtensor.substrate,
         "get_account_next_index",
         new=mocker.AsyncMock(side_effect=[current_nonce, next_nonce]),
+    )
+    mocker.patch.object(
+        subtensor.substrate,
+        "get_block_number",
+        new=mocker.AsyncMock(return_value=current_block),
     )
     mock_signed_extrinsic = mocker.MagicMock()
     mock_signed_extrinsic.extrinsic_hash.hex.return_value = signed_extrinsic_hash_hex
@@ -847,7 +881,7 @@ async def test_submit_encrypted_extrinsic_execution_failure(
         call=call,
         keypair=fake_wallet.coldkey,
         nonce=next_nonce,
-        era={"period": 8},
+        era={"period": 8, "current": current_block},
     )
     mocked_get_mev_shielded_ciphertext.assert_called_once_with(
         signed_ext=mock_signed_extrinsic,
@@ -863,6 +897,7 @@ async def test_submit_encrypted_extrinsic_execution_failure(
         call=mock_extrinsic_call,
         nonce=current_nonce,
         period=8,
+        era_current=current_block,
         raise_error=False,
         wait_for_inclusion=True,
         wait_for_finalization=False,
@@ -898,6 +933,7 @@ async def test_submit_encrypted_extrinsic_sign_and_send_failure(
     mev_ciphertext = b"fake_ciphertext"
     current_nonce = 5
     next_nonce = 6
+    current_block = 12345
 
     mocked_unlock_wallet = mocker.patch.object(
         ExtrinsicResponse,
@@ -913,6 +949,11 @@ async def test_submit_encrypted_extrinsic_sign_and_send_failure(
         subtensor.substrate,
         "get_account_next_index",
         new=mocker.AsyncMock(side_effect=[current_nonce, next_nonce]),
+    )
+    mocker.patch.object(
+        subtensor.substrate,
+        "get_block_number",
+        new=mocker.AsyncMock(return_value=current_block),
     )
     mock_signed_extrinsic = mocker.MagicMock()
     mock_signed_extrinsic.extrinsic_hash.hex.return_value = "abcdef123456"
@@ -963,7 +1004,7 @@ async def test_submit_encrypted_extrinsic_sign_and_send_failure(
         call=call,
         keypair=fake_wallet.coldkey,
         nonce=next_nonce,
-        era={"period": 8},
+        era={"period": 8, "current": current_block},
     )
     mocked_get_mev_shielded_ciphertext.assert_called_once_with(
         signed_ext=mock_signed_extrinsic,
@@ -979,6 +1020,7 @@ async def test_submit_encrypted_extrinsic_sign_and_send_failure(
         call=mock_extrinsic_call,
         nonce=current_nonce,
         period=8,
+        era_current=current_block,
         raise_error=False,
         wait_for_inclusion=True,
         wait_for_finalization=False,
@@ -999,6 +1041,7 @@ async def test_submit_encrypted_extrinsic_with_hotkey(subtensor, fake_wallet, mo
     mev_ciphertext = b"fake_ciphertext"
     current_nonce = 5
     next_nonce = 6
+    current_block = 12345
 
     mocked_unlock_wallet = mocker.patch.object(
         ExtrinsicResponse,
@@ -1014,6 +1057,11 @@ async def test_submit_encrypted_extrinsic_with_hotkey(subtensor, fake_wallet, mo
         subtensor.substrate,
         "get_account_next_index",
         new=mocker.AsyncMock(side_effect=[current_nonce, next_nonce]),
+    )
+    mocker.patch.object(
+        subtensor.substrate,
+        "get_block_number",
+        new=mocker.AsyncMock(return_value=current_block),
     )
     mock_signed_extrinsic = mocker.MagicMock()
     mock_signed_extrinsic.extrinsic_hash.hex.return_value = "abcdef123456"
@@ -1065,7 +1113,7 @@ async def test_submit_encrypted_extrinsic_with_hotkey(subtensor, fake_wallet, mo
         call=call,
         keypair=fake_wallet.hotkey,
         nonce=next_nonce,
-        era={"period": 8},
+        era={"period": 8, "current": current_block},
     )
     mocked_get_mev_shielded_ciphertext.assert_called_once_with(
         signed_ext=mock_signed_extrinsic,
@@ -1081,6 +1129,7 @@ async def test_submit_encrypted_extrinsic_with_hotkey(subtensor, fake_wallet, mo
         call=mock_extrinsic_call,
         nonce=current_nonce,
         period=8,
+        era_current=current_block,
         raise_error=False,
         wait_for_inclusion=True,
         wait_for_finalization=False,
@@ -1101,6 +1150,7 @@ async def test_submit_encrypted_extrinsic_with_period(subtensor, fake_wallet, mo
     mev_ciphertext = b"fake_ciphertext"
     current_nonce = 5
     next_nonce = 6
+    current_block = 12345
     period = 64
 
     mocked_unlock_wallet = mocker.patch.object(
@@ -1117,6 +1167,11 @@ async def test_submit_encrypted_extrinsic_with_period(subtensor, fake_wallet, mo
         subtensor.substrate,
         "get_account_next_index",
         new=mocker.AsyncMock(side_effect=[current_nonce, next_nonce]),
+    )
+    mocker.patch.object(
+        subtensor.substrate,
+        "get_block_number",
+        new=mocker.AsyncMock(return_value=current_block),
     )
     mock_signed_extrinsic = mocker.MagicMock()
     mock_signed_extrinsic.extrinsic_hash.hex.return_value = "abcdef123456"
@@ -1168,7 +1223,7 @@ async def test_submit_encrypted_extrinsic_with_period(subtensor, fake_wallet, mo
         call=call,
         keypair=fake_wallet.coldkey,
         nonce=next_nonce,
-        era={"period": MAX_MEV_SHIELD_PERIOD},
+        era={"period": MAX_MEV_SHIELD_PERIOD, "current": current_block},
     )
     mocked_get_mev_shielded_ciphertext.assert_called_once_with(
         signed_ext=mock_signed_extrinsic,
@@ -1184,6 +1239,7 @@ async def test_submit_encrypted_extrinsic_with_period(subtensor, fake_wallet, mo
         call=mock_extrinsic_call,
         nonce=current_nonce,
         period=MAX_MEV_SHIELD_PERIOD,
+        era_current=current_block,
         raise_error=False,
         wait_for_inclusion=True,
         wait_for_finalization=False,

--- a/tests/unit_tests/extrinsics/test_mev_shield.py
+++ b/tests/unit_tests/extrinsics/test_mev_shield.py
@@ -111,6 +111,7 @@ def test_submit_encrypted_extrinsic_success_with_revealed_execution(
     signed_extrinsic_hash = f"0x{signed_extrinsic_hash_hex}"
     current_nonce = 5
     next_nonce = 6
+    current_block = 12345
     block_hash = "0xblockhash"
 
     mocked_unlock_wallet = mocker.patch.object(
@@ -125,6 +126,9 @@ def test_submit_encrypted_extrinsic_success_with_revealed_execution(
         subtensor.substrate,
         "get_account_next_index",
         return_value=current_nonce,
+    )
+    mocker.patch.object(
+        subtensor.substrate, "get_block_number", return_value=current_block
     )
     mock_signed_extrinsic = mocker.MagicMock()
     mock_signed_extrinsic.extrinsic_hash.hex.return_value = signed_extrinsic_hash_hex
@@ -196,7 +200,7 @@ def test_submit_encrypted_extrinsic_success_with_revealed_execution(
         call=call,
         keypair=fake_wallet.coldkey,
         nonce=next_nonce,
-        era={"period": 8},
+        era={"period": 8, "current": current_block},
     )
     mocked_get_mev_shielded_ciphertext.assert_called_once_with(
         signed_ext=mock_signed_extrinsic,
@@ -212,6 +216,7 @@ def test_submit_encrypted_extrinsic_success_with_revealed_execution(
         call=mock_extrinsic_call,
         nonce=current_nonce,
         period=8,
+        era_current=current_block,
         raise_error=False,
         wait_for_inclusion=True,
         wait_for_finalization=False,
@@ -249,6 +254,7 @@ def test_submit_encrypted_extrinsic_success_without_revealed_execution(
     signed_extrinsic_hash = f"0x{signed_extrinsic_hash_hex}"
     current_nonce = 5
     next_nonce = 6
+    current_block = 12345
 
     mocked_unlock_wallet = mocker.patch.object(
         ExtrinsicResponse,
@@ -262,6 +268,9 @@ def test_submit_encrypted_extrinsic_success_without_revealed_execution(
         subtensor.substrate,
         "get_account_next_index",
         return_value=current_nonce,
+    )
+    mocker.patch.object(
+        subtensor.substrate, "get_block_number", return_value=current_block
     )
     mock_signed_extrinsic = mocker.MagicMock()
     mock_signed_extrinsic.extrinsic_hash.hex.return_value = signed_extrinsic_hash_hex
@@ -308,7 +317,7 @@ def test_submit_encrypted_extrinsic_success_without_revealed_execution(
         call=call,
         keypair=fake_wallet.coldkey,
         nonce=next_nonce,
-        era={"period": 8},
+        era={"period": 8, "current": current_block},
     )
     mocked_get_mev_shielded_ciphertext.assert_called_once_with(
         signed_ext=mock_signed_extrinsic,
@@ -324,6 +333,7 @@ def test_submit_encrypted_extrinsic_success_without_revealed_execution(
         call=mock_extrinsic_call,
         nonce=current_nonce,
         period=8,
+        era_current=current_block,
         raise_error=False,
         wait_for_inclusion=True,
         wait_for_finalization=False,
@@ -445,6 +455,7 @@ def test_submit_encrypted_extrinsic_encrypted_submitted_event_not_found(
     mev_ciphertext = b"fake_ciphertext"
     current_nonce = 5
     next_nonce = 6
+    current_block = 12345
 
     mocked_unlock_wallet = mocker.patch.object(
         ExtrinsicResponse,
@@ -458,6 +469,9 @@ def test_submit_encrypted_extrinsic_encrypted_submitted_event_not_found(
         subtensor.substrate,
         "get_account_next_index",
         return_value=current_nonce,
+    )
+    mocker.patch.object(
+        subtensor.substrate, "get_block_number", return_value=current_block
     )
     mock_signed_extrinsic = mocker.MagicMock()
     mock_signed_extrinsic.extrinsic_hash.hex.return_value = "abcdef123456"
@@ -510,7 +524,7 @@ def test_submit_encrypted_extrinsic_encrypted_submitted_event_not_found(
         call=call,
         keypair=fake_wallet.coldkey,
         nonce=next_nonce,
-        era={"period": 8},
+        era={"period": 8, "current": current_block},
     )
     mocked_get_mev_shielded_ciphertext.assert_called_once_with(
         signed_ext=mock_signed_extrinsic,
@@ -526,6 +540,7 @@ def test_submit_encrypted_extrinsic_encrypted_submitted_event_not_found(
         call=mock_extrinsic_call,
         nonce=current_nonce,
         period=8,
+        era_current=current_block,
         raise_error=False,
         wait_for_inclusion=True,
         wait_for_finalization=False,
@@ -555,6 +570,7 @@ def test_submit_encrypted_extrinsic_failed_to_find_outcome(
     signed_extrinsic_hash = f"0x{signed_extrinsic_hash_hex}"
     current_nonce = 5
     next_nonce = 6
+    current_block = 12345
     block_hash = "0xblockhash"
 
     mocked_unlock_wallet = mocker.patch.object(
@@ -569,6 +585,9 @@ def test_submit_encrypted_extrinsic_failed_to_find_outcome(
         subtensor.substrate,
         "get_account_next_index",
         return_value=current_nonce,
+    )
+    mocker.patch.object(
+        subtensor.substrate, "get_block_number", return_value=current_block
     )
     mock_signed_extrinsic = mocker.MagicMock()
     mock_signed_extrinsic.extrinsic_hash.hex.return_value = signed_extrinsic_hash_hex
@@ -636,7 +655,7 @@ def test_submit_encrypted_extrinsic_failed_to_find_outcome(
         call=call,
         keypair=fake_wallet.coldkey,
         nonce=next_nonce,
-        era={"period": 8},
+        era={"period": 8, "current": current_block},
     )
     mocked_get_mev_shielded_ciphertext.assert_called_once_with(
         signed_ext=mock_signed_extrinsic,
@@ -652,6 +671,7 @@ def test_submit_encrypted_extrinsic_failed_to_find_outcome(
         call=mock_extrinsic_call,
         nonce=current_nonce,
         period=8,
+        era_current=current_block,
         raise_error=False,
         wait_for_inclusion=True,
         wait_for_finalization=False,
@@ -685,6 +705,7 @@ def test_submit_encrypted_extrinsic_execution_failure(subtensor, fake_wallet, mo
     signed_extrinsic_hash = f"0x{signed_extrinsic_hash_hex}"
     current_nonce = 5
     next_nonce = 6
+    current_block = 12345
     block_hash = "0xblockhash"
     error_message = "Execution failed"
     formatted_error = "Formatted error: Execution failed"
@@ -701,6 +722,9 @@ def test_submit_encrypted_extrinsic_execution_failure(subtensor, fake_wallet, mo
         subtensor.substrate,
         "get_account_next_index",
         return_value=current_nonce,
+    )
+    mocker.patch.object(
+        subtensor.substrate, "get_block_number", return_value=current_block
     )
     mock_signed_extrinsic = mocker.MagicMock()
     mock_signed_extrinsic.extrinsic_hash.hex.return_value = signed_extrinsic_hash_hex
@@ -775,7 +799,7 @@ def test_submit_encrypted_extrinsic_execution_failure(subtensor, fake_wallet, mo
         call=call,
         keypair=fake_wallet.coldkey,
         nonce=next_nonce,
-        era={"period": 8},
+        era={"period": 8, "current": current_block},
     )
     mocked_get_mev_shielded_ciphertext.assert_called_once_with(
         signed_ext=mock_signed_extrinsic,
@@ -791,6 +815,7 @@ def test_submit_encrypted_extrinsic_execution_failure(subtensor, fake_wallet, mo
         call=mock_extrinsic_call,
         nonce=current_nonce,
         period=8,
+        era_current=current_block,
         raise_error=False,
         wait_for_inclusion=True,
         wait_for_finalization=False,
@@ -825,6 +850,7 @@ def test_submit_encrypted_extrinsic_sign_and_send_failure(
     mev_ciphertext = b"fake_ciphertext"
     current_nonce = 5
     next_nonce = 6
+    current_block = 12345
 
     mocked_unlock_wallet = mocker.patch.object(
         ExtrinsicResponse,
@@ -838,6 +864,9 @@ def test_submit_encrypted_extrinsic_sign_and_send_failure(
         subtensor.substrate,
         "get_account_next_index",
         return_value=current_nonce,
+    )
+    mocker.patch.object(
+        subtensor.substrate, "get_block_number", return_value=current_block
     )
     mock_signed_extrinsic = mocker.MagicMock()
     mock_signed_extrinsic.extrinsic_hash.hex.return_value = "abcdef123456"
@@ -883,7 +912,7 @@ def test_submit_encrypted_extrinsic_sign_and_send_failure(
         call=call,
         keypair=fake_wallet.coldkey,
         nonce=next_nonce,
-        era={"period": 8},
+        era={"period": 8, "current": current_block},
     )
     mocked_get_mev_shielded_ciphertext.assert_called_once_with(
         signed_ext=mock_signed_extrinsic,
@@ -899,6 +928,7 @@ def test_submit_encrypted_extrinsic_sign_and_send_failure(
         call=mock_extrinsic_call,
         nonce=current_nonce,
         period=8,
+        era_current=current_block,
         raise_error=False,
         wait_for_inclusion=True,
         wait_for_finalization=False,
@@ -918,6 +948,7 @@ def test_submit_encrypted_extrinsic_with_hotkey(subtensor, fake_wallet, mocker):
     mev_ciphertext = b"fake_ciphertext"
     current_nonce = 5
     next_nonce = 6
+    current_block = 12345
 
     mocked_unlock_wallet = mocker.patch.object(
         ExtrinsicResponse,
@@ -931,6 +962,9 @@ def test_submit_encrypted_extrinsic_with_hotkey(subtensor, fake_wallet, mocker):
         subtensor.substrate,
         "get_account_next_index",
         return_value=current_nonce,
+    )
+    mocker.patch.object(
+        subtensor.substrate, "get_block_number", return_value=current_block
     )
     mock_signed_extrinsic = mocker.MagicMock()
     mock_signed_extrinsic.extrinsic_hash.hex.return_value = "abcdef123456"
@@ -977,7 +1011,7 @@ def test_submit_encrypted_extrinsic_with_hotkey(subtensor, fake_wallet, mocker):
         call=call,
         keypair=fake_wallet.hotkey,
         nonce=next_nonce,
-        era={"period": 8},
+        era={"period": 8, "current": current_block},
     )
     mocked_get_mev_shielded_ciphertext.assert_called_once_with(
         signed_ext=mock_signed_extrinsic,
@@ -993,6 +1027,7 @@ def test_submit_encrypted_extrinsic_with_hotkey(subtensor, fake_wallet, mocker):
         call=mock_extrinsic_call,
         nonce=current_nonce,
         period=8,
+        era_current=current_block,
         raise_error=False,
         wait_for_inclusion=True,
         wait_for_finalization=False,
@@ -1012,6 +1047,7 @@ def test_submit_encrypted_extrinsic_with_period(subtensor, fake_wallet, mocker):
     mev_ciphertext = b"fake_ciphertext"
     current_nonce = 5
     next_nonce = 6
+    current_block = 12345
     period = 64
 
     mocked_unlock_wallet = mocker.patch.object(
@@ -1026,6 +1062,9 @@ def test_submit_encrypted_extrinsic_with_period(subtensor, fake_wallet, mocker):
         subtensor.substrate,
         "get_account_next_index",
         return_value=current_nonce,
+    )
+    mocker.patch.object(
+        subtensor.substrate, "get_block_number", return_value=current_block
     )
     mock_signed_extrinsic = mocker.MagicMock()
     mock_signed_extrinsic.extrinsic_hash.hex.return_value = "abcdef123456"
@@ -1072,7 +1111,7 @@ def test_submit_encrypted_extrinsic_with_period(subtensor, fake_wallet, mocker):
         call=call,
         keypair=fake_wallet.coldkey,
         nonce=next_nonce,
-        era={"period": MAX_MEV_SHIELD_PERIOD},
+        era={"period": MAX_MEV_SHIELD_PERIOD, "current": current_block},
     )
     mocked_get_mev_shielded_ciphertext.assert_called_once_with(
         signed_ext=mock_signed_extrinsic,
@@ -1088,6 +1127,7 @@ def test_submit_encrypted_extrinsic_with_period(subtensor, fake_wallet, mocker):
         call=mock_extrinsic_call,
         nonce=current_nonce,
         period=MAX_MEV_SHIELD_PERIOD,
+        era_current=current_block,
         raise_error=False,
         wait_for_inclusion=True,
         wait_for_finalization=False,

--- a/tests/unit_tests/test_async_subtensor.py
+++ b/tests/unit_tests/test_async_subtensor.py
@@ -1785,6 +1785,42 @@ async def test_sign_and_send_extrinsic_success_finalization(
 
 
 @pytest.mark.asyncio
+async def test_sign_and_send_extrinsic_uses_era_current(subtensor, fake_wallet, mocker):
+    """Verify sign_and_send_extrinsic forwards an explicit era anchor."""
+    fake_call = mocker.Mock()
+    fake_extrinsic = mocker.Mock()
+    fake_response = mocker.Mock()
+    fake_response.total_fee_amount = mocker.AsyncMock(return_value=1)()
+    fake_response.is_success = mocker.AsyncMock(return_value=True)()
+
+    mocked_create_signed_extrinsic = mocker.AsyncMock(return_value=fake_extrinsic)
+    subtensor.substrate.create_signed_extrinsic = mocked_create_signed_extrinsic
+
+    mocked_submit_extrinsic = mocker.AsyncMock(return_value=fake_response)
+    subtensor.substrate.submit_extrinsic = mocked_submit_extrinsic
+
+    result = await subtensor.sign_and_send_extrinsic(
+        call=fake_call,
+        wallet=fake_wallet,
+        period=8,
+        era_current=12345,
+    )
+
+    mocked_create_signed_extrinsic.assert_awaited_once_with(
+        call=fake_call,
+        keypair=fake_wallet.coldkey,
+        era={"period": 8, "current": 12345},
+    )
+    mocked_submit_extrinsic.assert_awaited_once_with(
+        extrinsic=fake_extrinsic,
+        wait_for_inclusion=True,
+        wait_for_finalization=False,
+    )
+    assert result.success is True
+    assert result.message == "Success"
+
+
+@pytest.mark.asyncio
 async def test_sign_and_send_extrinsic_error_finalization(
     subtensor, fake_wallet, mocker
 ):

--- a/tests/unit_tests/test_subtensor.py
+++ b/tests/unit_tests/test_subtensor.py
@@ -101,6 +101,45 @@ def test_methods_comparable(mock_substrate):
         )
 
 
+def test_sign_and_send_extrinsic_uses_era_current(subtensor, fake_wallet, mocker):
+    """Verify sign_and_send_extrinsic forwards an explicit era anchor."""
+    fake_call = mocker.Mock()
+    fake_extrinsic = mocker.Mock()
+    fake_response = mocker.Mock(is_success=True, total_fee_amount=1)
+    fake_wallet.coldkey = mocker.Mock()
+
+    mocked_create_signed_extrinsic = mocker.patch.object(
+        subtensor.substrate,
+        "create_signed_extrinsic",
+        return_value=fake_extrinsic,
+    )
+    mocked_submit_extrinsic = mocker.patch.object(
+        subtensor.substrate,
+        "submit_extrinsic",
+        return_value=fake_response,
+    )
+
+    result = subtensor.sign_and_send_extrinsic(
+        call=fake_call,
+        wallet=fake_wallet,
+        period=8,
+        era_current=12345,
+    )
+
+    mocked_create_signed_extrinsic.assert_called_once_with(
+        call=fake_call,
+        keypair=fake_wallet.coldkey,
+        era={"period": 8, "current": 12345},
+    )
+    mocked_submit_extrinsic.assert_called_once_with(
+        extrinsic=fake_extrinsic,
+        wait_for_inclusion=True,
+        wait_for_finalization=False,
+    )
+    assert result.success is True
+    assert result.message == "Success"
+
+
 def test_serve_axon_with_external_ip_set():
     internal_ip: str = "192.0.2.146"
     external_ip: str = "2001:0db8:85a3:0000:0000:8a2e:0370:7334"


### PR DESCRIPTION
Hi! I am Loom Agent - an autonomous AI agent set up by my maintainer to help contribute to this repository. This pull request was prepared autonomously under human supervision. Feedback is very welcome - I will do my best to address review comments promptly.

### Bug

Closes #3395. `commit_timelocked_weights_extrinsic(..., mev_protection=True)` is intermittently rejected at pool admission with `Transaction is outdated` (`InvalidTransaction::Stale`) whenever finality lags the best head by the MEV Shield era period (8 blocks). The extrinsic is valid by construction but arrives already expired.

### Description of the Change

`create_signed_extrinsic` (async-substrate-interface) anchors a mortal era with no explicit `current` at the **finalized** head, but the transaction pool evaluates era mortality against the node's **best** head. With the chain-enforced `MAX_MEV_SHIELD_PERIOD = 8`, any moment where `best_head - finalized_head >= 8` makes the extrinsic dead on arrival.

This anchors both the inner MEV Shield signed extrinsic and the outer `submit_encrypted` to the **best** head instead:

- `bittensor/core/async_subtensor.py` and `bittensor/core/subtensor.py`: `sign_and_send_extrinsic` accepts an optional `era_current` (best-head block number) and forwards it into the era when provided.
- `bittensor/core/extrinsics/asyncex/mev_shield.py` and `bittensor/core/extrinsics/mev_shield.py`: resolve the best-head block number and pass it as `era_current`, so the era becomes `{"period": effective_period, "current": best_block}`.

The era is now anchored at the head the pool actually checks mortality against. `era_current` is optional and defaults to the existing behaviour, so non-MEV extrinsics are unaffected.

### Alternate Designs

The issue suggested three directions; this PR combines (1) anchor at the best head - the direct fix - with (2) exposing the anchor as an opt-in parameter (`era_current`). Direction (3), a reactive retry on `InvalidTransaction::Stale`, was not taken: the anchored window is valid by construction, so a retry would only paper over the symptom, add latency, and could itself land in the next lag spike.

Scoping the change to the MEV Shield path (rather than every extrinsic) is deliberate: MEV Shield is the only path whose era period can be as short as the typical finality lag, so it is the only path where the finalized-head anchor can produce a zero-length validity window.

### Possible Drawbacks

- The era window now depends on the best head, which can briefly sit on a non-finalized fork. In practice this is the same head the pool already evaluates mortality against, so it widens the effective validity window without making transactions invalid; if the best head is re-orged away the extrinsic simply is not included, same as today.
- Adds an optional parameter to an internal signing path; it is not part of the public API surface and carries a default that preserves prior behaviour.

### Verification Process

Reproduced the project's CI on a clean clone of `staging` (Python 3.12, mypy 1.20.2, ruff 0.15.12, matching `.github/workflows`):

```
mypy --ignore-missing-imports bittensor/
  Success: no issues found in 141 source files
ruff format --diff bittensor tests
  237 files already formatted
ruff check bittensor
  All checks passed!
pytest tests/unit_tests/extrinsics/asyncex/test_mev_shield.py \
       tests/unit_tests/extrinsics/test_mev_shield.py \
       tests/unit_tests/test_async_subtensor.py \
       tests/unit_tests/test_subtensor.py -q
  584 passed, 2 warnings in 68.96s
```

New regression tests assert the era carries both `period` and `current` on the sync and async MEV Shield paths, so the anchoring cannot silently regress to the finalized head.

### Release Notes

- Fixed MEV Shield `submit_encrypted` being intermittently rejected as "Transaction is outdated" when finality lagged the best head by the era period.

### Branch Acknowledgement
[x] I am acknowledging that I am opening this branch against `staging`
