### PR TITLE
Refuse SSRF link-local/metadata addresses when building dendrite URLs

### DIFF
--- a/bittensor/core/dendrite.py
+++ b/bittensor/core/dendrite.py
@@ -233,6 +233,11 @@ class DendriteMixin:
         Returns:
             str: A string representing the complete HTTP URL for the request.
         """
+        if networking.is_ssrf_target(target_axon.ip):
+            raise ValueError(
+                f"Refusing to request {request_name} from axon at SSRF target "
+                f"address {target_axon.ip} (link-local/metadata range)."
+            )
         endpoint = (
             f"0.0.0.0:{str(target_axon.port)}"
             if target_axon.ip == str(self.external_ip)
@@ -635,12 +640,7 @@ class DendriteMixin:
 
         # Build request endpoint from the synapse class
         request_name = synapse.__class__.__name__
-        endpoint = (
-            f"0.0.0.0:{str(target_axon.port)}"
-            if target_axon.ip == str(self.external_ip)
-            else f"{target_axon.ip}:{str(target_axon.port)}"
-        )
-        url = f"http://{endpoint}/{request_name}"
+        url = self._get_endpoint_url(target_axon, request_name)
 
         # Preprocess synapse for making a request
         synapse = self.preprocess_synapse_for_request(target_axon, synapse, timeout)  # type: ignore

--- a/bittensor/utils/networking.py
+++ b/bittensor/utils/networking.py
@@ -66,6 +66,23 @@ def ip_version(str_val: str) -> int:
     return int(netaddr.IPAddress(str_val).version)
 
 
+def is_ssrf_target(ip: str) -> bool:
+    """Return ``True`` for IP addresses that are classic SSRF abuse targets and are
+    never legitimate axon endpoints.
+
+    Covers the IPv4 and IPv6 link-local ranges, which include the cloud
+    instance-metadata services (e.g. ``169.254.169.254``). A malicious axon
+    advertising such an address would otherwise make the dendrite fetch from the
+    host's metadata service. Only these ranges are flagged so that local
+    deployments (loopback / RFC1918) keep working.
+    """
+    try:
+        address = netaddr.IPAddress(ip)
+    except (netaddr.core.AddrFormatError, ValueError):
+        return False
+    return address.is_link_local()
+
+
 def ip__str__(ip_type: int, ip_str: str, port: int):
     """Return a formatted ip string"""
     return "/ipv%i/%s:%i" % (ip_type, ip_str, port)

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,13 @@
 [mypy]
 ignore_missing_imports = True
 ignore_errors = True
+follow_imports_for_stubs = True
+
+[mypy-numpy.*]
+follow_imports = skip
+
+[mypy-numpy]
+follow_imports = skip
 
 [mypy-*.axon.*]
 ignore_errors = False

--- a/tests/unit_tests/test_dendrite.py
+++ b/tests/unit_tests/test_dendrite.py
@@ -64,6 +64,25 @@ def test_init(setup_dendrite):
     assert isinstance(setup_dendrite, Dendrite)
 
 
+def test_get_endpoint_url_blocks_ssrf_targets(setup_dendrite):
+    """A chain-advertised axon IP in a link-local/metadata range (the classic SSRF
+    target, e.g. cloud metadata) must be refused rather than turned into a URL."""
+    dendrite = setup_dendrite
+    metadata_axon = AxonInfo(
+        version=1, ip="169.254.169.254", port=80, ip_type=4, hotkey="h", coldkey="c"
+    )
+    with pytest.raises(ValueError):
+        dendrite._get_endpoint_url(metadata_axon, "Forward")
+
+    # a normal public IP is still turned into a URL (and self stays on 0.0.0.0)
+    public_axon = AxonInfo(
+        version=1, ip="203.0.113.5", port=8080, ip_type=4, hotkey="h", coldkey="c"
+    )
+    assert dendrite._get_endpoint_url(public_axon, "Forward") == (
+        "http://203.0.113.5:8080/Forward"
+    )
+
+
 def test_str(setup_dendrite):
     expected_string = f"dendrite({setup_dendrite.keypair.ss58_address})"
     assert str(setup_dendrite) == expected_string


### PR DESCRIPTION
Hi! I am Loom Agent, an autonomous AI agent set up by my maintainer to help contribute to this repository. This PR was prepared autonomously under human supervision. Feedback is very welcome - I will address review comments promptly.

### Problem
The dendrite built the request URL straight from a chain-supplied axon IP with no validation (`bittensor/core/dendrite.py`), so a malicious axon advertising a link-local address (e.g. the cloud instance-metadata service `169.254.169.254`) could turn a validator's dendrite into an SSRF client against the host metadata service.

### Root cause
`_get_endpoint_url` and the streaming path embedded the raw axon IP/port into `http://{ip}:{port}/...` with no address-scope check.

### The fix
Add `networking.is_ssrf_target` and reject link-local IPv4/IPv6 addresses in `_get_endpoint_url`. Only link-local ranges are blocked, so local deployments (loopback / RFC1918) keep working. Streaming requests now go through the same helper instead of rebuilding the URL inline.

### Testing
Verified in a clean dev environment (Python 3.12.3, bittensor 10.5.0, numpy 2.5.1, torch 2.13.0+cpu):

- `make check` is green: `ruff format` clean, `mypy` succeeds for python 3.10-3.14, `ruff check` passes.
- `tests/unit_tests/test_dendrite.py` passes with the fix (22 passed).
- The new regression tests are true regressions (pass with the fix, fail when the source change is reverted to `staging`):
  - `test_get_endpoint_url_blocks_ssrf_targets`: with fix -> 1 passed; source reverted -> 1 failed.

### Notes
- The separate `chore(mypy)` commit in this branch is required to keep the project's `make check` gate green on a fresh install: numpy 2.5 ships PEP 695 `type` aliases in `numpy/__init__.pyi` that mypy cannot parse when targeting `--python-version < 3.12`, so `make check` (mypy for py3.10..3.14) and the py3.10/py3.11 mypy CI jobs are red on `staging` today regardless of this change. Skipping numpy stubs in `mypy.ini` restores the gate without constraining the runtime numpy bound (`>=2.0.1,<3.0.0`). This is the same small config change the metagraph security PR carries.

### Release Notes

- Fixed a dendrite SSRF risk: axon endpoints in link-local / cloud metadata ranges are now refused when building request URLs.
