### PR TITLE
Stop register methods from closing the shared async subtensor connection

### DIFF
--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import copy
 import ssl
 from datetime import datetime, timezone
@@ -357,6 +358,19 @@ class AsyncSubtensor(SubtensorMixin):
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         await self.substrate.close()
+
+    @contextlib.asynccontextmanager
+    async def _ensure_connection(self):
+        """Ensure the substrate connection is open for the duration of a single call
+        without closing it afterwards.
+
+        Unlike ``async with self:``, this must be used by methods that run on a
+        long-lived, shared connection: ``__aexit__`` calls ``self.substrate.close()``,
+        so ``async with self:`` inside a method would close the caller's connection as
+        soon as the method returns, breaking every subsequent query on that subtensor.
+        """
+        await self.initialize()
+        yield
 
     # Helpers ==========================================================================================================
 
@@ -7216,7 +7230,7 @@ class AsyncSubtensor(SubtensorMixin):
         Notes:
             - Rate Limits: <https://docs.learnbittensor.org/learn/chain-rate-limits#registration-rate-limits>
         """
-        async with self:
+        async with self._ensure_connection():
             if netuid == 0:
                 return await root_register_extrinsic(
                     subtensor=self,
@@ -8507,7 +8521,7 @@ class AsyncSubtensor(SubtensorMixin):
         Notes:
             - Rate Limits: <https://docs.learnbittensor.org/learn/chain-rate-limits#registration-rate-limits>
         """
-        async with self:
+        async with self._ensure_connection():
             if netuid == 0:
                 return await root_register_extrinsic(
                     subtensor=self,
@@ -8586,7 +8600,7 @@ class AsyncSubtensor(SubtensorMixin):
             - Rate Limits: <https://docs.learnbittensor.org/learn/chain-rate-limits#registration-rate-limits>
         """
         check_balance_amount(limit_price)
-        async with self:
+        async with self._ensure_connection():
             return await register_limit_extrinsic(
                 subtensor=self,
                 wallet=wallet,

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,13 @@
 [mypy]
 ignore_missing_imports = True
 ignore_errors = True
+follow_imports_for_stubs = True
+
+[mypy-numpy.*]
+follow_imports = skip
+
+[mypy-numpy]
+follow_imports = skip
 
 [mypy-*.axon.*]
 ignore_errors = False

--- a/tests/unit_tests/test_async_subtensor.py
+++ b/tests/unit_tests/test_async_subtensor.py
@@ -195,6 +195,31 @@ async def test_burned_register(subtensor, fake_wallet, mocker):
 
 
 @pytest.mark.asyncio
+async def test_register_family_does_not_close_shared_connection(
+    subtensor, fake_wallet, mocker
+):
+    """register/burned_register/register_limit must not close the substrate connection
+    they share with the caller. The old ``async with self:`` ran ``__aexit__`` ->
+    ``substrate.close()`` on return, breaking every later query on the same subtensor."""
+    mocker.patch.object(subtensor, "compose_call")
+    mocker.patch.object(
+        subtensor, "sign_and_send_extrinsic", return_value=ExtrinsicResponse(True, "")
+    )
+    mocker.patch.object(
+        subtensor,
+        "get_neuron_for_pubkey_and_subnet",
+        return_value=NeuronInfo.get_null_neuron(),
+    )
+    mocker.patch.object(subtensor, "get_balance", return_value=Balance.from_tao(1))
+    mocker.patch.object(subtensor, "recycle")
+
+    await subtensor.burned_register(wallet=fake_wallet, netuid=14)
+
+    # the connection the caller is sharing must be left open
+    subtensor.substrate.close.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_burned_register_on_root(mock_substrate, subtensor, fake_wallet, mocker):
     mock_substrate.submit_extrinsic.return_value = mocker.AsyncMock(
         is_success=mocker.AsyncMock(return_value=True)(),


### PR DESCRIPTION
Hi! I am Loom Agent, an autonomous AI agent set up by my maintainer to help contribute to this repository. This PR was prepared autonomously under human supervision. Feedback is very welcome and I will address review comments promptly.

### Problem
`AsyncSubtensor.register`, `burned_register` and `register_limit` used `async with self:`, whose `__aexit__` calls `self.substrate.close()`. On a long-lived, shared subtensor this closed the caller's websocket as soon as the method returned, breaking every subsequent query.

### Root cause
Those three methods were the only async methods that closed the shared connection; every other async method assumes an already-open connection and leaves it open.

### The fix
Add an `_ensure_connection` async-context helper that initializes the substrate without closing it, and use it in place of `async with self:` in the three register methods.

### Testing
Verified in a clean dev environment (Python 3.12.3, bittensor 10.5.0, numpy 2.5.1, torch 2.13.0+cpu):

- `make check` is green: `ruff format` clean, `mypy` succeeds for python 3.10-3.14, `ruff check` passes.
- `tests/unit_tests/test_async_subtensor.py` passes with the fix (265 passed).
- The new regression tests are true regressions (pass with the fix, fail when the source change is reverted to `staging`):
  - `test_register_family_does_not_close_shared_connection`: with fix -> 1 passed; source reverted -> 1 failed.

### Notes
- The separate `chore(mypy)` commit in this branch is required to keep the project's `make check` gate green on a fresh install: numpy 2.5 ships PEP 695 `type` aliases in `numpy/__init__.pyi` that mypy cannot parse when targeting `--python-version < 3.12`, so `make check` (mypy for py3.10..3.14) and the py3.10/py3.11 mypy CI jobs are red on `staging` today regardless of this change. Skipping numpy stubs in `mypy.ini` restores the gate without constraining the runtime numpy bound (`>=2.0.1,<3.0.0`). This is the same small config change the metagraph security PR carries.

### Release Notes

- Fixed register methods closing the shared async subtensor connection, which could drop other in-flight async requests.
