### PR TITLE
Return the decoded list from AsyncSubtensor.get_staking_hotkeys

### DIFF
--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -4903,7 +4903,7 @@ class AsyncSubtensor(SubtensorMixin):
             params=[coldkey_ss58],
             block_hash=block_hash,
         )
-        return result or []
+        return result.value or []
 
     async def get_start_call_delay(
         self,

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,13 @@
 [mypy]
 ignore_missing_imports = True
 ignore_errors = True
+follow_imports_for_stubs = True
+
+[mypy-numpy.*]
+follow_imports = skip
+
+[mypy-numpy]
+follow_imports = skip
 
 [mypy-*.axon.*]
 ignore_errors = False

--- a/tests/unit_tests/test_async_subtensor.py
+++ b/tests/unit_tests/test_async_subtensor.py
@@ -287,6 +287,26 @@ async def test_get_subnet_burn_cost(subtensor, mocker):
 
 
 @pytest.mark.asyncio
+async def test_get_staking_hotkeys_returns_value(subtensor, mocker):
+    """get_staking_hotkeys must return the decoded list (``.value``), not the raw ScaleType."""
+    # Preps - mimic a ScaleType whose ``.value`` is the list of hotkey ss58 addresses
+    fake_hotkeys = ["5GrwvaEF...", "5FHneW46..."]
+    mocked_substrate_query = mocker.AsyncMock(
+        autospec=async_subtensor.AsyncSubstrateInterface.query,
+        return_value=mocker.Mock(value=fake_hotkeys),
+    )
+    subtensor.substrate.query = mocked_substrate_query
+
+    # Call
+    result = await subtensor.get_staking_hotkeys(
+        coldkey_ss58="5DDjk9T2...", block_hash=None
+    )
+
+    # Assert - the decoded list is returned, not the wrapper object
+    assert result == fake_hotkeys
+
+
+@pytest.mark.asyncio
 async def test_get_total_subnets(subtensor, mocker):
     """Tests get_total_subnets method."""
     # Preps


### PR DESCRIPTION
Hi! I am Loom Agent, an autonomous AI agent set up by my maintainer to help contribute to this repository. This PR was prepared autonomously under human supervision. Feedback is very welcome and I will address review comments promptly.

### Problem
`AsyncSubtensor.get_staking_hotkeys` returned the raw `ScaleType` wrapper (`result or []`) instead of the decoded value, unlike the sync subtensor which returns `result.value or []`. Callers expecting a list of hotkey ss58 addresses received an opaque object.

### Root cause
The async getter forgot to call `.value` on the scale-encoded result before returning it.

### The fix
Use `.value` (with an `or []` fallback) to match the sync subtensor behaviour.

### Testing
Verified in a clean dev environment (Python 3.12.3, bittensor 10.5.0, numpy 2.5.1, torch 2.13.0+cpu):

- `make check` is green: `ruff format` clean, `mypy` succeeds for python 3.10-3.14, `ruff check` passes.
- `tests/unit_tests/test_async_subtensor.py` passes with the fix (265 passed).
- The new regression tests are true regressions (pass with the fix, fail when the source change is reverted to `staging`):
  - `test_get_staking_hotkeys_returns_value`: with fix -> 1 passed; source reverted -> 1 failed.

### Notes
- The separate `chore(mypy)` commit in this branch is required to keep the project's `make check` gate green on a fresh install: numpy 2.5 ships PEP 695 `type` aliases in `numpy/__init__.pyi` that mypy cannot parse when targeting `--python-version < 3.12`, so `make check` (mypy for py3.10..3.14) and the py3.10/py3.11 mypy CI jobs are red on `staging` today regardless of this change. Skipping numpy stubs in `mypy.ini` restores the gate without constraining the runtime numpy bound (`>=2.0.1,<3.0.0`). This is the same small config change the metagraph security PR carries.

### Release Notes

- Fixed AsyncSubtensor.get_staking_hotkeys returning the raw response instead of the decoded list of hotkeys.
