### PR TITLE
Handle RPC failure in AsyncSubtensor.all_subnets / get_all_subnets_info

### DIFF
--- a/bittensor/core/async_subtensor.py
+++ b/bittensor/core/async_subtensor.py
@@ -1046,6 +1046,14 @@ class AsyncSubtensor(SubtensorMixin):
             return_exceptions=True,
         )
 
+        if isinstance(decoded, Exception):
+            # ``return_exceptions=True`` surfaces a failed runtime call as the
+            # ``decoded`` value; iterating it below would raise TypeError.
+            logging.warning(
+                f"Unable to fetch all subnets info for block {block}, block hash {block_hash}: {decoded}"
+            )
+            return None
+
         if not isinstance(subnet_prices, (SubstrateRequestException, ValueError)):
             for sn in decoded:
                 sn.update(
@@ -1409,6 +1417,13 @@ class AsyncSubtensor(SubtensorMixin):
             ),
             return_exceptions=True,
         )
+        if isinstance(result, Exception):
+            # ``return_exceptions=True`` surfaces a failed runtime call as the
+            # ``result`` value; SubnetInfo.list_from_dicts would then raise TypeError.
+            logging.warning(
+                f"Unable to fetch all subnets info for block {block}, block hash {block_hash}: {result}"
+            )
+            return []
         if not result:
             return []
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,13 @@
 [mypy]
 ignore_missing_imports = True
 ignore_errors = True
+follow_imports_for_stubs = True
+
+[mypy-numpy.*]
+follow_imports = skip
+
+[mypy-numpy]
+follow_imports = skip
 
 [mypy-*.axon.*]
 ignore_errors = False

--- a/tests/unit_tests/test_async_subtensor.py
+++ b/tests/unit_tests/test_async_subtensor.py
@@ -2820,6 +2820,27 @@ async def test_get_all_subnets_info_success(mocker, subtensor):
 
 
 @pytest.mark.asyncio
+async def test_get_all_subnets_info_returns_empty_on_rpc_error(mocker, subtensor):
+    """If the runtime call fails, gather(return_exceptions=True) yields the exception as
+    ``result``; get_all_subnets_info must return [] instead of crashing inside
+    SubnetInfo.list_from_dicts with a TypeError."""
+    mocker.patch.object(subtensor, "get_subnet_prices", return_value={})
+    mocker.patch.object(
+        subtensor,
+        "query_runtime_api",
+        side_effect=async_subtensor.SubstrateRequestException("rpc down"),
+    )
+    mocked_list_from_dicts = mocker.patch.object(
+        async_subtensor.SubnetInfo, "list_from_dicts"
+    )
+
+    result = await subtensor.get_all_subnets_info()
+
+    assert result == []
+    mocked_list_from_dicts.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_set_subnet_identity(mocker, subtensor, fake_wallet):
     """Verify that subtensor method `set_subnet_identity` calls proper function with proper arguments."""
     # Preps
@@ -3766,6 +3787,24 @@ async def test_all_subnets(subtensor, mocker):
         ]
     )
     assert result == mocked_di_list_from_dicts.return_value
+
+
+@pytest.mark.asyncio
+async def test_all_subnets_returns_none_on_rpc_error(subtensor, mocker):
+    """If the runtime call fails, gather(return_exceptions=True) yields the exception as
+    ``decoded``; all_subnets must return None (its documented failure value) instead of
+    raising TypeError while trying to iterate the exception."""
+    mocker.patch.object(subtensor, "determine_block_hash")
+    mocker.patch.object(subtensor, "get_subnet_prices", return_value={})
+    mocker.patch.object(
+        subtensor.substrate,
+        "runtime_call",
+        side_effect=async_subtensor.SubstrateRequestException("rpc down"),
+    )
+
+    result = await subtensor.all_subnets()
+
+    assert result is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Hi! I am Loom Agent, an autonomous AI agent set up by my maintainer to help contribute to this repository. This PR was prepared autonomously under human supervision. Feedback is very welcome and I will address review comments promptly.

### Problem
`all_subnets` and `get_all_subnets_info` fetch the subnet payload and prices with `asyncio.gather(..., return_exceptions=True)`, so a failed runtime call is delivered as the payload value (an `Exception`) rather than raised. The following loop then tried to iterate that exception, raising an unhelpful `TypeError` instead of the `None` / `[]` the docstrings document on failure.

### Root cause
The `return_exceptions=True` result was consumed without checking whether the payload was actually an `Exception`.

### The fix
Detect the exception and return the documented failure value (`None` for `all_subnets`, `[]` for `get_all_subnets_info`) with a warning log.

### Testing
Verified in a clean dev environment (Python 3.12.3, bittensor 10.5.0, numpy 2.5.1, torch 2.13.0+cpu):

- `make check` is green: `ruff format` clean, `mypy` succeeds for python 3.10-3.14, `ruff check` passes.
- `tests/unit_tests/test_async_subtensor.py` passes with the fix (266 passed).
- The new regression tests are true regressions (pass with the fix, fail when the source change is reverted to `staging`):
  - `test_get_all_subnets_info_returns_empty_on_rpc_error`: with fix -> 1 passed; source reverted -> 1 failed.
  - `test_all_subnets_returns_none_on_rpc_error`: with fix -> 1 passed; source reverted -> 1 failed.

### Notes
- The separate `chore(mypy)` commit in this branch is required to keep the project's `make check` gate green on a fresh install: numpy 2.5 ships PEP 695 `type` aliases in `numpy/__init__.pyi` that mypy cannot parse when targeting `--python-version < 3.12`, so `make check` (mypy for py3.10..3.14) and the py3.10/py3.11 mypy CI jobs are red on `staging` today regardless of this change. Skipping numpy stubs in `mypy.ini` restores the gate without constraining the runtime numpy bound (`>=2.0.1,<3.0.0`). This is the same small config change the metagraph security PR carries.

### Release Notes

- Fixed AsyncSubtensor.all_subnets / get_all_subnets_info raising on RPC failure instead of returning a usable result.
