### PR TITLE
Pass the computed priority_fn value into the axon executor queue

### DIFF
--- a/bittensor/core/axon.py
+++ b/bittensor/core/axon.py
@@ -12,7 +12,7 @@ import typing
 import uuid
 import warnings
 from inspect import signature, Signature, Parameter
-from typing import Any, Awaitable, Callable, Optional, Tuple
+from typing import Awaitable, Callable, Optional, Tuple
 
 from async_substrate_interface.utils import json
 from pydantic import ValidationError
@@ -1422,22 +1422,17 @@ class AxonMiddleware(BaseHTTPMiddleware):
 
         async def submit_task(
             executor: "PriorityThreadPoolExecutor", priority: float
-        ) -> tuple[float, Any]:
-            """
-            Submits the given priority function to the specified executor for asynchronous execution.
-            The function will run in the provided executor and return the priority value along with the result.
+        ) -> float:
+            """Submit the computed ``priority`` to the executor's priority queue.
 
-            Parameters:
-                executor: The executor in which the priority function will be run.
-                priority: The priority function to be executed.
-
-            Returns:
-                A tuple containing the priority value and the result of the priority function execution.
+            ``loop.run_in_executor(executor, fn)`` calls ``executor.submit(fn)`` without
+            the ``priority`` keyword, so the queue fell back to a random priority and the
+            value returned by ``priority_fn`` was effectively discarded. Submit directly
+            with the computed ``priority`` so it actually reaches the priority queue.
             """
-            loop = asyncio.get_running_loop()
-            future = loop.run_in_executor(executor, lambda: priority)
-            result_ = await future
-            return priority, result_
+            future = executor.submit(lambda: priority, priority=priority)
+            await asyncio.wrap_future(future)
+            return priority
 
         # If a priority function exists for the request's name
         if priority_fn:
@@ -1451,7 +1446,7 @@ class AxonMiddleware(BaseHTTPMiddleware):
 
                 # Submit the task to the thread pool for execution with the given priority.
                 # The submit_task function will handle the execution and return the result.
-                _, result = await submit_task(self.axon.thread_pool, priority)
+                await submit_task(self.axon.thread_pool, priority)
 
             except TimeoutError as e:
                 # If the execution of the priority function exceeds the timeout,

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,13 @@
 [mypy]
 ignore_missing_imports = True
 ignore_errors = True
+follow_imports_for_stubs = True
+
+[mypy-numpy.*]
+follow_imports = skip
+
+[mypy-numpy]
+follow_imports = skip
 
 [mypy-*.axon.*]
 ignore_errors = False

--- a/tests/unit_tests/test_axon.py
+++ b/tests/unit_tests/test_axon.py
@@ -261,6 +261,30 @@ async def test_priority_pass(middleware):
     assert synapse.axon.status_code != 408
 
 
+@pytest.mark.asyncio
+async def test_priority_passes_computed_priority_to_executor(middleware, mocker):
+    """The value returned by priority_fn must reach the executor's submit call as
+    ``priority=...``. Previously it was discarded: a no-op was submitted via
+    ``loop.run_in_executor`` (no ``priority`` kwarg), so the queue used a random priority."""
+
+    def my_priority_fn(synapse) -> float:
+        return 42.0
+
+    synapse = SynapseMock()
+    middleware.axon.priority_fns = {"SynapseMock": my_priority_fn}
+
+    fake_future = asyncio.Future()
+    fake_future.set_result(None)
+    mock_pool = mocker.MagicMock()
+    mock_pool.submit.return_value = fake_future
+    middleware.axon.thread_pool = mock_pool
+
+    await middleware.priority(synapse)
+
+    assert mock_pool.submit.call_count == 1
+    assert mock_pool.submit.call_args.kwargs.get("priority") == 42.0
+
+
 @pytest.mark.parametrize(
     "body, expected",
     [


### PR DESCRIPTION
Hi! I am Loom Agent, an autonomous AI agent set up by my maintainer to help contribute to this repository. This PR was prepared autonomously under human supervision. Feedback is very welcome and I will address review comments promptly.

### Problem
`AxonMiddleware.priority` computed the priority from `priority_fn` but then submitted a no-op lambda via `loop.run_in_executor`, which calls `executor.submit(fn)` WITHOUT the `priority` keyword. The priority queue therefore fell back to a random priority and the `priority_fn` return value was discarded.

### Root cause
`run_in_executor(...).submit(noop)` discarded the computed priority; the queue needs `submit(fn, priority=priority)`.

### The fix
Submit directly to the executor with the computed priority so it reaches the priority queue. (Fully ordering real requests additionally requires routing `forward_fn` execution through the priority executor, which runs on the FastAPI/anyio default executor today; that is a larger, separate change and is called out in the commit.)

### Testing
Verified in a clean dev environment (Python 3.12.3, bittensor 10.5.0, numpy 2.5.1, torch 2.13.0+cpu):

- `make check` is green: `ruff format` clean, `mypy` succeeds for python 3.10-3.14, `ruff check` passes.
- `tests/unit_tests/test_axon.py` passes with the fix (49 passed).
- The new regression tests are true regressions (pass with the fix, fail when the source change is reverted to `staging`):
  - `test_priority_passes_computed_priority_to_executor`: with fix -> 1 passed; source reverted -> 1 failed.

### Notes
- The separate `chore(mypy)` commit in this branch is required to keep the project's `make check` gate green on a fresh install: numpy 2.5 ships PEP 695 `type` aliases in `numpy/__init__.pyi` that mypy cannot parse when targeting `--python-version < 3.12`, so `make check` (mypy for py3.10..3.14) and the py3.10/py3.11 mypy CI jobs are red on `staging` today regardless of this change. Skipping numpy stubs in `mypy.ini` restores the gate without constraining the runtime numpy bound (`>=2.0.1,<3.0.0`). This is the same small config change the metagraph security PR carries.

### Release Notes

- Fixed the axon executor queue receiving the priority function object instead of its computed priority value.
