### PR TITLE
Convert tao to rao exactly in Balance (no float truncation)

### DIFF
--- a/bittensor/utils/balance.py
+++ b/bittensor/utils/balance.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from typing import Optional, Union
 
 from scalecodec.utils.math import (
@@ -7,6 +8,17 @@ from scalecodec.utils.math import (
 
 from bittensor.core import settings
 from bittensor.core.errors import BalanceTypeError, BalanceUnitMismatchError
+
+
+def _tao_to_rao(amount: Union[int, float]) -> int:
+    """Convert a tao amount to integer rao without floating-point truncation.
+
+    ``int(float_amount * 1e9)`` silently loses rao because binary floats cannot
+    represent most decimal fractions (e.g. ``1.001`` tao -> 1000999999 rao instead
+    of 1001000000). Routing through :class:`decimal.Decimal` from the value's
+    decimal string makes the conversion exact, so no rao is silently dropped.
+    """
+    return int(Decimal(str(amount)) * 1_000_000_000)
 
 
 def _check_currencies(self, other):
@@ -97,7 +109,7 @@ class Balance:
             self.rao = balance
         elif isinstance(balance, float):
             # Assume tao value for the float
-            self.rao = int(balance * pow(10, 9))
+            self.rao = _tao_to_rao(balance)
         else:
             raise TypeError(
                 f"Balance must be an int (rao) or a float (tao), not  `{type(balance)}`."
@@ -314,7 +326,7 @@ class Balance:
         Returns:
             A Balance object representing the given amount.
         """
-        rao_ = int(amount * pow(10, 9))
+        rao_ = _tao_to_rao(amount)
         return Balance(rao_).set_unit(netuid)
 
     @staticmethod
@@ -329,7 +341,7 @@ class Balance:
         Returns:
             A Balance object representing the given amount.
         """
-        rao_ = int(amount * pow(10, 9))
+        rao_ = _tao_to_rao(amount)
         return Balance(rao_).set_unit(netuid)
 
     @staticmethod

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,13 @@
 [mypy]
 ignore_missing_imports = True
 ignore_errors = True
+follow_imports_for_stubs = True
+
+[mypy-numpy.*]
+follow_imports = skip
+
+[mypy-numpy]
+follow_imports = skip
 
 [mypy-*.axon.*]
 ignore_errors = False

--- a/tests/unit_tests/utils/test_balance.py
+++ b/tests/unit_tests/utils/test_balance.py
@@ -224,11 +224,7 @@ def test_balance_mul_other_not_balance(
     """
     balance_ = Balance(balance)
     balance2_ = balance2
-    rao_: int
-    if isinstance(balance, int):
-        rao_ = balance
-    elif isinstance(balance, float):
-        rao_ = int(balance * pow(10, 9))
+    rao_ = balance_.rao
 
     prod_ = balance_ * balance2_
     assert isinstance(prod_, Balance)
@@ -248,11 +244,7 @@ def test_balance_rmul_other_not_balance(
     """
     balance_ = Balance(balance)
     balance2_ = balance2
-    rao_: int
-    if isinstance(balance, int):
-        rao_ = balance
-    elif isinstance(balance, float):
-        rao_ = int(balance * pow(10, 9))
+    rao_ = balance_.rao
 
     prod_ = balance2_ * balance_  # This is an rmul
     assert isinstance(prod_, Balance)
@@ -304,12 +296,8 @@ def test_balance_truediv_other_not_balance(
     """
     balance_ = Balance(balance)
     balance2_ = balance2
-    rao_: int
     rao2_: int
-    if isinstance(balance, int):
-        rao_ = balance
-    elif isinstance(balance, float):
-        rao_ = int(balance * pow(10, 9))
+    rao_ = balance_.rao
     # assume balance2 is a rao value
     rao2_ = balance2
 
@@ -388,12 +376,8 @@ def test_balance_floordiv_other_not_balance(
     """
     balance_ = Balance(balance)
     balance2_ = balance2
-    rao_: int
     rao2_: int
-    if isinstance(balance, int):
-        rao_ = balance
-    elif isinstance(balance, float):
-        rao_ = int(balance * pow(10, 9))
+    rao_ = balance_.rao
     # assume balance2 is a rao value
     rao2_ = balance2
 
@@ -518,6 +502,34 @@ def test_from_float():
 def test_from_rao():
     """Tests from_rao method call."""
     assert Balance.from_tao(1) == Balance(1000000000)
+
+
+@pytest.mark.parametrize(
+    "tao,expected_rao",
+    [
+        (1.001, 1001000000),
+        (1.003, 1003000000),
+        (0.001, 1000000),
+        (123.456, 123456000000),
+        (1.0, 1000000000),
+    ],
+    ids=[
+        "truncating-float-1.001",
+        "truncating-float-1.003",
+        "milli-tao",
+        "three-decimals",
+        "whole",
+    ],
+)
+def test_from_tao_no_float_truncation(tao, expected_rao):
+    """from_tao must convert tao to rao exactly; binary float math used to drop rao
+    (e.g. from_tao(1.001) returned 1000999999 rao, losing 1 rao)."""
+    assert Balance.from_tao(tao).rao == expected_rao
+
+
+def test_balance_init_float_no_float_truncation():
+    """Balance(float) takes tao and must not drop rao to float truncation either."""
+    assert Balance(1.001).rao == 1001000000
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Hi! I am Loom Agent, an autonomous AI agent set up by my maintainer to help contribute to this repository. This PR was prepared autonomously under human supervision. Feedback is very welcome and I will address review comments promptly.

### Problem
`Balance(float)` and `Balance.from_tao` converted tao to rao with `int(amount * 1e9)`, which silently drops rao because binary floats cannot represent most decimal fractions (e.g. `from_tao(1.001)` returned `1000999999` rao instead of `1001000000`). This is a money-handling path.

### Root cause
Float multiplication followed by `int()` truncates sub-rao precision.

### The fix
Route the conversion through `decimal.Decimal` via a shared `_tao_to_rao` helper so the conversion is exact. Also update the mul/rmul/truediv/floordiv property tests, which encoded the old imprecision in their expected values, to derive the expected rao from the Balance under test.

### Testing
Verified in a clean dev environment (Python 3.12.3, bittensor 10.5.0, numpy 2.5.1, torch 2.13.0+cpu):

- `make check` is green: `ruff format` clean, `mypy` succeeds for python 3.10-3.14, `ruff check` passes.
- `tests/unit_tests/utils/test_balance.py` passes with the fix (39 passed).
- The new regression tests are true regressions (pass with the fix, fail when the source change is reverted to `staging`):
  - `test_from_tao_no_float_truncation`: with fix -> 5 passed; source reverted -> 2 failed, 3 passed.
  - `test_balance_init_float_no_float_truncation`: with fix -> 1 passed; source reverted -> 1 failed.

### Notes
- The separate `chore(mypy)` commit in this branch is required to keep the project's `make check` gate green on a fresh install: numpy 2.5 ships PEP 695 `type` aliases in `numpy/__init__.pyi` that mypy cannot parse when targeting `--python-version < 3.12`, so `make check` (mypy for py3.10..3.14) and the py3.10/py3.11 mypy CI jobs are red on `staging` today regardless of this change. Skipping numpy stubs in `mypy.ini` restores the gate without constraining the runtime numpy bound (`>=2.0.1,<3.0.0`). This is the same small config change the metagraph security PR carries.

### Release Notes

- Fixed Balance tao-to-rao conversion truncating through float arithmetic; it now converts exactly.
